### PR TITLE
test(se266): add git clean dry-run test cases (T11, T12)

### DIFF
--- a/tests/test-se-266-agent-git.bats
+++ b/tests/test-se-266-agent-git.bats
@@ -192,3 +192,13 @@ run_hook() {
   run run_hook "git log --oneline -5"
   [[ "$status" -eq 0 ]]
 }
+
+@test "SE266-T11: allows git clean dry-run (-fdn)" {
+  run bash -c "json_cmd 'git clean -fdn' | bash '$HOOK'"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "SE266-T12: allows git clean with -n flag" {
+  run bash -c "json_cmd 'git clean -n' | bash '$HOOK'"
+  [[ "$status" -eq 0 ]]
+}


### PR DESCRIPTION
## Que

Añade 2 test cases a `tests/test-se-266-agent-git.bats`:
- SE266-T11: permite `git clean -fdn`
- SE266-T12: permite `git clean -n`

## Por que

El hook `agent-git-discipline.sh` ya permite git clean con flag `-n`/`--dry-run`. Faltaban los tests que validan ese comportamiento.

## Cambios

- 1 archivo, +10 lineas

## Riesgo

Nulo. Solo tests adicionales.