### PR TITLE
feat(se294): multi-provider proxy + shared contracts

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=56edbe2fe1fd855aecea34b5636bb4d5968a7f8fcf81e7057188ca728331622e
-timestamp=2026-08-02T21:03:27Z
-branch=savia/se292-se293-rebase
-head_commit=d51d93eb
-signature=8033b6ea9b47b41836b373683d0e4be2ba2844cdb2e89b8f26d86a4f13221afa
+diff_hash=b3c8ad87b2b7d102a6fc8731a83edb3a198f74e230c1859c827f991f2e88315c
+timestamp=2026-08-03T05:04:26Z
+branch=savia/se294-rebase
+head_commit=fc30cb8a
+signature=f1eda747efebb9df2f9ab2fa79f6956a5dbc1e3c9a8fd4371feab9afa3b244e8

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=b3c8ad87b2b7d102a6fc8731a83edb3a198f74e230c1859c827f991f2e88315c
-timestamp=2026-08-03T05:04:26Z
+diff_hash=8ed8a1c167f9f2ea6049dbe2ca0438ac0beef1759bda23819da8433b51d7fba0
+timestamp=2026-08-03T05:27:01Z
 branch=savia/se294-rebase
-head_commit=fc30cb8a
-signature=f1eda747efebb9df2f9ab2fa79f6956a5dbc1e3c9a8fd4371feab9afa3b244e8
+head_commit=be729daf
+signature=a70d1fa416a5a228fc147e30dcb1458ad5a9c5100172adcbad2190c430f50fb5

--- a/CHANGELOG.d/se294-multi-provider-contracts.md
+++ b/CHANGELOG.d/se294-multi-provider-contracts.md
@@ -1,0 +1,9 @@
+---
+version_bump: minor
+section: Added
+---
+
+### Added
+
+- SE-294: Multi-provider proxy + shared contracts. ProviderRouter with health check and failover (DeepSeek, Anthropic). Contracts package with shared TypeScript types.
+

--- a/projects/savia-vaults/packages/contracts/package.json
+++ b/projects/savia-vaults/packages/contracts/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@savia/contracts",
+  "version": "0.1.0",
+  "description": "Shared TypeScript types for SaviaVaults — contracts between server, MCP clients, and A2A consumers",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./entities": {
+      "types": "./dist/entities/index.d.ts",
+      "import": "./dist/entities/index.js"
+    },
+    "./api": {
+      "types": "./dist/api/index.d.ts",
+      "import": "./dist/api/index.js"
+    },
+    "./providers": {
+      "types": "./dist/providers/index.d.ts",
+      "import": "./dist/providers/index.js"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/projects/savia-vaults/packages/contracts/src/api/index.ts
+++ b/projects/savia-vaults/packages/contracts/src/api/index.ts
@@ -1,0 +1,4 @@
+export { type VaultReadParams, type VaultReadResult } from './read.js';
+export { type VaultWriteParams, type VaultWriteResult } from './write.js';
+export { type VaultSearchParams, type VaultSearchResultItem } from './search.js';
+export { type VaultListParams, type VaultListItem } from './list.js';

--- a/projects/savia-vaults/packages/contracts/src/api/list.ts
+++ b/projects/savia-vaults/packages/contracts/src/api/list.ts
@@ -1,0 +1,9 @@
+export interface VaultListParams {
+  vault?: string;
+  path?: string;
+}
+
+export interface VaultListItem {
+  path: string;
+  type: 'file' | 'directory';
+}

--- a/projects/savia-vaults/packages/contracts/src/api/read.ts
+++ b/projects/savia-vaults/packages/contracts/src/api/read.ts
@@ -1,0 +1,12 @@
+export interface VaultReadParams {
+  vault?: string;
+  path: string;
+}
+
+export interface VaultReadResult {
+  path: string;
+  name: string;
+  frontmatter: Record<string, unknown>;
+  tags: string[];
+  content: string;
+}

--- a/projects/savia-vaults/packages/contracts/src/api/search.ts
+++ b/projects/savia-vaults/packages/contracts/src/api/search.ts
@@ -1,0 +1,13 @@
+export interface VaultSearchParams {
+  vault?: string;
+  query: string;
+  maxResults?: number;
+  pathPrefix?: string;
+}
+
+export interface VaultSearchResultItem {
+  path: string;
+  score: number;
+  snippet: string;
+  tags: string[];
+}

--- a/projects/savia-vaults/packages/contracts/src/api/write.ts
+++ b/projects/savia-vaults/packages/contracts/src/api/write.ts
@@ -1,0 +1,14 @@
+export interface VaultWriteParams {
+  vault?: string;
+  path: string;
+  content: string;
+  message?: string;
+}
+
+export interface VaultWriteResult {
+  vault: string;
+  path: string;
+  contentHash: string;
+  signature: string;
+  timestamp: string;
+}

--- a/projects/savia-vaults/packages/contracts/src/entities/config.ts
+++ b/projects/savia-vaults/packages/contracts/src/entities/config.ts
@@ -1,0 +1,17 @@
+export interface VaultConfig {
+  name: string;
+  path: string;
+  allowedExtensions: string[];
+  deniedPaths: string[];
+  maxDepth: number;
+  maxFileSize: number;
+  schemaDir?: string;
+}
+
+export interface DomeConfig {
+  name: string;
+  path: string;
+  description?: string;
+  confidentiality: 'N1' | 'N2' | 'N3' | 'N4a' | 'N4b';
+  schemaDir?: string;
+}

--- a/projects/savia-vaults/packages/contracts/src/entities/entity.ts
+++ b/projects/savia-vaults/packages/contracts/src/entities/entity.ts
@@ -1,0 +1,27 @@
+export type EntityType =
+  | 'document' | 'hypothesis' | 'protocol' | 'decision'
+  | 'system' | 'person' | 'project' | 'experiment'
+  | 'result' | 'event' | 'organization';
+
+export interface Entity {
+  type: EntityType;
+  id: string;
+  label: string;
+  count: number;
+  properties: Record<string, EntityProperty>;
+}
+
+export interface EntityProperty {
+  populated: number;
+  total: number;
+  coverage: number;
+}
+
+export interface IntrospectResult {
+  vault: string;
+  entityTypes: Entity[];
+  totalDocuments: number;
+  totalEntities: number;
+  schemaTypes: string[];
+  lastIndexed: string;
+}

--- a/projects/savia-vaults/packages/contracts/src/entities/index.ts
+++ b/projects/savia-vaults/packages/contracts/src/entities/index.ts
@@ -1,0 +1,4 @@
+export { type VaultConfig, type DomeConfig } from './config.js';
+export { type Note, type Frontmatter, type Receipt, type CommitEntry } from './note.js';
+export { type Entity, type EntityType, type EntityProperty, type IntrospectResult } from './entity.js';
+export { type SearchQuery, type SearchResult, type VaultStats, type HealthReport } from './search.js';

--- a/projects/savia-vaults/packages/contracts/src/entities/note.ts
+++ b/projects/savia-vaults/packages/contracts/src/entities/note.ts
@@ -1,0 +1,31 @@
+export interface Frontmatter {
+  title?: string;
+  tags?: string[];
+  created?: string;
+  modified?: string;
+  [key: string]: unknown;
+}
+
+export interface Note {
+  path: string;
+  name: string;
+  frontmatter: Frontmatter;
+  tags: string[];
+  content: string;
+  created: string;
+  modified: string;
+}
+
+export interface Receipt {
+  vault: string;
+  path: string;
+  contentHash: string;
+  signature: string;
+  timestamp: string;
+}
+
+export interface CommitEntry {
+  hash: string;
+  date: string;
+  message: string;
+}

--- a/projects/savia-vaults/packages/contracts/src/entities/search.ts
+++ b/projects/savia-vaults/packages/contracts/src/entities/search.ts
@@ -1,0 +1,27 @@
+export interface SearchQuery {
+  query: string;
+  maxResults?: number;
+  pathPrefix?: string;
+}
+
+export interface SearchResult {
+  path: string;
+  score: number;
+  snippet: string;
+  tags: string[];
+}
+
+export interface VaultStats {
+  name: string;
+  noteCount: number;
+  totalSize: number;
+  commitCount?: number;
+}
+
+export interface HealthReport {
+  computed: string;
+  coverage: Record<string, { populated: number; total: number; coverage: number }>;
+  provenance: { assertionsWithSource: number };
+  health: { expiredAssertions: number; openConflicts: number; orphanEntities: number; pendingRelations: number };
+  freshness: { avgDaysSinceAssertion: number };
+}

--- a/projects/savia-vaults/packages/contracts/src/index.ts
+++ b/projects/savia-vaults/packages/contracts/src/index.ts
@@ -1,0 +1,3 @@
+export * from './entities/index.js';
+export * from './api/index.js';
+export * from './providers/index.js';

--- a/projects/savia-vaults/packages/contracts/src/providers/index.ts
+++ b/projects/savia-vaults/packages/contracts/src/providers/index.ts
@@ -1,0 +1,2 @@
+export { type ProviderTier, type LlmRequest, type LlmResponse, type LlmProvider } from './types.js';
+export { type ProviderRouterConfig, type ProviderRouter } from './router.js';

--- a/projects/savia-vaults/packages/contracts/src/providers/router.ts
+++ b/projects/savia-vaults/packages/contracts/src/providers/router.ts
@@ -1,0 +1,13 @@
+import type { LlmProvider, LlmRequest, LlmResponse, ProviderTier } from './types.js';
+
+export interface ProviderRouterConfig {
+  providers: LlmProvider[];
+  fallbackOrder: ProviderTier[];
+  healthCheckIntervalMs: number;
+}
+
+export interface ProviderRouter {
+  complete(request: LlmRequest): Promise<LlmResponse>;
+  healthCheck(): Promise<Record<string, boolean>>;
+  activeProvider(tier: ProviderTier): string;
+}

--- a/projects/savia-vaults/packages/contracts/src/providers/types.ts
+++ b/projects/savia-vaults/packages/contracts/src/providers/types.ts
@@ -1,0 +1,23 @@
+export type ProviderTier = 'heavy' | 'mid' | 'fast';
+
+export interface LlmRequest {
+  tier: ProviderTier;
+  messages: { role: 'system' | 'user' | 'assistant'; content: string }[];
+  temperature?: number;
+  maxTokens?: number;
+}
+
+export interface LlmResponse {
+  content: string;
+  provider: string;
+  tier: ProviderTier;
+  tokensUsed: number;
+  latencyMs: number;
+}
+
+export interface LlmProvider {
+  readonly name: string;
+  readonly tiers: ProviderTier[];
+  complete(request: LlmRequest): Promise<LlmResponse>;
+  healthCheck(): Promise<boolean>;
+}

--- a/projects/savia-vaults/packages/contracts/tsconfig.json
+++ b/projects/savia-vaults/packages/contracts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/projects/savia-vaults/specs/SE-294-multi-provider-contracts.spec.md
+++ b/projects/savia-vaults/specs/SE-294-multi-provider-contracts.spec.md
@@ -1,0 +1,346 @@
+# Spec: SE-294 — Multi-Provider Proxy + Shared Contracts
+
+**Task ID:**        SE-294
+**PBI padre:**      SE-294 — Multi-provider integration (ADR-012)
+**Sprint:**         2026-08
+**Fecha creacion:** 2026-08-02
+**Creado por:**     Savia (arquitectura)
+
+**Developer Type:** agent-single
+**Asignado a:**     typescript-developer
+**Estado:**         Pendiente
+
+**Effort Estimation (Dual Model):**
+
+| Dimension | Value |
+|---|---|
+| Agent effort | 45 min |
+| Human effort | 2 h |
+| Review effort | 15 min |
+| Context risk | low |
+| Agent-capable | yes |
+| Fallback | Si agente falla: humano necesita 1h desde cero |
+
+---
+
+## 1. Contexto y Objetivo
+
+Savia opera hoy con DeepSeek v4-pro como unico proveedor de inferencia.
+ADR-012 establece la estrategia multi-proveedor (DeepSeek, Claude, Qwen)
+con failover entre ellos. Ademas, el analisis de ai-form-creator revelo
+dos patrones adicionales que Savia deberia adoptar:
+
+1. **Shared contracts package**: Tipos TypeScript compartidos entre SaviaVaults
+   y sus consumidores (MCP clients, A2A clients, frontends). Evita duplicacion
+   de tipos y divergencia entre cliente y servidor.
+2. **Multi-provider proxy**: Capa de abstraccion sobre providers LLM que
+   enruta peticiones segun tier (heavy/mid/fast) con failover entre proveedores.
+
+Objetivo: SaviaVaults expone un contrato tipado, y Savia puede usar cualquier
+proveedor LLM sin cambiar codigo.
+
+---
+
+## 2. Contrato Tecnico
+
+### 2.1 Contracts Package
+
+```typescript
+// packages/contracts/src/index.ts — Re-exporta todo
+
+// Entidades del knowledge layer
+export { Note, NoteFrontmatter, NoteWithContent } from './entities/note.js';
+export { Entity, EntityType } from './entities/entity.js';
+export { SearchResult, SearchQuery } from './entities/search.js';
+export { VaultConfig, DomeConfig } from './entities/config.js';
+
+// Contratos de API (MCP tools params/returns)
+export { VaultReadParams, VaultReadResult } from './api/read.js';
+export { VaultWriteParams, VaultWriteResult } from './api/write.js';
+export { VaultSearchParams, VaultSearchResult } from './api/search.js';
+export { VaultListParams, VaultListResult } from './api/list.js';
+
+// Contratos de provider LLM
+export { LlmProvider, LlmRequest, LlmResponse, ProviderTier } from './providers/types.js';
+export { ProviderRouter, ProviderRouterConfig } from './providers/router.js';
+```
+
+### 2.2 Proveedor Multi-Modelo
+
+```typescript
+// src/providers/types.ts
+export type ProviderTier = 'heavy' | 'mid' | 'fast';
+
+export interface LlmRequest {
+  tier: ProviderTier;
+  messages: { role: 'system' | 'user' | 'assistant'; content: string }[];
+  temperature?: number;
+  maxTokens?: number;
+}
+
+export interface LlmResponse {
+  content: string;
+  provider: string;
+  tier: ProviderTier;
+  tokensUsed: number;
+  latencyMs: number;
+}
+
+export interface LlmProvider {
+  readonly name: string;
+  readonly tiers: ProviderTier[];
+  complete(request: LlmRequest): Promise<LlmResponse>;
+  healthCheck(): Promise<boolean>;
+}
+```
+
+### 2.3 Provider Router con Failover
+
+```typescript
+// src/providers/router.ts
+export class ProviderRouter {
+  constructor(config: ProviderRouterConfig);
+
+  // Enruta a provider disponible segun tier, con fallback entre providers
+  async complete(request: LlmRequest): Promise<LlmResponse>;
+
+  // Chequea salud de todos los providers
+  async healthCheck(): Promise<Record<string, boolean>>;
+
+  // Proveedor actualmente activo por tier
+  activeProvider(tier: ProviderTier): string;
+}
+
+export interface ProviderRouterConfig {
+  providers: LlmProvider[];
+  fallbackOrder: ProviderTier[]; // ['heavy', 'mid', 'fast']
+  healthCheckIntervalMs: number;
+}
+```
+
+### 2.4 Implementaciones concretas
+
+```typescript
+// src/providers/deepseek.ts
+export class DeepSeekProvider implements LlmProvider {
+  readonly name = 'deepseek';
+  readonly tiers: ProviderTier[] = ['heavy', 'mid', 'fast'];
+  // Usa OPENROUTER_API_KEY o DEEPSEEK_API_KEY
+}
+
+// src/providers/anthropic.ts
+export class AnthropicProvider implements LlmProvider {
+  readonly name = 'claude';
+  readonly tiers: ProviderTier[] = ['heavy', 'mid'];
+  // Usa ANTHROPIC_API_KEY
+}
+```
+
+---
+
+## 3. Reglas de Negocio
+
+### RB-001: Failover
+Si un provider falla (timeout >30s, HTTP 5xx, rate-limit 429), el router
+intenta el siguiente provider en `fallbackOrder`. Si todos fallan, devuelve
+error `ALL_PROVIDERS_DOWN`.
+
+### RB-002: Health Check
+El router ejecuta health check cada `healthCheckIntervalMs` (default 30s).
+Un provider unhealthy se excluye del routing hasta que recupere.
+
+### RB-003: Tier Mapping
+- `heavy` → deepseek-v4-pro, claude-opus-4
+- `mid` → deepseek-v4-pro, claude-sonnet-4, qwen-max
+- `fast` → deepseek-v4-pro, claude-haiku, qwen-turbo
+
+### RB-004: Contracts as Source of Truth
+Los tipos del contracts package son la fuente de verdad. SaviaVaults y sus
+consumidores importan de `@savia/contracts`. Cualquier cambio en contratos
+rompe build de consumidores → integridad garantizada.
+
+### RB-005: Zero Vendor Lock-in
+El codigo de Savia NUNCA referencia un provider concreto. Solo usa
+`ProviderRouter.complete(request)` con `request.tier`.
+
+---
+
+## 4. Constraints and Limits
+
+- Contracts package: zero runtime dependencies. Solo tipos TypeScript.
+- Provider implementations: cada provider en su propio fichero.
+- Secrets via variables de entorno, nunca hardcodeados.
+- ProviderRouter: max 3 retries por request, timeout global 120s.
+- Health check: no puede exceder 5s por provider.
+
+---
+
+## 5. Test Scenarios
+
+### TC-001: Router enruta a provider disponible
+```
+GIVEN providers deepseek (healthy) y claude (healthy)
+WHEN router.complete({ tier: 'heavy', messages: [...] })
+THEN response.provider es 'deepseek' o 'claude'
+AND response.tier es 'heavy'
+AND response.content no esta vacio
+```
+
+### TC-002: Failover cuando primer provider falla
+```
+GIVEN deepseek unhealthy, claude healthy
+WHEN router.complete({ tier: 'heavy', messages: [...] })
+THEN no usa deepseek
+AND response.provider es 'claude'
+```
+
+### TC-003: ALL_PROVIDERS_DOWN cuando todos fallan
+```
+GIVEN todos los providers unhealthy
+WHEN router.complete({ tier: 'heavy', messages: [...] })
+THEN lanza error con codigo ALL_PROVIDERS_DOWN
+```
+
+### TC-004: Contracts exportan todos los tipos necesarios
+```
+GIVEN packages/contracts compilado
+WHEN typescript-developer importa Note, SearchResult, VaultReadParams
+THEN todos los tipos estan disponibles y son correctos
+```
+
+### TC-005: Health check recupera provider caido
+```
+GIVEN deepseek unhealthy
+WHEN deepseek recupera (health check OK)
+THEN router incluye deepseek en siguiente routing
+```
+
+### TC-006: Contracts import no introduce runtime deps
+```
+GIVEN packages/contracts instalado en proyecto consumidor
+WHEN se hace build del consumidor
+THEN el bundle no incluye codigo runtime de contracts
+AND solo incluye los tipos usados
+```
+
+---
+
+## 6. Ficheros a Crear/Modificar
+
+### Crear
+
+| Fichero | Proposito |
+|---|---|
+| `projects/savia-vaults/packages/contracts/package.json` | Package config |
+| `projects/savia-vaults/packages/contracts/tsconfig.json` | TS config |
+| `projects/savia-vaults/packages/contracts/src/index.ts` | Re-exports |
+| `projects/savia-vaults/packages/contracts/src/entities/note.ts` | Note types |
+| `projects/savia-vaults/packages/contracts/src/entities/entity.ts` | Entity types |
+| `projects/savia-vaults/packages/contracts/src/entities/search.ts` | Search types |
+| `projects/savia-vaults/packages/contracts/src/entities/config.ts` | Config types |
+| `projects/savia-vaults/packages/contracts/src/api/read.ts` | Read API |
+| `projects/savia-vaults/packages/contracts/src/api/write.ts` | Write API |
+| `projects/savia-vaults/packages/contracts/src/api/search.ts` | Search API |
+| `projects/savia-vaults/packages/contracts/src/api/list.ts` | List API |
+| `projects/savia-vaults/packages/contracts/src/providers/types.ts` | Provider types |
+| `projects/savia-vaults/packages/contracts/src/providers/router.ts` | Router interface |
+| `projects/savia-vaults/src/providers/types.ts` | Provider impl types |
+| `projects/savia-vaults/src/providers/router.ts` | Router implementation |
+| `projects/savia-vaults/src/providers/deepseek.ts` | DeepSeek provider |
+| `projects/savia-vaults/src/providers/anthropic.ts` | Anthropic provider |
+| `projects/savia-vaults/src/providers/index.ts` | Barrel export |
+| `projects/savia-vaults/tests/unit/providers/router.test.ts` | Router tests |
+| `projects/savia-vaults/tests/unit/providers/deepseek.test.ts` | Provider tests |
+
+### Modificar
+
+| Fichero | Cambio |
+|---|---|
+| `projects/savia-vaults/package.json` | Referencia a contracts workspace |
+| `projects/savia-vaults/tsconfig.json` | Path alias a contracts |
+
+---
+
+## 7. Codigo de Referencia
+
+### Patron: Router Pattern (inspirado en LiteLLM)
+```typescript
+// Patron de routing con failover y health check
+// Referencia: https://github.com/BerriAI/litellm
+// Principio: abstraer N providers tras una interfaz unica
+```
+
+### Patron: Contracts Package (inspirado en ai-form-creator)
+```typescript
+// Monorepo con /packages/contracts como fuente unica de tipos
+// Referencia: https://github.com/FernandoDSanchez/ai-form-creator
+// packages/contracts/src/ tiene tipos puros, sin implementacion
+```
+
+---
+
+## 8. OpenCode Implementation Plan
+
+> **Spec classification**: `infrastructure` — new project infrastructure, no existing code to break.
+> **Required agents**: typescript-developer
+> **Prerequisites**: Node.js 22+, SaviaVaults v0.3.0 workspace
+
+### Implementation sequence
+
+1. Create `packages/contracts/` with package.json, tsconfig.json, and all type files
+2. Build contracts package, verify types export correctly
+3. Create `src/providers/` module in SaviaVaults
+4. Implement ProviderRouter with health check and failover
+5. Implement DeepSeekProvider and AnthropicProvider
+6. Write unit tests for router and providers
+7. Run `npm test` in SaviaVaults, verify all pass
+
+### Context budget
+- Contracts: 8 type-only files (~200 lines total) → 3K tokens
+- Providers: 4 implementation files (~300 lines total) → 5K tokens
+- Tests: 2 test files (~150 lines total) → 2K tokens
+- Total: ~10K tokens (within mid-tier budget)
+
+---
+
+## 9. Estado de Implementacion
+
+| Slice | Estado | Fecha | Commits |
+|---|---|---|---|
+| S1: Contracts package | Pendiente | — | — |
+| S2: Provider router | Pendiente | — | — |
+| S3: Provider implementations | Pendiente | — | — |
+| S4: Tests | Pendiente | — | — |
+
+---
+
+## 10. Checklist Pre-Entrega
+
+- [ ] Contracts package compila sin errores (tsc --noEmit)
+- [ ] Todos los tipos exportados desde index.ts
+- [ ] ProviderRouter pasa tests de failover
+- [ ] DeepSeekProvider y AnthropicProvider pasan health check test
+- [ ] 0 errores de lint
+- [ ] npm test en SaviaVaults: todos los tests existentes siguen pasando
+- [ ] Secrets nunca hardcodeados (solo env vars)
+
+---
+
+## 11. Criterios de Aceptacion
+
+- [ ] AC1: Existe `packages/contracts/` con tipos TypeScript exportables
+- [ ] AC2: `import { Note, SearchResult } from '@savia/contracts'` funciona
+- [ ] AC3: ProviderRouter enruta peticiones a provider healthy
+- [ ] AC4: Failover funciona: si provider A falla, usa provider B
+- [ ] AC5: ALL_PROVIDERS_DOWN cuando ningun provider responde
+- [ ] AC6: Health check recupera providers caidos automaticamente
+- [ ] AC7: Contracts package no introduce runtime dependencies
+
+---
+
+## 12. Iteration & Convergence Criteria
+
+- S1: Contracts compila, `npm pack` produce .tgz instalable
+- S2: Router pasa TC-001, TC-002, TC-003
+- S3: Al menos 2 providers implementados (DeepSeek, Anthropic)
+- S4: 80%+ cobertura en providers module

--- a/projects/savia-vaults/src/providers/anthropic.ts
+++ b/projects/savia-vaults/src/providers/anthropic.ts
@@ -1,0 +1,90 @@
+import type { LlmProvider, LlmRequest, LlmResponse, ProviderTier } from './types.js';
+
+export class AnthropicProvider implements LlmProvider {
+  readonly name = 'claude';
+  readonly tiers: ProviderTier[] = ['heavy', 'mid'];
+
+  private baseUrl: string;
+  private apiKey: string;
+
+  constructor(config?: { baseUrl?: string; apiKey?: string }) {
+    this.baseUrl = config?.baseUrl ?? process.env.ANTHROPIC_BASE_URL ?? 'https://api.anthropic.com';
+    this.apiKey = config?.apiKey ?? process.env.ANTHROPIC_API_KEY ?? '';
+  }
+
+  async complete(request: LlmRequest): Promise<LlmResponse> {
+    const start = Date.now();
+    const model = this.mapTierToModel(request.tier);
+
+    const systemMsg = request.messages.find((m) => m.role === 'system')?.content;
+    const userMsgs = request.messages
+      .filter((m) => m.role !== 'system')
+      .map((m) => ({ role: m.role, content: m.content }));
+
+    const response = await fetch(`${this.baseUrl}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model,
+        system: systemMsg,
+        messages: userMsgs,
+        max_tokens: request.maxTokens ?? 4096,
+      }),
+    });
+
+    if (response.status === 429) {
+      throw new Error('Anthropic rate limited');
+    }
+    if (!response.ok) {
+      throw new Error(`Anthropic error ${response.status}: ${await response.text()}`);
+    }
+
+    const data = (await response.json()) as {
+      content: { type: string; text: string }[];
+      usage: { input_tokens: number; output_tokens: number };
+    };
+
+    return {
+      content: data.content[0].text,
+      provider: this.name,
+      tier: request.tier,
+      tokensUsed: data.usage.input_tokens + data.usage.output_tokens,
+      latencyMs: Date.now() - start,
+    };
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 5_000);
+
+      const response = await fetch(`${this.baseUrl}/v1/messages`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': this.apiKey,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model: 'claude-3-haiku-20240307',
+          max_tokens: 1,
+          messages: [{ role: 'user', content: '.' }],
+        }),
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  private mapTierToModel(tier: ProviderTier): string {
+    const envKey = `ANTHROPIC_MODEL_${tier.toUpperCase()}`;
+    return process.env[envKey] ?? 'claude-sonnet-4-20250514';
+  }
+}

--- a/projects/savia-vaults/src/providers/deepseek.ts
+++ b/projects/savia-vaults/src/providers/deepseek.ts
@@ -1,0 +1,74 @@
+import type { LlmProvider, LlmRequest, LlmResponse, ProviderTier } from './types.js';
+
+export class DeepSeekProvider implements LlmProvider {
+  readonly name = 'deepseek';
+  readonly tiers: ProviderTier[] = ['heavy', 'mid', 'fast'];
+
+  private baseUrl: string;
+  private apiKey: string;
+
+  constructor(config?: { baseUrl?: string; apiKey?: string }) {
+    this.baseUrl = config?.baseUrl ?? process.env.DEEPSEEK_BASE_URL ?? 'https://api.deepseek.com';
+    this.apiKey = config?.apiKey ?? process.env.DEEPSEEK_API_KEY ?? process.env.OPENROUTER_API_KEY ?? '';
+  }
+
+  async complete(request: LlmRequest): Promise<LlmResponse> {
+    const start = Date.now();
+    const model = this.mapTierToModel(request.tier);
+
+    const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: request.messages,
+        temperature: request.temperature ?? 0.7,
+        max_tokens: request.maxTokens ?? 4096,
+      }),
+    });
+
+    if (response.status === 429) {
+      throw new Error('DeepSeek rate limited');
+    }
+    if (!response.ok) {
+      throw new Error(`DeepSeek error ${response.status}: ${await response.text()}`);
+    }
+
+    const data = (await response.json()) as {
+      choices: { message: { content: string } }[];
+      usage: { total_tokens: number };
+    };
+
+    return {
+      content: data.choices[0].message.content,
+      provider: this.name,
+      tier: request.tier,
+      tokensUsed: data.usage.total_tokens,
+      latencyMs: Date.now() - start,
+    };
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 5_000);
+
+      const response = await fetch(`${this.baseUrl}/v1/models`, {
+        headers: { Authorization: `Bearer ${this.apiKey}` },
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  private mapTierToModel(tier: ProviderTier): string {
+    const envKey = `DEEPSEEK_MODEL_${tier.toUpperCase()}`;
+    return process.env[envKey] ?? 'deepseek-chat';
+  }
+}

--- a/projects/savia-vaults/src/providers/index.ts
+++ b/projects/savia-vaults/src/providers/index.ts
@@ -1,0 +1,11 @@
+export { ProviderRouter } from './router.js';
+export { DeepSeekProvider } from './deepseek.js';
+export { AnthropicProvider } from './anthropic.js';
+export { ProviderError, type ProviderHealth } from './types.js';
+export type {
+  LlmProvider,
+  LlmRequest,
+  LlmResponse,
+  ProviderTier,
+  ProviderRouterConfig,
+} from './types.js';

--- a/projects/savia-vaults/src/providers/router.ts
+++ b/projects/savia-vaults/src/providers/router.ts
@@ -1,0 +1,103 @@
+import type { LlmProvider, LlmRequest, LlmResponse, ProviderTier } from './types.js';
+import { ProviderError } from './types.js';
+import type { ProviderRouterConfig, ProviderHealth } from './types.js';
+
+export class ProviderRouter {
+  private providers: LlmProvider[];
+  private fallbackOrder: ProviderTier[];
+  private health: Map<string, ProviderHealth> = new Map();
+  private healthTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private config: ProviderRouterConfig) {
+    this.providers = config.providers;
+    this.fallbackOrder = config.fallbackOrder;
+    this.startHealthChecks();
+  }
+
+  async complete(request: LlmRequest): Promise<LlmResponse> {
+    const candidates = this.getCandidates(request.tier);
+    if (candidates.length === 0) {
+      throw new ProviderError(`No healthy providers for tier ${request.tier}`, 'ALL_PROVIDERS_DOWN');
+    }
+
+    let lastError: Error | null = null;
+    for (const provider of candidates) {
+      try {
+        const result = await this.withTimeout(
+          provider.complete(request),
+          30_000,
+          `Provider ${provider.name} timed out`,
+        );
+        return result;
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+        this.markUnhealthy(provider.name);
+      }
+    }
+
+    throw new ProviderError(
+      `All providers failed for tier ${request.tier}: ${lastError?.message}`,
+      'ALL_PROVIDERS_DOWN',
+    );
+  }
+
+  async healthCheck(): Promise<Record<string, boolean>> {
+    const results: Record<string, boolean> = {};
+    await Promise.all(
+      this.providers.map(async (p) => {
+        const start = Date.now();
+        try {
+          const healthy = await this.withTimeout(p.healthCheck(), 5_000, '');
+          const latency = Date.now() - start;
+          this.health.set(p.name, { name: p.name, healthy, lastCheck: Date.now(), latencyMs: latency });
+          results[p.name] = healthy;
+        } catch {
+          this.health.set(p.name, { name: p.name, healthy: false, lastCheck: Date.now(), latencyMs: -1 });
+          results[p.name] = false;
+        }
+      }),
+    );
+    return results;
+  }
+
+  activeProvider(tier: ProviderTier): string {
+    const candidates = this.getCandidates(tier);
+    return candidates[0]?.name ?? 'none';
+  }
+
+  stop(): void {
+    if (this.healthTimer) {
+      clearInterval(this.healthTimer);
+      this.healthTimer = null;
+    }
+  }
+
+  private getCandidates(tier: ProviderTier): LlmProvider[] {
+    return this.providers.filter(
+      (p) => p.tiers.includes(tier) && this.isHealthy(p.name),
+    );
+  }
+
+  private isHealthy(name: string): boolean {
+    const h = this.health.get(name);
+    return h ? h.healthy : true;
+  }
+
+  private markUnhealthy(name: string): void {
+    this.health.set(name, { name, healthy: false, lastCheck: Date.now(), latencyMs: -1 });
+  }
+
+  private startHealthChecks(): void {
+    this.healthCheck().catch(() => {});
+    this.healthTimer = setInterval(() => {
+      this.healthCheck().catch(() => {});
+    }, this.config.healthCheckIntervalMs);
+  }
+
+  private async withTimeout<T>(promise: Promise<T>, ms: number, msg: string): Promise<T> {
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new ProviderError(msg, 'PROVIDER_TIMEOUT')), ms),
+    );
+    return Promise.race([promise, timeout]);
+  }
+}

--- a/projects/savia-vaults/src/providers/types.ts
+++ b/projects/savia-vaults/src/providers/types.ts
@@ -1,0 +1,47 @@
+export type ProviderTier = 'heavy' | 'mid' | 'fast';
+
+export interface LlmRequest {
+  tier: ProviderTier;
+  messages: { role: 'system' | 'user' | 'assistant'; content: string }[];
+  temperature?: number;
+  maxTokens?: number;
+}
+
+export interface LlmResponse {
+  content: string;
+  provider: string;
+  tier: ProviderTier;
+  tokensUsed: number;
+  latencyMs: number;
+}
+
+export interface LlmProvider {
+  readonly name: string;
+  readonly tiers: ProviderTier[];
+  complete(request: LlmRequest): Promise<LlmResponse>;
+  healthCheck(): Promise<boolean>;
+}
+
+export interface ProviderRouterConfig {
+  providers: LlmProvider[];
+  fallbackOrder: ProviderTier[];
+  healthCheckIntervalMs: number;
+}
+
+export interface ProviderHealth {
+  name: string;
+  healthy: boolean;
+  lastCheck: number;
+  latencyMs: number;
+}
+
+export class ProviderError extends Error {
+  constructor(
+    message: string,
+    public readonly code: 'ALL_PROVIDERS_DOWN' | 'PROVIDER_TIMEOUT' | 'PROVIDER_ERROR' | 'RATE_LIMITED',
+    public readonly providerName?: string,
+  ) {
+    super(message);
+    this.name = 'ProviderError';
+  }
+}

--- a/projects/savia-vaults/tests/unit/contracts/api.test.ts
+++ b/projects/savia-vaults/tests/unit/contracts/api.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import type { VaultReadParams, VaultReadResult } from '../../../packages/contracts/src/api/read.js';
+import type { VaultWriteParams, VaultWriteResult } from '../../../packages/contracts/src/api/write.js';
+import type { VaultSearchParams, VaultSearchResultItem } from '../../../packages/contracts/src/api/search.js';
+import type { VaultListParams, VaultListItem } from '../../../packages/contracts/src/api/list.js';
+
+describe('API contracts (compile-time)', () => {
+  it('VaultReadParams and VaultReadResult compile', () => {
+    const p: VaultReadParams = { path: 'test.md' };
+    const r: VaultReadResult = { path: 't.md', name: 't', frontmatter: {}, tags: [], content: '' };
+    expect(p.path).toBe('test.md');
+    expect(r.name).toBe('t');
+  });
+
+  it('VaultWriteParams and VaultWriteResult compile', () => {
+    const p: VaultWriteParams = { path: 't.md', content: '# test' };
+    const r: VaultWriteResult = { vault: 'v', path: 't.md', contentHash: 'h', signature: 's', timestamp: 't' };
+    expect(p.content).toBe('# test');
+    expect(r.vault).toBe('v');
+  });
+
+  it('VaultSearchParams and VaultSearchResultItem compile', () => {
+    const p: VaultSearchParams = { query: 'test' };
+    const r: VaultSearchResultItem = { path: 't.md', score: 0.5, snippet: 's', tags: [] };
+    expect(p.query).toBe('test');
+    expect(r.score).toBe(0.5);
+  });
+
+  it('VaultListParams and VaultListItem compile', () => {
+    const p: VaultListParams = {};
+    const r: VaultListItem = { path: 'docs/', type: 'directory' };
+    expect(r.type).toBe('directory');
+  });
+
+  it('all API types are importable from barrel', async () => {
+    const mod = await import('../../../packages/contracts/src/api/index.js');
+    expect(mod).toBeDefined();
+  });
+});

--- a/projects/savia-vaults/tests/unit/contracts/entity.test.ts
+++ b/projects/savia-vaults/tests/unit/contracts/entity.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import type { Entity, EntityType, IntrospectResult } from '../../../packages/contracts/src/entities/entity.js';
+
+describe('Entity types (compile-time)', () => {
+  it('Entity type works', () => {
+    const e: Entity = { type: 'document', id: 'd1', label: 'Doc', count: 10, properties: { title: { populated: 10, total: 10, coverage: 100 } } };
+    expect(e.type).toBe('document');
+  });
+
+  it('EntityType union covers 11 types', () => {
+    const types: EntityType[] = ['document', 'hypothesis', 'protocol', 'decision', 'system', 'person', 'project', 'experiment', 'result', 'event', 'organization'];
+    expect(types).toHaveLength(11);
+  });
+});

--- a/projects/savia-vaults/tests/unit/contracts/note.test.ts
+++ b/projects/savia-vaults/tests/unit/contracts/note.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import type { Note, Frontmatter, Receipt, CommitEntry } from '../../../packages/contracts/src/entities/note.js';
+
+describe('Note types (compile-time)', () => {
+  it('Note type is usable', () => {
+    const note: Note = {
+      path: 'test.md', name: 'test',
+      frontmatter: { title: 'Test' }, tags: ['test'],
+      content: '# Test', created: '2026-01-01', modified: '2026-01-01',
+    };
+    expect(note.path).toBe('test.md');
+    expect(note.frontmatter.title).toBe('Test');
+  });
+
+  it('Frontmatter allows extra properties', () => {
+    const fm: Frontmatter = { title: 'Test', custom: 'value' };
+    expect(fm.custom).toBe('value');
+  });
+
+  it('Receipt has required fields', () => {
+    const r: Receipt = { vault: 'test', path: 'test.md', contentHash: 'abc', signature: 'def', timestamp: '2026-01-01' };
+    expect(r.vault).toBe('test');
+  });
+});

--- a/projects/savia-vaults/tests/unit/contracts/search.test.ts
+++ b/projects/savia-vaults/tests/unit/contracts/search.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import type { SearchResult, SearchQuery, VaultStats } from '../../../packages/contracts/src/entities/search.js';
+
+describe('Search types (compile-time)', () => {
+  it('SearchResult works', () => {
+    const r: SearchResult = { path: 't.md', score: 0.85, snippet: 's', tags: ['t'] };
+    expect(r.score).toBe(0.85);
+  });
+
+  it('SearchQuery optional fields', () => {
+    const q: SearchQuery = { query: 'test' };
+    expect(q.maxResults).toBeUndefined();
+    const withOpts: SearchQuery = { query: 'test', maxResults: 5, pathPrefix: 'docs/' };
+    expect(withOpts.maxResults).toBe(5);
+  });
+
+  it('VaultStats works', () => {
+    const s: VaultStats = { name: 'test', noteCount: 10, totalSize: 1000 };
+    expect(s.name).toBe('test');
+  });
+});

--- a/projects/savia-vaults/tests/unit/providers/anthropic.test.ts
+++ b/projects/savia-vaults/tests/unit/providers/anthropic.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AnthropicProvider } from '../../../src/providers/anthropic.js';
+
+describe('AnthropicProvider', () => {
+  let provider: AnthropicProvider;
+  beforeEach(() => {
+    global.fetch = vi.fn();
+    provider = new AnthropicProvider({ apiKey: 'test-key', baseUrl: 'http://localhost:9999' });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('name is claude', () => expect(provider.name).toBe('claude'));
+  it('has two tiers', () => expect(provider.tiers).toEqual(['heavy', 'mid']));
+  it('healthy on ok', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({ ok: true } as Response);
+    expect(await provider.healthCheck()).toBe(true);
+  });
+  it('unhealthy on error', async () => {
+    vi.mocked(global.fetch).mockRejectedValue(new Error('timeout'));
+    expect(await provider.healthCheck()).toBe(false);
+  });
+});

--- a/projects/savia-vaults/tests/unit/providers/deepseek.test.ts
+++ b/projects/savia-vaults/tests/unit/providers/deepseek.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DeepSeekProvider } from '../../../src/providers/deepseek.js';
+
+describe('DeepSeekProvider', () => {
+  let provider: DeepSeekProvider;
+  beforeEach(() => {
+    global.fetch = vi.fn();
+    provider = new DeepSeekProvider({ apiKey: 'test-key', baseUrl: 'http://localhost:9999' });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('name is deepseek', () => expect(provider.name).toBe('deepseek'));
+  it('has three tiers', () => expect(provider.tiers).toEqual(['heavy', 'mid', 'fast']));
+  it('healthy on ok response', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({ ok: true } as Response);
+    expect(await provider.healthCheck()).toBe(true);
+  });
+  it('unhealthy on error', async () => {
+    vi.mocked(global.fetch).mockRejectedValue(new Error('fail'));
+    expect(await provider.healthCheck()).toBe(false);
+  });
+  it('throws on 429', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({ status: 429, ok: false } as Response);
+    await expect(provider.complete({ tier: 'heavy', messages: [{ role: 'user', content: 'hi' }] }))
+      .rejects.toThrow('rate limited');
+  });
+});

--- a/projects/savia-vaults/tests/unit/providers/router.test.ts
+++ b/projects/savia-vaults/tests/unit/providers/router.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ProviderRouter } from '../../../src/providers/router.js';
+import { ProviderError } from '../../../src/providers/types.js';
+import type { LlmProvider, LlmRequest, LlmResponse } from '../../../src/providers/types.js';
+
+function mockProvider(name: string, tiers: string[]): LlmProvider {
+  return {
+    name,
+    tiers: tiers as ('heavy' | 'mid' | 'fast')[],
+    complete: vi.fn<[LlmRequest], Promise<LlmResponse>>(),
+    healthCheck: vi.fn<[], Promise<boolean>>(),
+  };
+}
+
+const req: LlmRequest = { tier: 'heavy', messages: [{ role: 'user', content: 'hi' }] };
+
+describe('ProviderRouter', () => {
+  let router: ProviderRouter;
+  afterEach(() => { if (router) router.stop(); });
+
+  it('routes to healthy provider', async () => {
+    const p = mockProvider('deepseek', ['heavy', 'mid', 'fast']);
+    vi.mocked(p.complete).mockResolvedValue({ content: 'ok', provider: 'deepseek', tier: 'heavy', tokensUsed: 10, latencyMs: 100 });
+    vi.mocked(p.healthCheck).mockResolvedValue(true);
+    router = new ProviderRouter({ providers: [p], fallbackOrder: ['heavy'], healthCheckIntervalMs: 60_000 });
+    const r = await router.complete(req);
+    expect(r.provider).toBe('deepseek');
+  });
+
+  it('fails over when first provider fails', async () => {
+    const a = mockProvider('a', ['heavy']);
+    const b = mockProvider('b', ['heavy']);
+    vi.mocked(a.complete).mockRejectedValue(new Error('down'));
+    vi.mocked(a.healthCheck).mockResolvedValue(true);
+    vi.mocked(b.complete).mockResolvedValue({ content: 'backup', provider: 'b', tier: 'heavy', tokensUsed: 5, latencyMs: 200 });
+    vi.mocked(b.healthCheck).mockResolvedValue(true);
+    router = new ProviderRouter({ providers: [a, b], fallbackOrder: ['heavy'], healthCheckIntervalMs: 60_000 });
+    const r = await router.complete(req);
+    expect(r.provider).toBe('b');
+  });
+
+  it('throws ALL_PROVIDERS_DOWN when all fail', async () => {
+    const p = mockProvider('a', ['heavy']);
+    vi.mocked(p.complete).mockRejectedValue(new Error('down'));
+    vi.mocked(p.healthCheck).mockResolvedValue(true);
+    router = new ProviderRouter({ providers: [p], fallbackOrder: ['heavy'], healthCheckIntervalMs: 60_000 });
+    await expect(router.complete(req)).rejects.toThrow(ProviderError);
+    await expect(router.complete(req)).rejects.toMatchObject({ code: 'ALL_PROVIDERS_DOWN' });
+  });
+
+  it('skips unhealthy providers', async () => {
+    const a = mockProvider('a', ['heavy']);
+    const b = mockProvider('b', ['heavy']);
+    vi.mocked(a.healthCheck).mockResolvedValue(false);
+    vi.mocked(b.complete).mockResolvedValue({ content: 'ok', provider: 'b', tier: 'heavy', tokensUsed: 1, latencyMs: 10 });
+    vi.mocked(b.healthCheck).mockResolvedValue(true);
+    router = new ProviderRouter({ providers: [a, b], fallbackOrder: ['heavy'], healthCheckIntervalMs: 60_000 });
+    await router.healthCheck(); // wait for initial health check
+    const r = await router.complete(req);
+    expect(r.provider).toBe('b');
+    expect(a.complete).not.toHaveBeenCalled();
+  });
+
+  it('healthCheck reports all', async () => {
+    const a = mockProvider('a', ['heavy']);
+    const b = mockProvider('b', ['heavy']);
+    vi.mocked(a.healthCheck).mockResolvedValue(true);
+    vi.mocked(b.healthCheck).mockResolvedValue(false);
+    router = new ProviderRouter({ providers: [a, b], fallbackOrder: ['heavy'], healthCheckIntervalMs: 60_000 });
+    const r = await router.healthCheck();
+    expect(r).toEqual({ a: true, b: false });
+  });
+
+  it('activeProvider returns first healthy', () => {
+    const p = mockProvider('deepseek', ['heavy']);
+    vi.mocked(p.healthCheck).mockResolvedValue(true);
+    router = new ProviderRouter({ providers: [p], fallbackOrder: ['heavy'], healthCheckIntervalMs: 60_000 });
+    expect(router.activeProvider('heavy')).toBe('deepseek');
+    expect(router.activeProvider('fast')).toBe('none');
+  });
+});


### PR DESCRIPTION
## Que hace este PR

Implementa dos capacidades nuevas inspiradas en el analisis de ai-form-creator:

**Contracts package** (packages/contracts/): 10 ficheros TypeScript con tipos compartidos entre SaviaVaults y sus consumidores. Zero dependencias runtime.

**Multi-provider proxy** (src/providers/): ProviderRouter con health check y failover. Implementaciones DeepSeek y Anthropic/Claude.

28 tests nuevos (13 contracts + 15 providers). Suite completa 175/175.

Riesgo: bajo. Codigo nuevo, no modifica comportamiento existente.