### PR TITLE
feat(se-222-s0): resource: URI convention validator + 5 specs back-filled

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=1c7aae270eeb619c6a80396c3378e6cc6add69abb9c6d20d902369663415f3cf
-timestamp=2026-06-22T23:22:38Z
+diff_hash=a6d063924c1e6c3834809f4556aea0d81b0fb98f63bd764145e0b203c1c732e3
+timestamp=2026-06-23T07:38:17Z
 branch=agent/se222-s0-resource-uri-20260623
-head_commit=bc63d743
-signature=ad310931f1311511e9801c64f1c087096a638c14887d77068854a935953d0bf8
+head_commit=a44857c6
+signature=e2556a23a17ea23f6db9d7c0e757c398fa468914043c672ea66ba9f83c3f0767

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=aeda75d29acdd65a7cd86f6334666a0f16335e7ee7fae8270b8883c5579e1b61
-timestamp=2026-06-20T12:48:00Z
-branch=feature/se-220-output-taxonomy
-head_commit=842ff3f6
-signature=f91d6a90dd1952e5cf6bddd5243e1e25153cd2cdb87d0cebc22d2076c76dafa1
+diff_hash=1c7aae270eeb619c6a80396c3378e6cc6add69abb9c6d20d902369663415f3cf
+timestamp=2026-06-22T23:22:38Z
+branch=agent/se222-s0-resource-uri-20260623
+head_commit=bc63d743
+signature=ad310931f1311511e9801c64f1c087096a638c14887d77068854a935953d0bf8

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=a6d063924c1e6c3834809f4556aea0d81b0fb98f63bd764145e0b203c1c732e3
-timestamp=2026-06-23T07:38:17Z
+diff_hash=7ff885f512c4d27ab52a34b48607982a6df8dc2b523b52dc82b448a6676df07f
+timestamp=2026-06-24T07:30:32Z
 branch=agent/se222-s0-resource-uri-20260623
-head_commit=a44857c6
-signature=e2556a23a17ea23f6db9d7c0e757c398fa468914043c672ea66ba9f83c3f0767
+head_commit=36d5ba30
+signature=a0f413ca65b65ccb97afed802f2250ca765d339b107c71e4867304c0b0ace4df

--- a/CHANGELOG.d/20260623-se-222-s0-resource-uri.md
+++ b/CHANGELOG.d/20260623-se-222-s0-resource-uri.md
@@ -1,0 +1,37 @@
+## SE-222-S0 — resource: URI convention validator (2026-06-23)
+
+### Added
+
+- `scripts/spec-validator.sh` — Frontmatter validator for resource: URI convention. Scans `docs/propuestas/*.md` and `docs/rules/domain/*.md` and emits WARN findings when:
+  - `origin:` field is present but `resource:` is absent (MISSING_RESOURCE)
+  - `resource:` field is present but not a valid URI (INVALID_RESOURCE_URI)
+- `docs/rules/domain/spec-resource-uri.md` — Canonical rule documenting the convention.
+- `tests/test-spec-validator.bats` — Tests covering argument parsing, frontmatter detection, both rules (positive + negative paths), `--strict` mode, `--json` output, and `--batch` mode. Certified by test-auditor (≥80).
+
+### Changed
+
+- `docs/propuestas/SE-216-evo-patterns.md` — Added `resource: "https://github.com/evo-hq/evo"`.
+- `docs/propuestas/SE-217-autoresearch-patterns.md` — Added `resource: "https://github.com/karpathy/autoresearch"`.
+- `docs/propuestas/SE-218-codebase-memory-patterns.md` — Added `resource: "https://github.com/DeusData/codebase-memory-mcp"`.
+- `docs/propuestas/SE-219-abtop-patterns.md` — Added `resource: "https://github.com/graykode/abtop"`.
+- `docs/ROADMAP.md` — Added Era 208 OKF Adoptable Patterns section + repriorized backlog 2026-06-20 with SE-222 S0-S3 entries.
+
+### New
+
+- `docs/propuestas/SE-222-okf-adoptable-patterns.md` — Spec proposing OKF v0.1 adoptable patterns (resource: URI, log.md convention, index.md auto-gen). Discarded: portability inter-org, OKF as export bundle, external SDK. S0 implemented in this PR; S1+S2 in follow-up PRs; S3 (back-fill 20 specs) is P3.
+
+### Rationale
+
+SE-222 S0 first slice of Era 208 in backlog priorizado 2026-06-20. Inspired by Google Cloud OKF v0.1 (2026-06-12) as formalization of the LLM-wiki pattern. Three OKF conventions adopted (resource:, log.md, index.md) without touching the N1-N4b dome model. See `docs/propuestas/SE-222-okf-adoptable-patterns.md` for the discarded patterns and why.
+
+### Tests
+
+- `bats tests/test-spec-validator.bats`: full suite passing
+- `bash scripts/test-auditor.sh tests/test-spec-validator.bats`: certified
+- `bash scripts/spec-validator.sh --batch docs/propuestas/`: backfill reduces total findings; full back-fill deferred to S3
+
+### Ref
+
+- Spec: `docs/propuestas/SE-222-okf-adoptable-patterns.md`
+- Origin: análisis comparativo OKF Google Cloud 2026-06-20 vs modelo de cúpulas Savia
+- Resource: https://github.com/GoogleCloudPlatform/knowledge-catalog

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap Unificado — pm-workspace / Savia
 
-**Updated:** 2026-06-13 | **Version:** v6.20.0 | **562 commands · 75 agents · 104 skills · 81 hooks · 470+ test suites + 122 nuevos · Active backlog 5 items (SPEC-199 P2 desbloqueado + 4 P2/P3 viejos) · 5 specs DiffusionGemma implementadas (195, 196, 197, 198, 200) en 1 PR** — ver `### Backlog restante — repriorizado 2026-06-13`
+**Updated:** 2026-06-20 | **Version:** v6.20.0 | **562 commands · 75 agents · 104 skills · 81 hooks · 470+ test suites · Active backlog 7 items P2 + 3 items P3 · SE-222 OKF patterns añadido (Era 208)** — ver `### Backlog restante — repriorizado 2026-06-20`
 
 ---
 
@@ -714,7 +714,7 @@ Google Sheets · ServiceNow/SAP · Tableau · Kafka · VS Code ext · Cloud voic
 | SE-218 S1-S5 | codebase-memory patterns: hook augmentation, KG snapshot, qualified names, tiered flush, .saviaignore — 81 tests | #834 |
 | SE-219 S1-S5 | abtop patterns: session-status, context-meter, session-cleanup, profile-discover, agent-tick — 48 tests | #835 |
 
-### Backlog restante — repriorizado 2026-06-13
+### Backlog restante — repriorizado 2026-06-20
 
 | # | ID | Qué | Esfuerzo | Prioridad | Deps |
 |---|---|---|---|---|---|
@@ -727,8 +727,10 @@ Google Sheets · ServiceNow/SAP · Tableau · Kafka · VS Code ext · Cloud voic
 | 7 | **SPEC-SE-036 Slice 3** | JWT sunset opt-in (PAT file migration) | 4h | P2 | Slice 1+2 ✓ |
 | 8 | **SPEC-188 Fase 2** | Sealed Contract Tests | ~8h | P2 | Fase 1 ✓ |
 | 9 | **SE-220** | Speculative Tool Execution — draft+verify pattern (Slice 0 BLOQUEANTE) | ~18h (3h S0 + 15h S1-4) | P2 | feasibility ≥60% acceptance |
-| 10 | **SE-216 Slice 4** | Experiment Graph — tree search | ~6h | P3 | SE-216 S1+S2+S3 ✓ |
-| 11 | **SPEC-188 Fases 3+4** | Causal confidence + diagnostic metrics | ~56h | P3 | Fase 2 |
+| 10 | **SE-222 S0-S2** | OKF Adoptable Patterns — resource URI + log.md + index.md auto-gen | ~6h | P2 | — |
+| 11 | **SE-216 Slice 4** | Experiment Graph — tree search | ~6h | P3 | SE-216 S1+S2+S3 ✓ |
+| 12 | **SE-222 S3** | OKF back-fill resource: en 20 specs de alto valor | ~2h | P3 | SE-222 S0 |
+| 13 | **SPEC-188 Fases 3+4** | Causal confidence + diagnostic metrics | ~56h | P3 | Fase 2 |
 
 ### Telemetry pilot (30d desde 2026-06-13)
 
@@ -824,6 +826,19 @@ Origen: https://github.com/graykode/abtop (2.7k stars, MIT). Patrones: JSON snap
 | 4 | SE-220 S4 | Telemetry dashboard + GO/CONTINUE/KILL semanal | S (~3h) | P2 |
 
 Origen: investigación speculative decoding 2026-06-20 (papers Leviathan 2022, EAGLE-3 NeurIPS'25, Medusa, Lookahead). El decoder de Claude API es opaco — speculative decoding clásico NO aplica. El **principio** draft+verify SÍ aplica a la capa de orquestación: predictor barato (haiku) pre-ejecuta tool calls idempotentes en background mientras el orquestador (sonnet/opus) piensa. Spec: `docs/propuestas/SE-220-speculative-tool-execution.md`. priority_score = 78.4 (V=75, U=65, E=22) según SPEC-154. Dep: SE-202 (agent-hook-runner) ✓ + SE-217 (time-budget) ✓.
+
+---
+
+### Era 208 — OKF Adoptable Patterns (resource URI + log.md + index.md, ~8h)
+
+| # | ID | Título | Esfuerzo | Prioridad |
+|---|---|---|---|---|
+| 0 | SE-222 S0 | `resource:` URI en frontmatter de specs y reglas + validator WARN | S (~2h) | P2 |
+| 1 | SE-222 S1 | `log.md` convention — `docs/propuestas/LOG.md` append-only + `spec-lifecycle.sh` | S (~2h) | P2 |
+| 2 | SE-222 S2 | `index.md` auto-generado para `docs/propuestas/` via PostToolUse hook | S (~2h) | P2 |
+| 3 | SE-222 S3 | Back-fill `resource:` en ≥20 specs/reglas de alto valor | S (~2h) | P3 |
+
+Origen: análisis comparativo OKF (Google Cloud, 2026-06-12) vs modelo de cúpulas Savia (2026-06-20). OKF formaliza el patrón LLM-wiki de Karpathy — tres de sus convenciones son adoptables sin tocar el modelo N1-N4b: campo `resource:` como URI navegable al origen, fichero `log.md` de historial conceptual por directorio, e `index.md` de descubrimiento progresivo. Descartados: portabilidad inter-org (sistema cerrado), exportación como bundle OKF (rompe confidencialidad), SDK externo (tenemos grafo propio SE-162). Spec: `docs/propuestas/SE-222-okf-adoptable-patterns.md`. Sin dependencias bloqueantes.
 
 ---
 

--- a/docs/propuestas/SE-216-evo-patterns.md
+++ b/docs/propuestas/SE-216-evo-patterns.md
@@ -6,6 +6,7 @@ priority: P2
 effort: L
 era: 204
 origin: output/research/evo-hq-savia-20260609.md
+resource: "https://github.com/evo-hq/evo"
 inspiration: evo-hq/evo v0.5.0 (Apache-2.0) — autonomous codebase research
 deps:
   - SE-211 (typed memory schema — implemented)

--- a/docs/propuestas/SE-217-autoresearch-patterns.md
+++ b/docs/propuestas/SE-217-autoresearch-patterns.md
@@ -6,6 +6,7 @@ priority: P2
 effort: M
 era: 204
 origin: https://github.com/karpathy/autoresearch (85.8k stars, MIT)
+resource: "https://github.com/karpathy/autoresearch"
 inspiration: karpathy/autoresearch — autonomous ML research loop
 deps:
   - autonomous-safety.md (AGENT_TASK_TIMEOUT_MINUTES — implemented)

--- a/docs/propuestas/SE-218-codebase-memory-patterns.md
+++ b/docs/propuestas/SE-218-codebase-memory-patterns.md
@@ -6,6 +6,7 @@ priority: P2
 effort: M
 era: 205
 origin: https://github.com/DeusData/codebase-memory-mcp (3.2k stars, MIT)
+resource: "https://github.com/DeusData/codebase-memory-mcp"
 inspiration: codebase-memory-mcp v0.7.0 — high-performance code intelligence engine (arXiv:2603.27277)
 deps:
   - scripts/knowledge-graph.py (implemented — SE-162)

--- a/docs/propuestas/SE-219-abtop-patterns.md
+++ b/docs/propuestas/SE-219-abtop-patterns.md
@@ -6,6 +6,7 @@ priority: P2
 effort: M
 era: 206
 origin: https://github.com/graykode/abtop (2.7k stars, MIT)
+resource: "https://github.com/graykode/abtop"
 inspiration: graykode/abtop v0.4.8 — htop for AI coding agents
 deps:
   - scripts/session-action-log.sh (implemented)

--- a/docs/propuestas/SE-222-okf-adoptable-patterns.md
+++ b/docs/propuestas/SE-222-okf-adoptable-patterns.md
@@ -1,0 +1,205 @@
+---
+spec_id: SE-222
+title: OKF Adoptable Patterns — resource URI + log.md convention + index.md progressive disclosure
+status: PROPOSED
+priority: P2
+effort: S (~8h total: S0 2h + S1 2h + S2 2h + S3 2h)
+era: 208
+value: 70
+urgency: 55
+effort_score: 28
+priority_score: 71.4
+confidence: alta — patrones concretos y acotados; sin riesgo de romper confidencialidad ni SDD
+bucket: Q3 2026
+origin: análisis OKF Google Cloud 2026-06-20. OKF v0.1 publicado 2026-06-12 en https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing. Repo: https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf
+resource: "https://github.com/GoogleCloudPlatform/knowledge-catalog"
+related_specs:
+  - SE-162 (Knowledge Graph SQLite — base para el grafo de relaciones)
+  - SE-211 (Typed memory schema — complementa resource provenance)
+  - SE-213 (Confidence + provenance en KG entries — adopción parcial solapada)
+  - SPEC-185 (Critical-facts anchor — misma filosofía de disclosure progresivo)
+  - docs/rules/domain/output-taxonomy.md (output/ taxonomy — misma filosofía de convenciones claras)
+discarded:
+  - Portabilidad inter-org (Savia es sistema cerrado; no hay consumidores externos)
+  - Producer/consumer separation formal (Savia escribe y lee su propio knowledge — separar añade overhead sin beneficio)
+  - OKF como formato de exportación (rompe modelo N1-N4b; bundle plano no tiene modelo de confidencialidad)
+  - SDK / tooling OKF (dependencia externa innecesaria; Savia ya tiene su grafo SQLite)
+  - Visualizador HTML de bundle (out of scope; Savia no necesita visualización externa)
+---
+
+# SE-222 — OKF Adoptable Patterns
+
+## Why
+
+Google publicó OKF v0.1 el 2026-06-12 como formalización del patrón LLM-wiki
+(Karpathy gist). El análisis comparativo con Savia (2026-06-20) identifica tres
+patrones concretos del spec que Savia puede adoptar sin romper el modelo de
+cúpulas N1-N4b ni SDD:
+
+1. **`resource:` URI** — cada regla/spec apunta a su origen canónico (ADO work
+   item, paper, repo, RFC). Hoy las specs tienen `origin:` como texto libre sin
+   formato. Formalizar como URI permite navegación directa y trazabilidad
+   automatizable.
+
+2. **`log.md` convention** — historial cronológico de cambios por concepto.
+   Hoy el histórico está en CHANGELOG.md (repo-wide) o en commits git. Un
+   `log.md` por directorio de propuestas/specs captura el historial conceptual
+   (no solo el diff), visible sin `git log`.
+
+3. **`index.md` progressive disclosure** — ficheros índice por directorio que
+   describen qué contiene cada sección. Hoy `docs/propuestas/` no tiene índice;
+   los agentes hacen `ls` o `glob` para orientarse. Un `index.md` generado
+   automáticamente reduce el coste de descubrimiento en cada sesión nueva.
+
+Estos tres patrones son ortogonales al modelo de confidencialidad de Savia —
+aplican solo a ficheros N1 (docs/propuestas/, docs/rules/, .opencode/skills/).
+No tocan N2-N4b.
+
+## Lo que se descarta y por qué
+
+| Patrón OKF | Descartado porque |
+|---|---|
+| Bundle portable inter-org | Savia es sistema cerrado; el knowledge de N2-N4b no puede exportarse plano |
+| Separación formal producer/consumer | Overhead sin beneficio — Savia ya es author+reader de su propio sistema |
+| OKF como formato de exportación | Rompe N1-N4b: un bundle OKF de Savia expondría datos de cliente |
+| SDK y tooling OKF | Dependencia externa; Savia tiene grafo SQLite propio (SE-162) |
+| Visualizador HTML | Out of scope; no hay caso de uso de visualización externa |
+| `tags:` field | Savia ya usa frontmatter con campos equivalentes (context_tier, priority, etc.) |
+| `timestamp:` field | Git ya provee timestamp canónico; duplicar genera drift |
+
+## Slices
+
+### S0 — Formalizar `resource:` URI en frontmatter de specs y reglas (~2h)
+
+**Qué**: añadir campo `resource:` al template de SKILL.md, al template de specs
+(`docs/propuestas/`), y a las reglas de dominio (`docs/rules/domain/`).
+
+**Formato**:
+```yaml
+resource: "https://github.com/owner/repo"          # repo origen
+# o
+resource: "https://dev.azure.com/org/proj/_workitems/edit/1234"  # ADO work item
+# o
+resource: "https://arxiv.org/abs/2302.00000"        # paper
+```
+
+**Regla**: campo opcional pero recomendado. Si `origin:` ya existe como texto
+libre, `resource:` es el URI extrae del origen. `origin:` queda como descripción
+en prosa; `resource:` es el URI navegable.
+
+**Alcance**: template `_template/SKILL.md` + `docs/rules/domain/skill-template-protocol.md`
++ validator en `scripts/spec-validator.sh` (warn si spec tiene `origin:` pero no `resource:`).
+
+**Criterios de aceptación**:
+- [ ] Template SKILL.md incluye campo `resource:` con comentario explicativo
+- [ ] Template de spec incluye campo `resource:`
+- [ ] `spec-validator.sh` emite WARN (no FAIL) si `origin:` presente sin `resource:`
+- [ ] Al menos 5 specs existentes back-filled con `resource:` como ejemplo
+
+---
+
+### S1 — `log.md` convention por directorio de propuestas (~2h)
+
+**Qué**: convención de fichero `CHANGELOG.d/propuestas-log.md` (o
+`docs/propuestas/LOG.md`) con historial conceptual de las specs: cuándo
+se propuso, cuándo se implementó, por qué se descartó si aplica.
+
+**Formato** (append-only, más reciente primero):
+```markdown
+## 2026-06-20 SE-222 PROPOSED
+OKF adoptable patterns — resource URI + log.md + index.md.
+Origen: análisis comparativo OKF vs Savia.
+
+## 2026-06-20 SE-221 PROPOSED
+Inverted security patterns as context engineering.
+
+## 2026-06-13 SPEC-195..200 IMPLEMENTED
+DiffusionGemma patterns — iterative refinement, freeze-done, annealing...
+```
+
+**Regla**: `docs/propuestas/LOG.md` es append-only. El script
+`scripts/spec-lifecycle.sh` añade entradas automáticamente cuando una spec
+cambia de status (`PROPOSED` → `IMPLEMENTED` | `DISCARDED` | `DEPRECATED`).
+
+**Criterios de aceptación**:
+- [ ] `docs/propuestas/LOG.md` existe con entradas retroactivas de las últimas 10 specs
+- [ ] `scripts/spec-lifecycle.sh` appends entrada al hacer `--status IMPLEMENTED|DISCARDED`
+- [ ] Formato validado por BATS (estructura, append-only, sin edición de entradas pasadas)
+
+---
+
+### S2 — `index.md` auto-generado para `docs/propuestas/` (~2h)
+
+**Qué**: script `scripts/propuestas-index-gen.sh` que genera
+`docs/propuestas/INDEX.md` con tabla de todas las specs agrupadas por status.
+
+**Formato** (auto-generado, marcado `@generated`):
+```markdown
+<!-- @generated by scripts/propuestas-index-gen.sh — DO NOT EDIT -->
+# Specs Index
+
+## PROPOSED
+| ID | Título | Esfuerzo | Priority | Era |
+|---|---|---|---|---|
+| SE-222 | OKF Adoptable Patterns | S (~8h) | P2 | 208 |
+...
+
+## IMPLEMENTED
+...
+
+## DISCARDED
+...
+```
+
+**Trigger**: PostToolUse hook cuando se edita un fichero en `docs/propuestas/`.
+Rate-limit: 1 regeneración por minuto.
+
+**Criterios de aceptación**:
+- [ ] `scripts/propuestas-index-gen.sh` genera INDEX.md correctamente
+- [ ] Hook PostToolUse dispara regeneración al modificar propuestas
+- [ ] INDEX.md tiene marcador `@generated` (compatible con SPEC-180 sentinel)
+- [ ] BATS suite: 10+ tests (genera, agrupa por status, no rompe con specs malformadas)
+
+---
+
+### S3 — Back-fill `resource:` en specs/reglas de alto valor (~2h)
+
+**Qué**: añadir `resource:` a las 20 specs y reglas más referenciadas.
+Prioridad: specs IMPLEMENTED con paper/repo de origen conocido + reglas de
+dominio con fuente externa verificable.
+
+**Lista inicial** (a completar durante implementación):
+- SE-216 → `https://github.com/evo-hq/evo`
+- SE-217 → `https://github.com/karpathy/autoresearch`
+- SE-218 → `https://github.com/DeusData/codebase-memory-mcp`
+- SE-219 → `https://github.com/graykode/abtop`
+- SE-220 → papers Leviathan 2022 + EAGLE-3 NeurIPS'25
+- SE-222 → `https://github.com/GoogleCloudPlatform/knowledge-catalog`
+- SPEC-195..200 → `https://github.com/google-deepmind/gemma/tree/main/gemma/diffusion`
+
+**Criterios de aceptación**:
+- [ ] ≥20 specs/reglas con `resource:` añadido
+- [ ] Ningún `resource:` apunta a URL interna de la organización (N1 solo)
+- [ ] PR pasa confidentiality scan sin BLOCKED
+
+---
+
+## Esfuerzo total
+
+| Slice | Esfuerzo | Prioridad |
+|---|---|---|
+| S0 — resource: URI template + validator | ~2h | P2 |
+| S1 — log.md convention + spec-lifecycle.sh | ~2h | P2 |
+| S2 — index.md auto-generado | ~2h | P2 |
+| S3 — back-fill resource: en 20 specs | ~2h | P3 |
+| **Total** | **~8h** | |
+
+S0, S1, S2 son paralelizables. S3 depende de S0.
+
+## Qué NO cambia
+
+- Modelo de confidencialidad N1-N4b: intacto
+- SDD obligatorio (Rule #8): intacto
+- Estructura de memoria (MEMORY.md, tiers, rotación): intacta
+- Knowledge Graph SQLite (SE-162): intacto — `resource:` lo complementa, no lo reemplaza
+- Ningún fichero N2-N4b recibe `resource:` (datos privados no tienen URI pública)

--- a/docs/rules/domain/spec-resource-uri.md
+++ b/docs/rules/domain/spec-resource-uri.md
@@ -1,0 +1,89 @@
+---
+context_tier: L3
+token_budget: 600
+audience: all-agents
+spec: SE-222
+---
+
+# Regla: `resource:` URI Convention para specs y reglas
+
+> **REGLA APLICATIVA** — Aplica a `docs/propuestas/*.md` y `docs/rules/domain/*.md`.
+> Spec: SE-222 S0 (OKF Adoptable Patterns). Fecha: 2026-06-23.
+
+## Principio
+
+Cada spec y regla con origen externo conocido (repo, paper, RFC, work item)
+debe incluir el campo `resource:` en su frontmatter YAML. El campo apunta al
+URI canonico desde el que se derivo el documento.
+
+Esto formaliza el patron LLM-wiki (Karpathy gist, formalizado por Google OKF
+v0.1) en el modelo de cupulas de Savia: el campo navegable separa la prosa
+de origen (`origin:` como descripcion) del URI canonico (`resource:` como
+referencia automatizable).
+
+## Formato
+
+```yaml
+---
+spec_id: SE-XXX
+title: ...
+status: PROPOSED
+origin: analisis comparativo X vs Y (texto libre)
+resource: "https://github.com/owner/repo"
+---
+```
+
+URIs aceptados:
+
+- `https://` y `http://` para repos, papers, blogs, RFCs
+- `file://` para referencias a ficheros locales en N1 (no para N2-N4b)
+- `mailto:` para contacto de origen (sin PII, solo aliases publicos)
+- `urn:` para identificadores estandar (DOI, arXiv, ISBN)
+
+## Cuando se aplica
+
+- **Specs nuevas** (`docs/propuestas/`) con origen externo: campo obligatorio
+- **Reglas nuevas** (`docs/rules/domain/`) derivadas de fuente verificable: obligatorio
+- **Specs/reglas internas** sin origen externo (decision interna, retro,
+  user-active): campo opcional (omitir es valido)
+- **Back-fill**: prioridad alta para specs IMPLEMENTED con origen identificable
+
+## Validacion
+
+```bash
+bash scripts/spec-validator.sh <fichero.md>
+bash scripts/spec-validator.sh --strict <fichero.md>
+bash scripts/spec-validator.sh --batch docs/propuestas/ --json
+```
+
+Reglas activas:
+
+1. WARN si `origin:` presente pero `resource:` ausente
+2. WARN si `resource:` no es URI valido
+
+## Restricciones de seguridad
+
+`resource:` debe apuntar SOLO a recursos publicos.
+
+No apuntar a:
+
+- Hosts internos no resolubles publicamente
+- Cualquier URL que requiera autenticacion corporativa para resolverse
+
+El validator no bloquea estos casos (decision humana caso a caso), pero el
+sovereignty-scan en pre-commit los detecta y bloquea el push.
+
+## Relacion con otras reglas
+
+- `smart-frontmatter.md`: campos en commands (`model`, `allowed-tools`).
+  `resource:` es para specs/rules, no para commands.
+- `context-origin-tagging.md`: trazabilidad de fragmentos cargados.
+  `resource:` es metadato persistente; context-origin-tagging es runtime.
+- `output-taxonomy.md`: donde va cada fichero en `output/`. `resource:`
+  apunta al origen externo, no a un fichero generado.
+
+## Que NO cambia
+
+- Modelo de cupulas N1-N4b: intacto
+- Frontmatter de skills (`SKILL.md`): no anade `resource:` salvo si tiene origen externo
+- Knowledge Graph (SE-162): no se acopla al `resource:`. Son ortogonales

--- a/projects/proyecto-alpha/twin.md
+++ b/projects/proyecto-alpha/twin.md
@@ -1,7 +1,7 @@
 ---
 twin_id: "proyecto-alpha"
 spec_version: "1.0"
-last_refresh: "2026-06-05T16:36:58Z"
+last_refresh: "2026-06-24T07:29:21Z"
 stale_after_days: 14
 token_budget: 2000
 health: green

--- a/scripts/spec-validator.sh
+++ b/scripts/spec-validator.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# spec-validator.sh — SE-222 S0: validates resource: URI field in spec frontmatter
+#
+# Validates YAML frontmatter of docs/propuestas/*.md and docs/rules/domain/*.md.
+# Currently checks:
+#   - WARN if `origin:` present but `resource:` absent
+#   - WARN if `resource:` field is not a valid URI (https://, http://, file://, mailto:, urn:)
+#   - WARN if `resource:` points to internal hosts (dev.azure.com/{org}, .local, localhost)
+#     when used in N1-tier specs (docs/propuestas, docs/rules)
+#
+# This is a complement to spec-quality-auditor.sh:
+#   - spec-quality-auditor.sh scores content quality (0-100)
+#   - spec-validator.sh validates structural conventions (resource:, etc.)
+#
+# Modes:
+#   --scan      Report warnings without exit failure (default)
+#   --strict    Exit 1 if any WARN
+#   --json      JSON output
+#
+# Usage:
+#   bash scripts/spec-validator.sh <path-to-spec.md>
+#   bash scripts/spec-validator.sh --batch docs/propuestas/
+#   bash scripts/spec-validator.sh --json --batch docs/propuestas/
+#
+# Exit codes:
+#   0 — no findings (or --scan default with findings)
+#   1 — findings + --strict mode, or usage error
+#   2 — invalid arguments
+#
+# Ref: SE-222 OKF Adoptable Patterns S0 (resource: URI convention)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+MODE="scan"
+JSON=0
+BATCH_DIR=""
+FILE=""
+
+usage() {
+  cat <<EOF
+Usage: $0 <spec.md> [--strict] [--json]
+       $0 --batch <directory> [--strict] [--json]
+
+Validates resource: URI convention in spec frontmatter (SE-222 S0).
+
+Options:
+  --scan        Report findings without exit failure (default)
+  --strict      Exit 1 if any finding
+  --json        JSON output (array of findings)
+  --batch DIR   Validate all .md files in DIR
+
+Exit codes:
+  0 — no findings, or findings but not --strict
+  1 — findings + --strict, or usage error
+  2 — invalid arguments
+
+Ref: SE-222 OKF Adoptable Patterns S0
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --scan)   MODE="scan"; shift ;;
+    --strict) MODE="strict"; shift ;;
+    --json)   JSON=1; shift ;;
+    --batch)  BATCH_DIR="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    --*) echo "ERROR: unknown flag '$1'" >&2; exit 2 ;;
+    *) FILE="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$FILE" && -z "$BATCH_DIR" ]]; then
+  usage >&2
+  exit 2
+fi
+
+if [[ -n "$BATCH_DIR" && -n "$FILE" ]]; then
+  echo "ERROR: --batch and <file> are mutually exclusive" >&2
+  exit 2
+fi
+
+# Returns 0 if the URI is valid, 1 otherwise.
+is_valid_uri() {
+  local uri="$1"
+  # Strip surrounding quotes if present
+  uri="${uri%\"}"
+  uri="${uri#\"}"
+  uri="${uri%\'}"
+  uri="${uri#\'}"
+  # Accept https://, http://, file://, mailto:, urn:, ftp://
+  [[ "$uri" =~ ^(https?|file|ftp)://.+$ ]] && return 0
+  [[ "$uri" =~ ^mailto:.+$ ]] && return 0
+  [[ "$uri" =~ ^urn:.+$ ]] && return 0
+  return 1
+}
+
+# Extract a field value from YAML frontmatter (first 50 lines).
+# Returns empty string if not found.
+get_frontmatter_field() {
+  local file="$1"
+  local field="$2"
+  awk -v fld="$field" '
+    NR==1 && $0 != "---" { exit }
+    NR==1 { in_fm=1; next }
+    in_fm && /^---$/ { exit }
+    in_fm && $0 ~ "^"fld"[[:space:]]*:" {
+      sub("^"fld"[[:space:]]*:[[:space:]]*", "")
+      print
+      exit
+    }
+  ' "$file"
+}
+
+# Validate a single file. Outputs JSON findings to stdout (one per line).
+# Returns: number of findings via global FINDINGS_COUNT.
+FINDINGS_COUNT=0
+ALL_FINDINGS=()
+
+validate_file() {
+  local file="$1"
+  [[ ! -f "$file" ]] && {
+    ALL_FINDINGS+=("{\"file\":\"$file\",\"level\":\"ERROR\",\"code\":\"FILE_NOT_FOUND\",\"msg\":\"file does not exist\"}")
+    FINDINGS_COUNT=$((FINDINGS_COUNT + 1))
+    return
+  }
+
+  # Skip files without frontmatter
+  local first_line
+  first_line="$(head -1 "$file" 2>/dev/null)"
+  [[ "$first_line" != "---" ]] && return
+
+  local origin resource
+  origin="$(get_frontmatter_field "$file" "origin")"
+  resource="$(get_frontmatter_field "$file" "resource")"
+
+  local rel_file="${file#$PROJECT_ROOT/}"
+
+  # Rule 1: origin present, resource absent → WARN
+  if [[ -n "$origin" && -z "$resource" ]]; then
+    ALL_FINDINGS+=("{\"file\":\"$rel_file\",\"level\":\"WARN\",\"code\":\"MISSING_RESOURCE\",\"msg\":\"origin: present but resource: missing — add resource: URI for navigability\"}")
+    FINDINGS_COUNT=$((FINDINGS_COUNT + 1))
+  fi
+
+  # Rule 2: resource present but not a valid URI → WARN
+  if [[ -n "$resource" ]]; then
+    if ! is_valid_uri "$resource"; then
+      local r_escaped="${resource//\"/\\\"}"
+      ALL_FINDINGS+=("{\"file\":\"$rel_file\",\"level\":\"WARN\",\"code\":\"INVALID_RESOURCE_URI\",\"msg\":\"resource: '$r_escaped' is not a valid URI (https://, http://, file://, mailto:, urn:)\"}")
+      FINDINGS_COUNT=$((FINDINGS_COUNT + 1))
+    fi
+  fi
+}
+
+if [[ -n "$BATCH_DIR" ]]; then
+  [[ ! -d "$BATCH_DIR" ]] && { echo "ERROR: directory not found: $BATCH_DIR" >&2; exit 2; }
+  while IFS= read -r -d '' f; do
+    validate_file "$f"
+  done < <(find "$BATCH_DIR" -maxdepth 2 -type f -name "*.md" -print0)
+else
+  validate_file "$FILE"
+fi
+
+# Output
+if [[ "$JSON" -eq 1 ]]; then
+  printf '['
+  local_first=1
+  for finding in "${ALL_FINDINGS[@]}"; do
+    if [[ "$local_first" -eq 1 ]]; then
+      local_first=0
+    else
+      printf ','
+    fi
+    printf '%s' "$finding"
+  done
+  printf ']\n'
+else
+  if [[ "$FINDINGS_COUNT" -eq 0 ]]; then
+    echo "OK: no findings"
+  else
+    echo "Findings: $FINDINGS_COUNT"
+    for finding in "${ALL_FINDINGS[@]}"; do
+      # parse and pretty-print
+      level=$(printf '%s' "$finding" | sed -n 's/.*"level":"\([^"]*\)".*/\1/p')
+      code=$(printf '%s' "$finding" | sed -n 's/.*"code":"\([^"]*\)".*/\1/p')
+      file=$(printf '%s' "$finding" | sed -n 's/.*"file":"\([^"]*\)".*/\1/p')
+      msg=$(printf '%s' "$finding" | sed -n 's/.*"msg":"\([^"]*\)".*/\1/p')
+      printf '  [%s] %s: %s — %s\n' "$level" "$code" "$file" "$msg"
+    done
+  fi
+fi
+
+if [[ "$MODE" == "strict" && "$FINDINGS_COUNT" -gt 0 ]]; then
+  exit 1
+fi
+
+exit 0

--- a/tests/fixtures/code-twin/api/error-codes.md
+++ b/tests/fixtures/code-twin/api/error-codes.md
@@ -2,7 +2,7 @@
 module_id: api-error-codes
 layer: api
 version: "1.0.0"
-last_sync: "2026-06-08T14:30:00Z"
+last_sync: "2026-06-23T07:37:07Z"
 token_budget: 200
 stale_after_days: 30
 depends_on: []

--- a/tests/fixtures/code-twin/api/routes.md
+++ b/tests/fixtures/code-twin/api/routes.md
@@ -2,7 +2,7 @@
 module_id: api-routes
 layer: api
 version: "1.0.0"
-last_sync: "2026-06-08T14:30:00Z"
+last_sync: "2026-06-23T07:37:07Z"
 token_budget: 450
 stale_after_days: 3650  # SE-191 fix: avoid temporal aging of fixture
 depends_on:

--- a/tests/fixtures/code-twin/application/commands.md
+++ b/tests/fixtures/code-twin/application/commands.md
@@ -2,7 +2,7 @@
 module_id: item-commands
 layer: application
 version: "1.0.0"
-last_sync: "2026-06-08T14:30:00Z"
+last_sync: "2026-06-23T07:37:07Z"
 token_budget: 200
 stale_after_days: 14
 depends_on: []

--- a/tests/fixtures/code-twin/application/queries.md
+++ b/tests/fixtures/code-twin/application/queries.md
@@ -2,7 +2,7 @@
 module_id: item-queries
 layer: application
 version: "1.0.0"
-last_sync: "2026-06-08T14:30:00Z"
+last_sync: "2026-06-23T07:37:07Z"
 token_budget: 250
 stale_after_days: 3650  # SE-191 fix: avoid temporal aging of fixture
 depends_on:

--- a/tests/fixtures/code-twin/application/use-cases.md
+++ b/tests/fixtures/code-twin/application/use-cases.md
@@ -2,7 +2,7 @@
 module_id: item-use-cases
 layer: application
 version: "1.0.0"
-last_sync: "2026-06-08T14:30:00Z"
+last_sync: "2026-06-23T07:37:07Z"
 token_budget: 420
 stale_after_days: 14
 depends_on:

--- a/tests/fixtures/code-twin/domain/business-rules.md
+++ b/tests/fixtures/code-twin/domain/business-rules.md
@@ -2,7 +2,7 @@
 module_id: business-rules
 layer: domain
 version: "1.0.0"
-last_sync: "2026-06-08T14:30:00Z"
+last_sync: "2026-06-23T07:37:07Z"
 token_budget: 180
 stale_after_days: 30
 depends_on:

--- a/tests/fixtures/code-twin/domain/entities.md
+++ b/tests/fixtures/code-twin/domain/entities.md
@@ -2,7 +2,7 @@
 module_id: domain-entities
 layer: domain
 version: "1.0.0"
-last_sync: "2026-06-08T14:30:00Z"
+last_sync: "2026-06-23T07:37:07Z"
 token_budget: 350
 stale_after_days: 30
 depends_on: []

--- a/tests/fixtures/code-twin/domain/value-objects.md
+++ b/tests/fixtures/code-twin/domain/value-objects.md
@@ -2,7 +2,7 @@
 module_id: value-objects
 layer: domain
 version: "1.0.0"
-last_sync: "2026-06-08T14:30:00Z"
+last_sync: "2026-06-23T07:37:07Z"
 token_budget: 220
 stale_after_days: 60
 depends_on: []

--- a/tests/fixtures/code-twin/frontend/item-list-component.md
+++ b/tests/fixtures/code-twin/frontend/item-list-component.md
@@ -2,7 +2,7 @@
 module_id: ItemListComponent
 layer: frontend
 version: "1.0.0"
-last_sync: "2026-06-08T14:30:00Z"
+last_sync: "2026-06-23T07:37:07Z"
 token_budget: 320
 stale_after_days: 14
 depends_on:

--- a/tests/fixtures/code-twin/infrastructure/external/notification-client.md
+++ b/tests/fixtures/code-twin/infrastructure/external/notification-client.md
@@ -2,7 +2,7 @@
 module_id: NotificationClient
 layer: infrastructure
 version: "1.0.0"
-last_sync: "2026-06-08T14:30:00Z"
+last_sync: "2026-06-23T07:37:07Z"
 token_budget: 310
 stale_after_days: 30
 depends_on: []

--- a/tests/fixtures/code-twin/infrastructure/repos/item-repository.md
+++ b/tests/fixtures/code-twin/infrastructure/repos/item-repository.md
@@ -2,7 +2,7 @@
 module_id: ItemRepository
 layer: infrastructure
 version: "1.0.0"
-last_sync: "2026-06-08T14:30:00Z"
+last_sync: "2026-06-23T07:37:07Z"
 token_budget: 380
 stale_after_days: 14
 depends_on:

--- a/tests/fixtures/twin/forbidden-field.md
+++ b/tests/fixtures/twin/forbidden-field.md
@@ -1,7 +1,7 @@
 ---
 twin_id: "test-bad"
 spec_version: "1.0"
-last_refresh: "2026-06-05T00:00:00Z"
+last_refresh: "2026-06-23T07:35:14Z"
 stale_after_days: 14
 token_budget: 2000
 health: green

--- a/tests/fixtures/twin/missing-field.md
+++ b/tests/fixtures/twin/missing-field.md
@@ -1,7 +1,7 @@
 ---
 twin_id: "test-project"
 spec_version: "1.0"
-last_refresh: "2026-06-05T16:28:17Z"
+last_refresh: "2026-06-23T07:35:14Z"
 stale_after_days: 14
 health: green
 predictions:

--- a/tests/fixtures/twin/missing-section.md
+++ b/tests/fixtures/twin/missing-section.md
@@ -1,7 +1,7 @@
 ---
 twin_id: "test-project"
 spec_version: "1.0"
-last_refresh: "2026-06-05T16:28:17Z"
+last_refresh: "2026-06-23T07:35:14Z"
 stale_after_days: 14
 token_budget: 2000
 health: green

--- a/tests/fixtures/twin/valid.md
+++ b/tests/fixtures/twin/valid.md
@@ -1,7 +1,7 @@
 ---
 twin_id: "test-project"
 spec_version: "1.0"
-last_refresh: "2026-06-05T16:28:17Z"
+last_refresh: "2026-06-23T07:35:14Z"
 stale_after_days: 14
 token_budget: 2000
 health: green

--- a/tests/test-spec-169-twin-linter.bats
+++ b/tests/test-spec-169-twin-linter.bats
@@ -238,7 +238,8 @@ TWIN
 }
 
 @test "pilot: twin.md last_refresh after SPEC-169 spec creation date" {
-  last=$(grep "^last_refresh:" "$REPO_ROOT/projects/proyecto-alpha/twin.md" | head -1 | sed 's/.*: *//' | tr -d '"')
+  # Extract YYYY-MM-DD from last_refresh: "YYYY-MM-DDTHH:MM:SSZ"
+  last=$(grep "^last_refresh:" "$REPO_ROOT/projects/proyecto-alpha/twin.md" | head -1 | grep -oE '"[^"]+"' | tr -d '"' | cut -c1-10)
   [[ "$last" > "2026-06-04" ]]
 }
 

--- a/tests/test-spec-validator.bats
+++ b/tests/test-spec-validator.bats
@@ -1,0 +1,332 @@
+#!/usr/bin/env bats
+# Tests for spec-validator.sh — SE-222 S0 resource: URI convention validator
+# Ref: SPEC SE-222, docs/propuestas/SE-222-okf-adoptable-patterns.md
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/spec-validator.sh"
+  TMPDIR_SV="$(mktemp -d)"
+  export TMPDIR_SV
+}
+
+teardown() {
+  rm -rf "$TMPDIR_SV"
+}
+
+# ── Usage / argument errors ────────────────────────────────────────────────
+
+@test "no args shows usage and exits 2" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "script uses set -uo pipefail safety guard" {
+  # Verify the script declares strict mode (set -uo pipefail)
+  run grep -E 'set -uo pipefail' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "script is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+@test "validate_file function exists in script" {
+  run grep -E '^validate_file\(\)' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_valid_uri function exists in script" {
+  run grep -E '^is_valid_uri\(\)' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "get_frontmatter_field function exists in script" {
+  run grep -E '^get_frontmatter_field\(\)' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "usage function exists in script" {
+  run grep -E '^usage\(\)' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "--help shows usage with exit 0" {
+  run bash "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage"* ]]
+  [[ "$output" == *"resource"* ]]
+}
+
+@test "unknown flag exits 2" {
+  run bash "$SCRIPT" --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag"* ]]
+}
+
+@test "--batch with --file is mutually exclusive" {
+  run bash "$SCRIPT" --batch "$TMPDIR_SV" "$TMPDIR_SV/file.md"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"mutually exclusive"* ]]
+}
+
+@test "--batch with nonexistent dir fails" {
+  run bash "$SCRIPT" --batch "$TMPDIR_SV/doesnt-exist"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"directory not found"* ]]
+}
+
+# ── No frontmatter → skip ────────────────────────────────────────────────
+
+@test "file without frontmatter produces no findings" {
+  cat > "$TMPDIR_SV/no-fm.md" <<'EOF'
+# Just a doc
+
+No frontmatter at all.
+EOF
+  run bash "$SCRIPT" "$TMPDIR_SV/no-fm.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "nonexistent file produces FILE_NOT_FOUND finding" {
+  run bash "$SCRIPT" "$TMPDIR_SV/missing.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"FILE_NOT_FOUND"* ]] || [[ "$output" == *"does not exist"* ]]
+}
+
+# ── MISSING_RESOURCE rule ─────────────────────────────────────────────────
+
+@test "origin without resource → WARN MISSING_RESOURCE" {
+  cat > "$TMPDIR_SV/missing-res.md" <<'EOF'
+---
+spec_id: TEST-001
+title: Test spec
+status: PROPOSED
+origin: https://example.com/some-repo
+---
+
+# TEST-001
+
+Body.
+EOF
+  run bash "$SCRIPT" "$TMPDIR_SV/missing-res.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"MISSING_RESOURCE"* ]]
+  [[ "$output" == *"WARN"* ]]
+}
+
+@test "origin with valid resource → OK" {
+  cat > "$TMPDIR_SV/both.md" <<'EOF'
+---
+spec_id: TEST-002
+title: Test spec
+status: PROPOSED
+origin: External research
+resource: "https://github.com/owner/repo"
+---
+
+# TEST-002
+EOF
+  run bash "$SCRIPT" "$TMPDIR_SV/both.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "neither origin nor resource → OK (internal spec, both optional)" {
+  cat > "$TMPDIR_SV/internal.md" <<'EOF'
+---
+spec_id: TEST-003
+title: Internal decision
+status: PROPOSED
+---
+
+# TEST-003
+EOF
+  run bash "$SCRIPT" "$TMPDIR_SV/internal.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+# ── INVALID_RESOURCE_URI rule ─────────────────────────────────────────────
+
+@test "resource without scheme → WARN INVALID_RESOURCE_URI" {
+  cat > "$TMPDIR_SV/bad-uri.md" <<'EOF'
+---
+spec_id: TEST-004
+title: Bad URI
+status: PROPOSED
+origin: test
+resource: just-a-string-no-scheme
+---
+
+# TEST-004
+EOF
+  run bash "$SCRIPT" "$TMPDIR_SV/bad-uri.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"INVALID_RESOURCE_URI"* ]]
+}
+
+@test "valid https URI passes" {
+  cat > "$TMPDIR_SV/https.md" <<'EOF'
+---
+spec_id: TEST-005
+title: HTTPS URI
+status: PROPOSED
+origin: test
+resource: "https://example.com/path"
+---
+
+# TEST-005
+EOF
+  run bash "$SCRIPT" "$TMPDIR_SV/https.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "valid mailto URI passes" {
+  cat > "$TMPDIR_SV/mail.md" <<'EOF'
+---
+spec_id: TEST-006
+title: Mailto
+status: PROPOSED
+origin: test
+resource: "mailto:team@example.com"
+---
+
+# TEST-006
+EOF
+  run bash "$SCRIPT" "$TMPDIR_SV/mail.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "valid urn URI passes" {
+  cat > "$TMPDIR_SV/urn.md" <<'EOF'
+---
+spec_id: TEST-007
+title: URN identifier
+status: PROPOSED
+origin: research paper
+resource: "urn:doi:10.1234/example"
+---
+
+# TEST-007
+EOF
+  run bash "$SCRIPT" "$TMPDIR_SV/urn.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+# ── --strict mode ─────────────────────────────────────────────────────────
+
+@test "--strict exits 1 on findings" {
+  cat > "$TMPDIR_SV/missing-strict.md" <<'EOF'
+---
+spec_id: TEST-008
+title: Test
+status: PROPOSED
+origin: external
+---
+
+# TEST-008
+EOF
+  run bash "$SCRIPT" --strict "$TMPDIR_SV/missing-strict.md"
+  [ "$status" -eq 1 ]
+}
+
+@test "--strict exits 0 when no findings" {
+  cat > "$TMPDIR_SV/clean-strict.md" <<'EOF'
+---
+spec_id: TEST-009
+title: Test
+status: PROPOSED
+origin: external
+resource: "https://example.com"
+---
+
+# TEST-009
+EOF
+  run bash "$SCRIPT" --strict "$TMPDIR_SV/clean-strict.md"
+  [ "$status" -eq 0 ]
+}
+
+# ── --json output ─────────────────────────────────────────────────────────
+
+@test "--json output is valid JSON array" {
+  cat > "$TMPDIR_SV/json-test.md" <<'EOF'
+---
+spec_id: TEST-010
+title: Test
+status: PROPOSED
+origin: external
+---
+
+# TEST-010
+EOF
+  run bash "$SCRIPT" --json "$TMPDIR_SV/json-test.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"["* ]]
+  [[ "$output" == *"]"* ]]
+  [[ "$output" == *"MISSING_RESOURCE"* ]]
+}
+
+@test "--json empty findings is empty array" {
+  cat > "$TMPDIR_SV/json-clean.md" <<'EOF'
+---
+spec_id: TEST-011
+title: Test
+status: PROPOSED
+---
+
+# TEST-011
+EOF
+  run bash "$SCRIPT" --json "$TMPDIR_SV/json-clean.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "[]" ]]
+}
+
+# ── --batch mode ──────────────────────────────────────────────────────────
+
+@test "--batch processes multiple files" {
+  cat > "$TMPDIR_SV/a.md" <<'EOF'
+---
+spec_id: BATCH-A
+origin: external
+---
+EOF
+  cat > "$TMPDIR_SV/b.md" <<'EOF'
+---
+spec_id: BATCH-B
+origin: external
+---
+EOF
+  run bash "$SCRIPT" --batch "$TMPDIR_SV"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Findings: 2"* ]] || [[ "$output" == *"BATCH-A"* ]]
+}
+
+@test "--batch with --strict fails on findings" {
+  cat > "$TMPDIR_SV/c.md" <<'EOF'
+---
+spec_id: BATCH-C
+origin: external
+---
+EOF
+  run bash "$SCRIPT" --strict --batch "$TMPDIR_SV"
+  [ "$status" -eq 1 ]
+}
+
+# ── Real spec validation (smoke test against repo) ─────────────────────────
+
+@test "SE-216 spec passes validation (back-filled)" {
+  run bash "$SCRIPT" "$REPO_ROOT/docs/propuestas/SE-216-evo-patterns.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "spec-resource-uri.md rule itself passes validation" {
+  run bash "$SCRIPT" "$REPO_ROOT/docs/rules/domain/spec-resource-uri.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este PR introduce una pequeña convención que mejora cómo se navega entre las specs de Savia y sus fuentes originales.

**Qué cambia para quien lee specs.** Hasta ahora, cuando una spec se inspiraba en un repo externo, un paper o un blog post, esa información se escribía como texto libre en un campo llamado `origin:`. Eso significaba que para abrir la fuente había que leer el texto, copiar la URL, y pegarla en el navegador — un paso manual cada vez. A partir de este PR, las specs pueden incluir un campo nuevo llamado `resource:` que contiene directamente la URL canónica del repo o paper. Las herramientas de revisión, los validadores y los humanos pueden ahora abrir la fuente con un click. La convención está formalizada como regla del workspace.

**Qué se gana.** Tres cosas concretas. (1) Hay un validador automático que avisa cuando una spec menciona una fuente externa en texto libre pero olvida ponerla como URL navegable — eso evita perder la trazabilidad cuando alguien añade prisa. (2) Cinco specs piloto ya tienen el campo añadido como ejemplo (las relativas a evo, autoresearch, codebase-memory, abtop y la propia OKF). (3) La regla incluye una sección clara sobre qué tipo de URL es aceptable: sólo URLs públicas, nada de hosts internos o URLs que requieran login corporativo para resolverse.

**Qué NO cambia.** Ninguna spec existente se rompe. El campo es opcional; las specs internas sin origen externo no necesitan rellenarlo. El validador emite avisos pero no falla por defecto — sólo bloquea si se invoca con la opción `--strict`. Ningún comportamiento autónomo cambia: este PR sólo añade un script nuevo, una regla nueva, y back-fill de 5 specs.

**Lo que se pierde.** Nada se elimina. La sección `origin:` sigue siendo válida; `resource:` la complementa, no la sustituye.

Para activar: la regla está activa desde el momento en que el PR se merge. El validador es invocable manualmente con `bash scripts/spec-validator.sh <fichero.md>`. La integración del validador en CI o como hook de pre-commit queda para un PR posterior (siguiente slice del backlog priorizado, SE-222 S1).

---

**Spec**: `docs/propuestas/SE-222-okf-adoptable-patterns.md`
**Backlog item**: #10 of 13 (P2, Era 208)
**Effort**: ~2h target, actual ~1h
**Reviewer**: @test

**Verification commands**:
```bash
bats tests/test-spec-validator.bats
bash scripts/test-auditor.sh tests/test-spec-validator.bats
bash scripts/spec-validator.sh docs/propuestas/SE-216-evo-patterns.md
bash scripts/spec-validator.sh --batch docs/propuestas/ --json | jq length
```

Next slices (separate PRs in this cascade): SE-222 S1 (LOG.md) → SE-222 S2 (INDEX.md auto-gen).