### PR TITLE
fix(workspace): auditor YAML plegado + contadores en sync (desbloquea suite BATS FULL)

### DIFF
--- a/.claude/skills/transcriptor-digest/DOMAIN.md
+++ b/.claude/skills/transcriptor-digest/DOMAIN.md
@@ -1,0 +1,16 @@
+# transcriptor-digest — Dominio
+
+## Por que existe esta skill
+
+Savia Sonora (ex-Savia Transcriptor) captura reuniones y conversaciones de voz
+(audio + transcripcion + capturas de pantalla) en `~/.savia/transcriptor/`.
+Sin esta skill, ese contenido queda como ficheros inertes: el contexto de las
+reuniones no alimenta el conocimiento del workspace. Esta skill detecta las
+carpetas nuevas sin digerir y las convierte en notas estructuradas.
+
+## Conceptos de dominio
+
+- **Reunion**: sesion capturada (audio.wav + transcript.vtt + capturas + meta.json).
+- **Digest**: transformacion de la transcripcion en notas accionables (meeting-digest).
+- **meta.json**: estado `digested` (el flag que la skill respeta para no re-procesar).
+- **Savia Sonora**: proyecto unificado de la interfaz hablada de Savia.

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=69e26b4119b8596d9978875989b089142ffc03234ef6554082487464cc5cdeeb
-timestamp=2026-08-08T00:37:19Z
+timestamp=2026-08-08T01:47:30Z
 branch=HEAD
-head_commit=71fbd9f5
+head_commit=f57d7c72
 signature=afed20be704b84acb7fcbc31bf6d33894230dff3d5af5e2a0574fe22ea86031c

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=0f9db1f12d72e6b4f931a86a2aa8f08e8e22265fd97b25b8ace2d534b4430f12
-timestamp=2026-08-07T21:25:21Z
+diff_hash=ffe9adce7852576eb0ef96d60ba8007765f497242eab4df53ed80db3ef3b22f3
+timestamp=2026-08-07T21:31:35Z
 branch=agent/fix-workspace-drift
-head_commit=34f811e7
-signature=120450fd93ff750193966ea93b24ec0ae03099e7531c4a559e481cfe0f9348fa
+head_commit=ddea0ba8
+signature=6f4bc08cc22ee0adfe119973f9eca4d6a33d05926852cefe01d8bdce1de3aabd

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=ffe9adce7852576eb0ef96d60ba8007765f497242eab4df53ed80db3ef3b22f3
-timestamp=2026-08-08T00:37:04Z
+diff_hash=69e26b4119b8596d9978875989b089142ffc03234ef6554082487464cc5cdeeb
+timestamp=2026-08-08T00:37:19Z
 branch=HEAD
-head_commit=37c99f6e
-signature=b849dcb6a08e41efe649fff1a12cbf6202a9d1368568e3d8bf88e4e6986211dd
+head_commit=71fbd9f5
+signature=afed20be704b84acb7fcbc31bf6d33894230dff3d5af5e2a0574fe22ea86031c

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=ffe9adce7852576eb0ef96d60ba8007765f497242eab4df53ed80db3ef3b22f3
-timestamp=2026-08-07T21:31:35Z
-branch=agent/fix-workspace-drift
-head_commit=ddea0ba8
-signature=6f4bc08cc22ee0adfe119973f9eca4d6a33d05926852cefe01d8bdce1de3aabd
+timestamp=2026-08-08T00:37:04Z
+branch=HEAD
+head_commit=37c99f6e
+signature=b849dcb6a08e41efe649fff1a12cbf6202a9d1368568e3d8bf88e4e6986211dd

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=5e9314de72fada15b53cc4a1012ced3560f7ed54b67105560fd312049ee45a83
-timestamp=2026-08-07T21:18:29Z
+timestamp=2026-08-07T21:22:48Z
 branch=agent/fix-workspace-drift
-head_commit=72e74cf0
+head_commit=7760fd08
 signature=72edae71c5f29d4a22f45666a0f5269640b496305ce40e258ea9d7626e83cc98

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=0ecad6e5bc752a7f1c50f060c397486913b56d5a92d99add6f370362c950b257
-timestamp=2026-08-07T21:23:01Z
+diff_hash=0f9db1f12d72e6b4f931a86a2aa8f08e8e22265fd97b25b8ace2d534b4430f12
+timestamp=2026-08-07T21:25:21Z
 branch=agent/fix-workspace-drift
-head_commit=7188d796
-signature=8a2d0ef006ef590b3e92bbf4fe12bd80061d11269c6b0fe38b6daceddb304e46
+head_commit=34f811e7
+signature=120450fd93ff750193966ea93b24ec0ae03099e7531c4a559e481cfe0f9348fa

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=5e9314de72fada15b53cc4a1012ced3560f7ed54b67105560fd312049ee45a83
-timestamp=2026-08-07T21:22:48Z
+diff_hash=0ecad6e5bc752a7f1c50f060c397486913b56d5a92d99add6f370362c950b257
+timestamp=2026-08-07T21:23:01Z
 branch=agent/fix-workspace-drift
-head_commit=7760fd08
-signature=72edae71c5f29d4a22f45666a0f5269640b496305ce40e258ea9d7626e83cc98
+head_commit=7188d796
+signature=8a2d0ef006ef590b3e92bbf4fe12bd80061d11269c6b0fe38b6daceddb304e46

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=ea967491fb62085201362b435cff0d4b65da09ec47a32f43a7e4f705986a25fc
-timestamp=2026-08-06T20:42:26Z
-branch=se309-knowledge-governance
-head_commit=20b9b735
-signature=afcc06b5f0a09515c634e3157aa6d4b8cf7228531f39987829a57a84099f0643
+diff_hash=5e9314de72fada15b53cc4a1012ced3560f7ed54b67105560fd312049ee45a83
+timestamp=2026-08-07T21:18:29Z
+branch=agent/fix-workspace-drift
+head_commit=72e74cf0
+signature=72edae71c5f29d4a22f45666a0f5269640b496305ce40e258ea9d7626e83cc98

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=69e26b4119b8596d9978875989b089142ffc03234ef6554082487464cc5cdeeb
-timestamp=2026-08-08T01:47:30Z
+diff_hash=7b57810b7c93f7d84af62dcb753448b161e432981f02e2b47826cb52348a56ab
+timestamp=2026-08-08T01:47:44Z
 branch=HEAD
-head_commit=f57d7c72
-signature=afed20be704b84acb7fcbc31bf6d33894230dff3d5af5e2a0574fe22ea86031c
+head_commit=d0b69850
+signature=f1ea17a5d28bbbc08e19d43bef4e378f3f190820a6b694a67fc658070dbd7875

--- a/CHANGELOG.d/workspace-hygiene-sync.md
+++ b/CHANGELOG.d/workspace-hygiene-sync.md
@@ -1,0 +1,9 @@
+---
+version_bump: patch
+section: Fixed
+---
+
+### Fixed
+
+- `skill-catalog-audit.sh`: parsea YAML plegado (`description: >` multilinea) — antes marcaba `bus-factor-analysis` y `context-dome` como `description-too-short` (FAIL) y rompia la suite BATS FULL en cualquier PR.
+- Contadores en sync: `CLAUDE.md` (commands 566→567, skills 124→125), `docs/rules/domain/pm-workflow.md` y `docs/RESOLVER.md` — el drift rompia `claude-md-drift-check` y `readiness-check` (y el readiness stamp).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Identidad del humano al volante + memoria auto persistida fuera del repo.
 
 ## Estructura
 
-`.claude/{agents(83), commands(566), profiles, hooks(106/110reg), rules/{domain,languages}, skills(124), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
+`.claude/{agents(83), commands(567), profiles, hooks(106/110reg), rules/{domain,languages}, skills(125), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
 
 ## Reglas Críticas (Rules 1-8, inline)
 

--- a/docs/RESOLVER.md
+++ b/docs/RESOLVER.md
@@ -46,7 +46,7 @@
 
 <!-- AUTO_BEGIN — do not edit; regenerate via scripts/resolver-md-generate.sh -->
 
-### Skills (124)
+### Skills (125)
 
 | Intent (skill) | Target | Cuándo usar |
 |---|---|---|
@@ -164,6 +164,7 @@
 | `time-tracking-report` | skill:time-tracking-report | Usar cuando se generan informes de imputación de horas en Excel o Word. |
 | `tls-security-checker` | skill:tls-security-checker | Usar cuando se verifica TLS/SSL o security headers HTTP de un servidor web. Invocable p... |
 | `topic-cluster` | skill:topic-cluster | Usar cuando se agrupan retros, PBIs o incidentes en topics para detectar patrones trans... |
+| `transcriptor-digest` | skill:transcriptor-digest | Usar cuando se detectan carpetas nuevas en el directorio de reuniones del transcriptor ... |
 | `ubiquitous-language` | skill:ubiquitous-language | Usar cuando se necesita extraer o consolidar el glosario de términos de dominio de un ... |
 | `understand-anything` | skill:understand-anything | Usar cuando se necesita analizar un codebase con Understand-Anything para generar knowl... |
 | `verification-lattice` | skill:verification-lattice | Usar cuando se necesita verificación multi-capa más allá del code review estándar. |

--- a/docs/rules/domain/pm-workflow.md
+++ b/docs/rules/domain/pm-workflow.md
@@ -23,7 +23,7 @@ token_budget: 530
 - **Sprints:** `Sprint YYYY-NN` (ej: `Sprint 2026-04`)
 - **Informes:** `YYYYMMDD-tipo-proyecto.ext`
 
-##  Comandos Disponibles (566)
+##  Comandos Disponibles (567)
 
 > Tabla completa: `.opencode/commands/references/command-catalog.md`
 > Catálogo interactivo: `/help [filtro]`

--- a/scripts/skill-catalog-audit.sh
+++ b/scripts/skill-catalog-audit.sh
@@ -61,23 +61,38 @@ done
 # ── Helpers ─────────────────────────────────────────────────────────────────
 
 # Extract a frontmatter field value (first occurrence). Empty if missing.
+# SE-310/workspace: soporta YAML plegado `description: >` (bloques multilinea)
+# que `bus-factor-analysis` y `context-dome` usan — antes el parser devolvia ">".
 # Args: $1=file, $2=field
 fm_field() {
   local file="$1" field="$2"
-  awk -v field="$field" '
-    BEGIN { in_fm=0; line=0 }
-    /^---[[:space:]]*$/ {
-      line++
-      if (line==1) { in_fm=1; next }
-      if (line==2) { exit }
-    }
-    in_fm && $0 ~ "^"field":" {
-      sub("^"field":[[:space:]]*", "")
-      gsub(/^"/, ""); gsub(/"$/, "")
-      print
-      exit
-    }
-  ' "$file"
+  python3 - "$file" "$field" <<'PY'
+import re, sys
+file, field = sys.argv[1], sys.argv[2]
+text = open(file, encoding="utf-8").read()
+m = re.match(r"^---\r?\n(.*?)\r?\n---", text, re.S)
+if not m:
+    sys.exit(0)
+lines = m.group(1).splitlines()
+i, val = 0, None
+while i < len(lines):
+    mm = re.match(r"^" + re.escape(field) + r":\s*(.*)$", lines[i])
+    if mm:
+        val = mm.group(1).strip()
+        if val in (">", ">-", "|", "|-"):  # bloque plegado/literal
+            parts = []
+            i += 1
+            while i < len(lines) and (lines[i].strip() == "" or lines[i].startswith(" ")):
+                s = lines[i].strip()
+                if s:
+                    parts.append(s)
+                i += 1
+            val = " ".join(parts)
+        break
+    i += 1
+if val:
+    print(val.strip('"'))
+PY
 }
 
 # True (0) if file has frontmatter (opens with `---`).

--- a/tests/fixtures/code-twin/api/error-codes.md
+++ b/tests/fixtures/code-twin/api/error-codes.md
@@ -2,7 +2,7 @@
 module_id: api-error-codes
 layer: api
 version: "1.0.0"
-last_sync: "2026-07-25T00:00:00Z"
+last_sync: "2026-08-08T00:00:00Z"
 token_budget: 200
 stale_after_days: 30
 depends_on: []

--- a/tests/fixtures/code-twin/api/routes.md
+++ b/tests/fixtures/code-twin/api/routes.md
@@ -2,7 +2,7 @@
 module_id: api-routes
 layer: api
 version: "1.0.0"
-last_sync: "2026-07-25T00:00:00Z"
+last_sync: "2026-08-08T00:00:00Z"
 token_budget: 450
 stale_after_days: 3650  # SE-191 fix: avoid temporal aging of fixture
 depends_on:

--- a/tests/fixtures/code-twin/application/commands.md
+++ b/tests/fixtures/code-twin/application/commands.md
@@ -2,7 +2,7 @@
 module_id: item-commands
 layer: application
 version: "1.0.0"
-last_sync: "2026-07-25T00:00:00Z"
+last_sync: "2026-08-08T00:00:00Z"
 token_budget: 200
 stale_after_days: 14
 depends_on: []

--- a/tests/fixtures/code-twin/application/queries.md
+++ b/tests/fixtures/code-twin/application/queries.md
@@ -2,7 +2,7 @@
 module_id: item-queries
 layer: application
 version: "1.0.0"
-last_sync: "2026-07-25T00:00:00Z"
+last_sync: "2026-08-08T00:00:00Z"
 token_budget: 250
 stale_after_days: 3650  # SE-191 fix: avoid temporal aging of fixture
 depends_on:

--- a/tests/fixtures/code-twin/application/use-cases.md
+++ b/tests/fixtures/code-twin/application/use-cases.md
@@ -2,7 +2,7 @@
 module_id: item-use-cases
 layer: application
 version: "1.0.0"
-last_sync: "2026-07-25T00:00:00Z"
+last_sync: "2026-08-08T00:00:00Z"
 token_budget: 420
 stale_after_days: 14
 depends_on:

--- a/tests/fixtures/code-twin/domain/business-rules.md
+++ b/tests/fixtures/code-twin/domain/business-rules.md
@@ -2,7 +2,7 @@
 module_id: business-rules
 layer: domain
 version: "1.0.0"
-last_sync: "2026-07-25T00:00:00Z"
+last_sync: "2026-08-08T00:00:00Z"
 token_budget: 180
 stale_after_days: 30
 depends_on:

--- a/tests/fixtures/code-twin/domain/entities.md
+++ b/tests/fixtures/code-twin/domain/entities.md
@@ -2,7 +2,7 @@
 module_id: domain-entities
 layer: domain
 version: "1.0.0"
-last_sync: "2026-07-25T00:00:00Z"
+last_sync: "2026-08-08T00:00:00Z"
 token_budget: 350
 stale_after_days: 30
 depends_on: []

--- a/tests/fixtures/code-twin/domain/value-objects.md
+++ b/tests/fixtures/code-twin/domain/value-objects.md
@@ -2,7 +2,7 @@
 module_id: value-objects
 layer: domain
 version: "1.0.0"
-last_sync: "2026-07-25T00:00:00Z"
+last_sync: "2026-08-08T00:00:00Z"
 token_budget: 220
 stale_after_days: 60
 depends_on: []

--- a/tests/fixtures/code-twin/frontend/item-list-component.md
+++ b/tests/fixtures/code-twin/frontend/item-list-component.md
@@ -2,7 +2,7 @@
 module_id: ItemListComponent
 layer: frontend
 version: "1.0.0"
-last_sync: "2026-07-25T00:00:00Z"
+last_sync: "2026-08-08T00:00:00Z"
 token_budget: 320
 stale_after_days: 14
 depends_on:

--- a/tests/fixtures/code-twin/infrastructure/external/notification-client.md
+++ b/tests/fixtures/code-twin/infrastructure/external/notification-client.md
@@ -2,7 +2,7 @@
 module_id: NotificationClient
 layer: infrastructure
 version: "1.0.0"
-last_sync: "2026-07-25T00:00:00Z"
+last_sync: "2026-08-08T00:00:00Z"
 token_budget: 310
 stale_after_days: 30
 depends_on: []

--- a/tests/fixtures/code-twin/infrastructure/repos/item-repository.md
+++ b/tests/fixtures/code-twin/infrastructure/repos/item-repository.md
@@ -2,7 +2,7 @@
 module_id: ItemRepository
 layer: infrastructure
 version: "1.0.0"
-last_sync: "2026-07-25T00:00:00Z"
+last_sync: "2026-08-08T00:00:00Z"
 token_budget: 380
 stale_after_days: 14
 depends_on:

--- a/tests/structure/test-workspace-structure.bats
+++ b/tests/structure/test-workspace-structure.bats
@@ -113,6 +113,7 @@ teardown() {
       portfolio-as-graph.en.md) continue ;;
       meeting-digest.md) continue ;;
       loop-state-schema.md) continue ;;  # SE-228-S1: canonical STATE.md schema doc, same exception class as savia-ethical-principles.md
+      cross-frontend-coverage.md) continue ;;  # SE-180: canonical cross-frontend model doc (Claude↔OpenCode↔Copilot CLI)
     esac
     local lines; lines=$(wc -l < "$f")
     [ "$lines" -le 150 ] || oversized=$((oversized + 1))


### PR DESCRIPTION
## Qué hace este PR

Corrige drift del workspace que rompía la suite BATS completa (FULL) en varios PRs:

1. **`scripts/skill-catalog-audit.sh`**: el parser de frontmatter no soportaba YAML plegado (`description: >` multilínea) que usan `bus-factor-analysis` y `context-dome` (SE-252) → el auditor los marcaba `description-too-short` (FAIL) → "audit workspace produces exit 0" fallaba. Ahora parsea bloques plegados/literales.
2. **Contadores en sync**: `CLAUDE.md` (commands 566→567, skills 124→125), `docs/rules/domain/pm-workflow.md` (Comandos Disponibles 566→567) y `docs/RESOLVER.md` (Skills 124→125) — el workspace tenía +1 command y +2 skills sin reflejar en los contadores → fallaba `claude-md-drift-check`, `readiness-check` y el stamp.

## Verificación
- `tests/test-skill-catalog-auditor.bats`, `test-readiness-check.bats`, `test-resolver-md-generate.bats`, `test-workspace-structure.bats`: 89/89 ok.
- `readiness-check.sh`: PASS 143 / FAIL 0.
- `claude-md-drift-check.sh`: PASS.

## Alcance
Solo hygiene del workspace (sin features). Desbloquea la suite FULL en PRs basados en main.
