### PR TITLE
feat: add lightpanda-browser skill — headless browser for AI agents

### DIFF
--- a/.claude/skills/lightpanda-browser/DOMAIN.md
+++ b/.claude/skills/lightpanda-browser/DOMAIN.md
@@ -1,0 +1,44 @@
+# lightpanda-browser — Domain knowledge
+
+## Origin
+
+Lightpanda (33K stars GitHub) es un navegador headless escrito desde cero en Zig,
+disenado especificamente para agentes de IA y automatizacion. No es un fork de
+Chromium ni un parche de WebKit.
+
+## Por que existe esta skill
+
+Savia ya tiene `web-research` y `scrapling-fetch`. Pero ambos usan HTTP simple
+(curl/python requests) que no ejecuta JavaScript. Para SPAs, infinite scroll,
+o sitios que requieren renderizado JS, esas herramientas fallan.
+
+Lightpanda resuelve esto con `--dump markdown` que ejecuta JS completo y devuelve
+markdown. Ademas tiene MCP server y agent mode que permiten a los agentes de
+Savia interactuar con paginas web como un humano.
+
+## Arquitectura de integracion
+
+```
+Savia agent → skill lightpanda-browser
+  → ¿Lightpanda instalado?
+    SI → lightpanda fetch --dump markdown $URL
+    NO → fallback: curl + html-to-md.py
+  → output markdown → digest pipeline → KG extraction
+```
+
+## Decisiones de diseno
+
+- **Nunca bundled**: AGPL-3.0 es incompatible con MIT. Lightpanda es herramienta
+  externa opcional como Docker o git.
+- **Patron availability check**: `command -v lightpanda` antes de usarlo. Si no
+  esta, fallback silencioso. No rompe el flujo.
+- **MCP integration**: si Lightpanda MCP server esta corriendo, los agentes pueden
+  usar herramientas de navegacion directamente via MCP.
+
+## Relacion con otras skills
+
+- `web-research`: Lightpanda es el backend preferente para JS-heavy sites
+- `scrapling-fetch`: Lightpanda lo reemplaza cuando esta disponible
+- `meeting-transcript-extract`: podria usar Lightpanda para extraer transcripciones
+  de Teams Web
+- `dynamic-web-tester`: Lightpanda como backend CDP para tests web

--- a/.claude/skills/lightpanda-browser/SKILL.md
+++ b/.claude/skills/lightpanda-browser/SKILL.md
@@ -42,7 +42,6 @@ docker run -d --name lightpanda -p 127.0.0.1:9222:9222 lightpanda/browser:nightl
 ```bash
 lightpanda fetch --dump markdown --obey-robots \
   --wait-until networkidle0 \
-  --timeout 30 \
   "https://example.com"
 ```
 
@@ -71,11 +70,10 @@ lightpanda agent --no-llm  # REPL basico sin LLM
 ## Patron de integracion con Savia
 
 ```bash
-# Patron: usar si existe, fallback si no
 if command -v lightpanda &>/dev/null; then
-  lightpanda fetch --dump markdown --obey-robots --timeout 30 "$URL"
+  lightpanda fetch --dump markdown --obey-robots "$URL"
 else
-  python3 scripts/scrapling-fetch.py "$URL"  # fallback existente
+  python3 scripts/scrapling-fetch.py "$URL"
 fi
 ```
 

--- a/.claude/skills/lightpanda-browser/SKILL.md
+++ b/.claude/skills/lightpanda-browser/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: lightpanda-browser
+description: Usar cuando se necesita navegacion web headless avanzada (JS-heavy sites, SPAs, extraccion markdown de URLs, web scraping que requiere renderizado JS). Triggers: 'navega a', 'extrae contenido de', 'scrapea', 'renderiza esta pagina', 'dump markdown', 'web automation', 'headless browser'.
+maturity: experimental
+context: project
+category: tool
+priority: medium
+tags: [browser, headless, web, scraping, markdown, mcp, automation, lightpanda]
+---
+
+# lightpanda-browser
+
+Navegador headless optimizado para IA. 9x mas rapido y 16x menos RAM que Chrome.
+Escrito en Zig. AGPL-3.0 — solo como herramienta externa, nunca bundled.
+
+## Cuando usar Lightpanda vs alternativas
+
+| Escenario | Usar | Por que |
+|---|---|---|
+| SPA / React / Vue / Angular | Lightpanda | Ejecuta JS completo |
+| Infinite scroll / lazy load | Lightpanda | `--wait-selector` + `--wait-ms` |
+| HTML estatico simple | curl + regex | Mas ligero, sin dep externa |
+| PDF / captura de pantalla | Playwright | Lightpanda no renderiza graficos |
+| Formularios / login | Lightpanda agent mode | Navegacion interactiva |
+
+## Instalacion (externo, no bundled)
+
+```bash
+# Linux x86_64
+curl -L -o ~/.local/bin/lightpanda \
+  https://github.com/lightpanda-io/browser/releases/download/nightly/lightpanda-x86_64-linux
+chmod +x ~/.local/bin/lightpanda
+
+# Docker
+docker run -d --name lightpanda -p 127.0.0.1:9222:9222 lightpanda/browser:nightly
+```
+
+## Operaciones principales
+
+### 1. Dump a markdown (uso mas frecuente)
+
+```bash
+lightpanda fetch --dump markdown --obey-robots \
+  --wait-until networkidle0 \
+  --timeout 30 \
+  "https://example.com"
+```
+
+### 2. CDP server + Puppeteer/Playwright
+
+```bash
+lightpanda serve --host 127.0.0.1 --port 9222
+# Luego conectar con puppeteer.connect({ browserWSEndpoint: "ws://127.0.0.1:9222" })
+```
+
+### 3. MCP server (integracion con SaviaVaults)
+
+```bash
+lightpanda mcp --port 9223
+# Sesiones aisladas por Mcp-Session-Id header
+# Herramientas: navigate, click, type, extract, screenshot, execute
+```
+
+### 4. Agent mode (navegacion por lenguaje natural)
+
+```bash
+lightpanda agent --task "top story on news.ycombinator.com"
+lightpanda agent --no-llm  # REPL basico sin LLM
+```
+
+## Patron de integracion con Savia
+
+```bash
+# Patron: usar si existe, fallback si no
+if command -v lightpanda &>/dev/null; then
+  lightpanda fetch --dump markdown --obey-robots --timeout 30 "$URL"
+else
+  python3 scripts/scrapling-fetch.py "$URL"  # fallback existente
+fi
+```
+
+## Anti-patrones
+
+- NO usar Lightpanda para HTML estatico (curl basta)
+- NO esperar renderizado grafico (no tiene motor de renderizado)
+- NO bundear el binario (AGPL-3.0 incompatible con MIT)
+- NO usar en modo `agent` para tareas simples (el LLM añade latencia)
+- NO olvidar `--obey-robots` en produccion
+
+## Limitaciones conocidas
+
+- Beta: algunos sitios pueden fallar
+- Sin CORS implementado aun (issue #2015)
+- Sin renderizado grafico (solo headless)
+- Sin binario nativo Windows (usar WSL2)
+- Telemetry activado por defecto (desactivar con LIGHTPANDA_DISABLE_TELEMETRY=true)

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=71ea1525b5a680528043885fbb47a33ee7fe5aa3e1dfa926b3fc8f93e1360c6d
-timestamp=2026-08-03T23:05:02Z
-branch=savia/se297-kg-extraction
-head_commit=dfb4eef8
-signature=3c218c39bf0f367a83beb5941bf8d7e2816c45f50368fba1bcc5fd5f35c76dc9
+diff_hash=f5fd9fc17057121a80161dc3b5dd65b577c44fe40dad8b5bf9f7a7e101634c18
+timestamp=2026-08-04T05:06:09Z
+branch=savia/lightpanda-skill
+head_commit=c807768b
+signature=a3fc58007ac8e107887504196d5ad828ff1cf6a7ff501b91de32939f73ddf042

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=f5fd9fc17057121a80161dc3b5dd65b577c44fe40dad8b5bf9f7a7e101634c18
-timestamp=2026-08-04T05:06:09Z
+diff_hash=882bf2a437a82a1ad42d85b2c3779a643880641f5f0908bdfb0889c8202ae9d9
+timestamp=2026-08-04T08:25:55Z
 branch=savia/lightpanda-skill
-head_commit=c807768b
-signature=a3fc58007ac8e107887504196d5ad828ff1cf6a7ff501b91de32939f73ddf042
+head_commit=d3fb4b78
+signature=af2e20870830de33a87724a1f7bcd30ec30275f51e332891c7713ef24f561699

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: 75abc261165b | resources: 1325
-> 290 commands · 123 skills · 83 agents · 829 scripts
+> hash: 314ae9d186bd | resources: 1326
+> 290 commands · 124 skills · 83 agents · 829 scripts
 
 [analysis] Trace Optimize — across,distributed,optimize,rates,sampling — cmd:.claude/commands/trace-optimize.md
 [analysis] agent-activity — activity,agent,executions,recent,show — cmd:.claude/commands/agent-activity.md
@@ -800,6 +800,7 @@
 [planning] lib/mock-env — environment,library,mock,reusable,scripts — script:scripts/lib/mock-env.sh
 [planning] lib/os-detect — defaults,detect,detection,path,portable — script:scripts/lib/os-detect.sh
 [planning] lib/slm-common — common,helpers,shared,slice,subcommands — script:scripts/lib/slm-common.sh
+[planning] lightpanda-browser — avanzada,contenido,dump,extraccion,extrae — skill:.claude/skills/lightpanda-browser/SKILL.md
 [planning] llms-txt-generate — docs,full,generate,llms — script:scripts/llms-txt-generate.sh
 [planning] loop-budget-check — budget,check,loop,scripts — script:scripts/loop-budget-check.sh
 [planning] loop-run-log — append,autónomas,gestión,loop,only — script:scripts/loop-run-log.sh

--- a/.scm/categories/planning.scm
+++ b/.scm/categories/planning.scm
@@ -1,5 +1,5 @@
 # planning — Savia Capability Map (L1)
-> 559 resources
+> 560 resources
 
 - **/decide-architecture** (cmd): Clasifica una tarea como WORKFLOW (deterministica) o AGENT (loop). Bias hacia workflow per Anthropic. Sugiere plantilla inicial. Mide accuracy contra corpus curado de 20 tareas.
 - **_template** (skill): TEMPLATE — copia este directorio para crear una skill nueva. NO se carga en runtime.
@@ -287,6 +287,7 @@
 - **lib/mock-env** (script): mock-env.sh — Reusable mock environment library for pm-workspace scripts
 - **lib/os-detect** (script): scripts/lib/os-detect.sh — Portable OS detection and path defaults
 - **lib/slm-common** (script): slm-common.sh — Shared helpers for SLM subcommands (SE-049 Slice 1).
+- **lightpanda-browser** (skill): Usar cuando se necesita navegacion web headless avanzada (JS-heavy sites, SPAs, extraccion markdown de URLs, web scraping que requiere renderizado JS). Triggers: 'navega a', 'extrae contenido de', 'scrapea', 'renderiza esta pagina', 'dump m
 - **llms-txt-generate** (script): llms-txt-generate.sh — Genera docs/llms.txt y docs/llms-full.txt (SE-269 S5)
 - **loop-budget-check** (script): scripts/loop-budget-check.sh
 - **loop-run-log** (script): loop-run-log.sh — CLI para gestión del run-log append-only de skills autónomas

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "bdfb73a6c7b8",
-  "total": 1325,
+  "hash": "172d097ef773",
+  "total": 1326,
   "resources": [
     {
       "category": "analysis",
@@ -10528,6 +10528,20 @@
       "kind": "script",
       "path": "scripts/lib/slm-common.sh",
       "description": "slm-common.sh — Shared helpers for SLM subcommands (SE-049 Slice 1)."
+    },
+    {
+      "category": "planning",
+      "name": "lightpanda-browser",
+      "intents": [
+        "avanzada",
+        "contenido",
+        "dump",
+        "extraccion",
+        "extrae"
+      ],
+      "kind": "skill",
+      "path": ".claude/skills/lightpanda-browser/SKILL.md",
+      "description": "Usar cuando se necesita navegacion web headless avanzada (JS-heavy sites, SPAs, extraccion markdown de URLs, web scraping que requiere renderizado JS). Triggers: 'navega a', 'extrae contenido de', 'scrapea', 'renderiza esta pagina', 'dump m"
     },
     {
       "category": "planning",

--- a/CHANGELOG.d/lightpanda-browser-skill.md
+++ b/CHANGELOG.d/lightpanda-browser-skill.md
@@ -1,0 +1,9 @@
+---
+version_bump: minor
+section: Added
+---
+
+### Added
+
+- lightpanda-browser skill: headless browser for AI agents (33K stars, Zig, 9x faster than Chrome). Markdown dump, MCP server, agent mode, CDP compatible. External optional tool (AGPL-3.0, never bundled).
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Identidad del humano al volante + memoria auto persistida fuera del repo.
 
 ## Estructura
 
-`.claude/{agents(83), commands(566), profiles, hooks(106/110reg), rules/{domain,languages}, skills(122), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
+`.claude/{agents(83), commands(566), profiles, hooks(106/110reg), rules/{domain,languages}, skills(123), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
 
 ## Reglas Críticas (Rules 1-8, inline)
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -72,6 +72,7 @@ To use a skill: read `<path>` and follow its instructions.
 | iac-security-scanner | `.opencode/skills/iac-security-scanner/SKILL.md` | Usar cuando se escanea IaC (Terraform, Bicep, Dockerfile, docker-compose) con Trivy config para d... |
 | knowledge-graph | `.opencode/skills/knowledge-graph/SKILL.md` | Usar cuando se construye o consulta el grafo de conocimiento de entidades del proyecto. |
 | legal-compliance | `.opencode/skills/legal-compliance/SKILL.md` | Usar cuando se audita compliance legal contra legislación española consolidada. |
+| lightpanda-browser | `.opencode/skills/lightpanda-browser/SKILL.md` | Usar cuando se necesita navegacion web headless avanzada (JS-heavy sites, SPAs, extraccion markdo... |
 | managed-content | `.opencode/skills/managed-content/SKILL.md` | Usar cuando se regeneran secciones auto-generadas en documentos con marcadores de seguridad. |
 | meeting-transcript-extract | `.opencode/skills/meeting-transcript-extract/SKILL.md` | Usar cuando se necesita extraer la transcripción de una reunión Teams desde el browser. |
 | memvid-backup | `.opencode/skills/memvid-backup/SKILL.md` | Usar cuando se crea un backup portable de la memoria externa de Savia. |

--- a/docs/RESOLVER.md
+++ b/docs/RESOLVER.md
@@ -46,7 +46,7 @@
 
 <!-- AUTO_BEGIN — do not edit; regenerate via scripts/resolver-md-generate.sh -->
 
-### Skills (122)
+### Skills (123)
 
 | Intent (skill) | Target | Cuándo usar |
 |---|---|---|

--- a/docs/RESOLVER.md
+++ b/docs/RESOLVER.md
@@ -105,6 +105,7 @@
 | `iac-security-scanner` | skill:iac-security-scanner | Usar cuando se escanea IaC (Terraform, Bicep, Dockerfile, docker-compose) con Trivy con... |
 | `knowledge-graph` | skill:knowledge-graph | Usar cuando se construye o consulta el grafo de conocimiento de entidades del proyecto. |
 | `legal-compliance` | skill:legal-compliance | Usar cuando se audita compliance legal contra legislación española consolidada. |
+| `lightpanda-browser` | skill:lightpanda-browser | Usar cuando se necesita navegacion web headless avanzada (JS-heavy sites, SPAs, extracc... |
 | `managed-content` | skill:managed-content | Usar cuando se regeneran secciones auto-generadas en documentos con marcadores de segur... |
 | `meeting-transcript-extract` | skill:meeting-transcript-extract | Usar cuando se necesita extraer la transcripción de una reunión Teams desde el browser. |
 | `memvid-backup` | skill:memvid-backup | Usar cuando se crea un backup portable de la memoria externa de Savia. |


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este cambio anade una skill que documenta como usar Lightpanda, un navegador headless disenado para agentes de IA. Lightpanda es 9 veces mas rapido y usa 16 veces menos memoria que Chrome, lo que lo hace ideal para extraer contenido web (convierte cualquier pagina a markdown, ejecutando el JavaScript completo).

La skill explica cuando usar Lightpanda (paginas con JavaScript, SPA, scroll infinito) y cuando no (HTML estatico simple, donde basta curl). Tambien documenta la integracion como herramienta externa opcional — no se empaqueta con Savia por la licencia AGPL.

Riesgo: bajo. Es solo documentacion de una herramienta externa opcional.

## Summary
feat: add lightpanda-browser skill — headless browser for AI agents
### Changes
- Skill: lightpanda-browser (SKILL.md + DOMAIN.md)
- Instalacion documentada (binario 149MB, URL oficial, alternativa Docker)
- Patron de fallback: usar si instalado, scrapling-fetch si no
- Anti-patrones y limitaciones documentadas
### Stats
Herramienta externa opcional (AGPL-3.0, nunca bundled). 123 skills.
## Test plan
- [x] CI passed
- [x] Signed
