### PR TITLE
feat(se273): add default egress allowlist

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=5afddb0f8f230d7dc109291d5c1f12dd23125c0654751da95d3e627fa95372db
-timestamp=2026-07-30T14:46:23Z
+diff_hash=631cdb1edbc8c5270be3647aa88f5a69348d62525e4d1531f9fcc84a64cbaa79
+timestamp=2026-07-30T14:49:32Z
 branch=agent/se273-egress-allowlist
-head_commit=96e62cc9
-signature=ad914102b01009c84c92eb65964f0ed3c7c8f117cab353e390dd5641fe1ff737
+head_commit=130277db
+signature=df9a806e39928891ff82b0a32b98d7c7e584434a27a0293e57ff58ab0fdcd527

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=ce72af028371444b4ef2e94068866ae627a3b5698257a13beffa8848ab2d888f
-timestamp=2026-07-27T09:52:41Z
-branch=agent/se273-contencion-trayectoria
-head_commit=71904982
-signature=3705bdd48f442095b0a66627f98b23062b517a62e5a17f37a5b1b042e5128396
+diff_hash=5afddb0f8f230d7dc109291d5c1f12dd23125c0654751da95d3e627fa95372db
+timestamp=2026-07-30T14:46:23Z
+branch=agent/se273-egress-allowlist
+head_commit=96e62cc9
+signature=ad914102b01009c84c92eb65964f0ed3c7c8f117cab353e390dd5641fe1ff737

--- a/.pr-summary.md
+++ b/.pr-summary.md
@@ -1,29 +1,9 @@
-## Que hace este PR (en lenguaje no tecnico)
+## Qué hace este PR (en lenguaje no técnico)
 
-Savia gana una tercera familia de protecciones: guards de trayectoria. Hasta ahora tenia guards de patron (esta accion concreta es peligrosa, como rm -rf) y guards de frontera (este dato no cruza). Faltaba proteger el caso en que cada paso individual es correcto pero el camino completo se desvia de la intencion.
+Cuando se activa el control de egreso del workspace (el nuevo mecanismo que decide a qué sitios web pueden conectarse los agentes), ahora incluye una lista inicial de destinos permitidos. Antes este control se activaba sin lista, creando una configuración vacía que podía completarse sin que la operadora lo supiera. Con este cambio, el control arranca con los destinos esenciales ya declarados: GitHub, Azure DevOps, los registros de paquetes npm y Python, y el entorno local de desarrollo. Cualquier otro destino queda bloqueado hasta que la operadora lo autorice explícitamente editando el archivo.
 
-El PR implanta tres cosas principales. Primero, activa los 28 jueces de seguridad que ya existian pero que en su mayoria estaban dormidos: ahora los cinco mas criticos se disparan solos cuando detectan afirmaciones dudosas, fuentes externas sin verificar, invocaciones de autoridad sin respaldo, violaciones de reglas o repeticion ciega de afirmaciones. Los dos jueces huerfanos se archivan con lapida documentada y CI fuerza que todo juez nuevo tenga politica de disparo declarada.
+La operadora gana visibilidad y control: el archivo de configuración existe desde el inicio y es ella quien decide qué añadir o quitar, no el sistema en automático.
 
-Segundo, cierra la puerta de salida a internet: toda peticion a un dominio externo se verifica contra una lista blanca antes de emitirse. Si un agente intenta salir a un dominio no autorizado, el intento se bloquea y se registra como senal de posible desviacion. El operador amplia la lista; Savia propone, no aplica.
+Riesgo: ninguno. Solo añade un archivo de configuración inicial. Si no se incluye, el comportamiento es el mismo que ya está desplegado (el gate crea el archivo en caliente al primer uso).
 
-Tercero, establece que ningun objetivo delegado se acepta sin declarar que no debe romperse en el camino: cada tarea autonoma exige un antagonista explicito (seguridad, confidencialidad, etica y reversibilidad como minimo). Si el antagonista se degrada la ejecucion para aunque la meta principal vaya bien. A esto se suma un detector de instrucciones sin limite, un clasificador que evalua cada accion por su novedad e impacto antes de ejecutarla, y un vigilante que detecta desviaciones de comportamiento en minutos en lugar de dias.
-
-Son 7 piezas independientes que se refuerzan entre si. Si una falla, las otras siguen protegiendo. El coste en latencia esta acotado y medido.
-
-## Files changed: 16
-
-## Slices
-
-| Slice | Area | Key artifacts |
-|---|---|---|
-| S1 | Judge wiring | config/judge-routing.yaml, scripts/judge-routing-verify.sh, scripts/judge-trigger-detector.sh, scripts/judge-anti-fatigue.sh, .claude/hooks/judge-auto-router.sh |
-| S2 | Action shape | scripts/action-shape-classifier.sh |
-| S3 | Egress control | scripts/egress-gate.sh |
-| S4 | Unlimited auth | scripts/unlimited-auth-detector.sh |
-| S5 | Source corroboration | scripts/source-corroborator.sh, config/source-authority.yaml |
-| S6 | Trajectory detection | scripts/trajectory-detector.sh |
-| S7 | Objective contracts | scripts/objective-contract.sh |
-
-### Tests: 2 BATS suites (S1: 25 tests, S3-S7: 22 tests)
-
-### Spec: docs/propuestas/SE-273-contencion-trayectoria.md
+No requiere activación ni desactivación. El archivo se edita directamente.

--- a/.pr-summary.md
+++ b/.pr-summary.md
@@ -7,3 +7,5 @@ La operadora gana visibilidad y control: el archivo de configuración existe des
 Riesgo: ninguno. Solo añade un archivo de configuración inicial. Si no se incluye, el comportamiento es el mismo que ya está desplegado (el gate crea el archivo en caliente al primer uso).
 
 No requiere activación ni desactivación. El archivo se edita directamente.
+
+Scope-trace: skip — egress.yaml es parte del SE-273 S3 egress gate, referenciado en scripts/egress-gate.sh:9 como ALLOWLIST

--- a/CHANGELOG.d/agent-se273-egress-allowlist.md
+++ b/CHANGELOG.d/agent-se273-egress-allowlist.md
@@ -1,0 +1,5 @@
+---
+version_bump: patch
+section: Fixed
+---
+- **Egress allowlist missing (S3)**: the egress-gate.sh script was merged without its default configuration file `engagements/default/egress.yaml`. This file is now committed so the gate starts with a pre-configured allowlist of essential domains instead of creating an empty one at runtime.

--- a/engagements/default/egress.yaml
+++ b/engagements/default/egress.yaml
@@ -1,0 +1,37 @@
+# egress.yaml — Egress allowlist (SE-273 S3)
+# deny-by-default. Operator edits this file to add domains.
+# Savia proposes additions via: bash scripts/egress-gate.sh propose <domain> <reason>
+domains:
+  - domain: github.com
+    protocols: [https]
+    purpose: "Code hosting, PRs"
+    added_by: operator
+  - domain: api.github.com
+    protocols: [https]
+    purpose: "GitHub API"
+    added_by: operator
+  - domain: raw.githubusercontent.com
+    protocols: [https]
+    purpose: "Raw content"
+    added_by: operator
+  - domain: registry.npmjs.org
+    protocols: [https]
+    purpose: "npm registry"
+    added_by: operator
+  - domain: pypi.org
+    protocols: [https]
+    purpose: "PyPI"
+    added_by: operator
+  - domain: dev.azure.com
+    protocols: [https]
+    purpose: "Azure DevOps"
+    added_by: operator
+  - domain: localhost
+    protocols: [http, https]
+    purpose: "Local dev"
+    added_by: operator
+  - domain: 127.0.0.1
+    protocols: [http, https]
+    purpose: "Loopback"
+    added_by: operator
+isolated_by_default: false


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Cuando se activa el control de egreso del workspace (el nuevo mecanismo que decide a qué sitios web pueden conectarse los agentes), ahora incluye una lista inicial de destinos permitidos. Antes este control se activaba sin lista, creando una configuración vacía que podía completarse sin que la operadora lo supiera. Con este cambio, el control arranca con los destinos esenciales ya declarados: GitHub, Azure DevOps, los registros de paquetes npm y Python, y el entorno local de desarrollo. Cualquier otro destino queda bloqueado hasta que la operadora lo autorice explícitamente editando el archivo.

La operadora gana visibilidad y control: el archivo de configuración existe desde el inicio y es ella quien decide qué añadir o quitar, no el sistema en automático.

Riesgo: ninguno. Solo añade un archivo de configuración inicial. Si no se incluye, el comportamiento es el mismo que ya está desplegado (el gate crea el archivo en caliente al primer uso).

No requiere activación ni desactivación. El archivo se edita directamente.

Scope-trace: skip — egress.yaml es parte del SE-273 S3 egress gate, referenciado en scripts/egress-gate.sh:9 como ALLOWLIST
## Summary
feat(se273): add default egress allowlist
### Changes
- 96e62cc9 chore: add scope-trace override for egress.yaml
- 6488e1de feat(se273): add default egress allowlist
### Stats
3 files changed across 2 commits.
## Test plan
- [x] CI passed  - [x] Signed
