### PR TITLE
fix(hooks): tdd-gate resolves project root from the edited file's repo

### DIFF
--- a/.claude/hooks/tdd-gate.sh
+++ b/.claude/hooks/tdd-gate.sh
@@ -74,9 +74,12 @@ esac
 # Buscar test correspondiente
 DIR=$(dirname "$FILE_PATH")
 NAME_NO_EXT="${BASENAME%.*}"
-# Try git first, but fall back to current dir or CLAUDE_PROJECT_DIR
+# Try git first (from the edited file's dir, so files outside the workspace
+# resolve to THEIR repo), but fall back to current dir or CLAUDE_PROJECT_DIR
 # In tests, this will be the TEST_TMPDIR which has .git initialized
-if PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null); then
+if PROJECT_ROOT=$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null); then
+  :
+elif PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null); then
   :
 elif [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ -d "$CLAUDE_PROJECT_DIR" ]; then
   PROJECT_ROOT="$CLAUDE_PROJECT_DIR"


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Arregla un falso bloqueo del guardián que exige tests antes de tocar código. Hasta ahora, cuando se editaba código de un proyecto que vive fuera de esta carpeta de trabajo (por ejemplo, un repositorio personal en el home del usuario), el guardián buscaba los tests en el sitio equivocado: siempre miraba dentro de esta carpeta de trabajo, en lugar de mirar en el proyecto al que pertenece el fichero editado. Resultado: aunque el proyecto externo tuviera sus tests perfectamente escritos, el guardián decía "no hay tests" y bloqueaba la edición. Ha pasado hoy de verdad: un arreglo de una línea en un proyecto personal con veinte tests en verde quedó bloqueado dos veces. Con este cambio, el guardián primero pregunta "¿a qué proyecto pertenece el fichero que se está editando?" y busca los tests ahí; solo si eso falla, recurre al comportamiento anterior. No cambia nada para el caso habitual (editar ficheros de esta misma carpeta), no hay nada que activar ni configurar, y el guardián sigue bloqueando igual que antes cuando de verdad no hay tests. Riesgo restante: ninguno conocido; el cambio son tres líneas con los mismos recursos de respaldo que ya existían.

## Summary

- `tdd-gate.sh` resolved `PROJECT_ROOT` via `git rev-parse --show-toplevel` from the hook's cwd (always the workspace), so edits to files in OTHER repos never found their tests (e.g. `~/rutas-ifr/rutas_ifr/client.py` with `tests/test_client.py` present → blocked)
- Now tries `git -C \"$DIR\" rev-parse --show-toplevel` first (repo of the edited file), keeping the previous fallbacks (cwd git root → `CLAUDE_PROJECT_DIR` → `.`) unchanged

## Test plan

Verificado manualmente con el hook real:
- Edit de fichero externo CON tests (`~/rutas-ifr/.../client.py`) → exit 0 (antes: bloqueado)
- Edit de fichero del workspace sin tests y fuera de paths exentos → sigue bloqueando (exit 2)
- Paths exentos (`*/scripts/*`, `tests/`) → exit 0 sin cambios

🤖 Generated with [Claude Code](https://claude.com/claude-code)