### PR TITLE
fix(ci): auto-label tolerante a PRs cross-repo (fork)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=fe91531ff912d56e4bf3c604e876c612863c63bb2ec8dc64ae3a22f486734d81
-timestamp=2026-08-06T07:50:08Z
-branch=hotfix/auto-label-fork-prs
-head_commit=c836946b
-signature=71ccf94b25c3a3276d9ca314a37f7fbacf745b800ba5e01bd91e447eec44b5ba
+diff_hash=b99a03cd0ebc2a13d337063e646f88ac5854d84df37eff8355bcc07e2f422bf5
+timestamp=2026-08-06T20:42:59Z
+branch=hotfix-tmp
+head_commit=0fd9123b
+signature=2bab41a9c06a5123fdfb1034748b40969b447b9c6ec67c63a3141b949fb9f9dd

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=0a7ade5414456249bb6a4d9ec08c2397cc202bda90b9a83ccd6e20f274771df5
-timestamp=2026-08-07T17:34:50Z
+diff_hash=131c494d7fc19d7f01a30a71acab27cee67e573d61301bd0fd1796cd68626f33
+timestamp=2026-08-07T21:03:58Z
 branch=hotfix/auto-label-fork-prs
-head_commit=f1db4c5b
-signature=1cc0039c3ff0a084642b0461ac659a74de850a657d6551210ba7ab6b83256b92
+head_commit=7c34baf5
+signature=0845523f9de81da097c9fb5911872d245f09118491092ffc32bec8a527b8bdf4

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=aedaaa38b401d6ac826fd86f20c00aad4ae60cbbf30a345176975672cb93a937
-timestamp=2026-08-06T02:39:59Z
-branch=se308-transcriptor
-head_commit=f17284b7
-signature=fe54bbc55c8f38e5f9152f43067467ee92c3e112e33fd9b32609f69571870894
+diff_hash=fe91531ff912d56e4bf3c604e876c612863c63bb2ec8dc64ae3a22f486734d81
+timestamp=2026-08-06T07:50:08Z
+branch=hotfix/auto-label-fork-prs
+head_commit=c836946b
+signature=71ccf94b25c3a3276d9ca314a37f7fbacf745b800ba5e01bd91e447eec44b5ba

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=b99a03cd0ebc2a13d337063e646f88ac5854d84df37eff8355bcc07e2f422bf5
-timestamp=2026-08-06T20:42:59Z
-branch=hotfix-tmp
-head_commit=0fd9123b
-signature=2bab41a9c06a5123fdfb1034748b40969b447b9c6ec67c63a3141b949fb9f9dd
+diff_hash=0a7ade5414456249bb6a4d9ec08c2397cc202bda90b9a83ccd6e20f274771df5
+timestamp=2026-08-07T17:34:50Z
+branch=hotfix/auto-label-fork-prs
+head_commit=f1db4c5b
+signature=1cc0039c3ff0a084642b0461ac659a74de850a657d6551210ba7ab6b83256b92

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -78,17 +78,18 @@ jobs:
                 }
               }
 
-            // Cross-repo (fork) PRs: the workflow token cannot always write
-            // labels to a PR whose head is in another repo (403). Labels are
-            // cosmetic — never fail the check because of them.
-            try {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                labels: labels
-              });
-              console.log(`Added labels: ${labels.join(', ')}`);
-            } catch (e) {
-              console.log(`Skipping labels for cross-repo PR (403 expected): ${e.message}`);
+              // Cross-repo (fork) PRs: the workflow token cannot always write
+              // labels to a PR whose head is in another repo (403). Labels are
+              // cosmetic — never fail the check because of them.
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  labels: labels
+                });
+                console.log(`Added labels: ${labels.join(', ')}`);
+              } catch (e) {
+                console.log(`Skipping labels for cross-repo PR (403 expected): ${e.message}`);
+              }
             }

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -78,12 +78,17 @@ jobs:
                 }
               }
 
+            // Cross-repo (fork) PRs: the workflow token cannot always write
+            // labels to a PR whose head is in another repo (403). Labels are
+            // cosmetic — never fail the check because of them.
+            try {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
                 labels: labels
               });
-
               console.log(`Added labels: ${labels.join(', ')}`);
+            } catch (e) {
+              console.log(`Skipping labels for cross-repo PR (403 expected): ${e.message}`);
             }

--- a/CHANGELOG.d/auto-label-fork-prs.md
+++ b/CHANGELOG.d/auto-label-fork-prs.md
@@ -1,0 +1,8 @@
+---
+version_bump: patch
+section: Fixed
+---
+
+### Fixed
+
+- Auto-label PRs cross-repo (fork): el job `label` fallaba con `SyntaxError` en PRs desde forks y el token del workflow no siempre podia escribir labels en PRs cuyo head vive en otro repo. Ahora el script ignora el error de 403 cross-repo (labels son cosmeticos) y el flujo ya no aborta. Tambien corrige la llave de cierre del bloque `if` que rompia el parseo del script.


### PR DESCRIPTION
## Summary

Los PRs de forks fallan en el workflow auto-label con `403: Resource not accessible by integration`. El token del workflow no puede etiquetar PRs cuyo head está en otro repo. Los labels son cosméticos — no deben bloquear el merge.

## Fix

Envuelto `issues.addLabels` en try/catch: si falla (403 esperado en fork PRs), se salta el etiquetado sin fallar el check.

## Impacto

Desbloquea PRs cross-repo (contribuciones de forks) que fallaban CI solo por el label check. Ejemplo: PR #943 (GitHub Copilot CLI hooks).