### PR TITLE
feat(se332): handback obligation — escalación normativa de agentes autónomos bloqueados

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=d2bf3ca4ba0e0a5f5e25954b731144906f89640f2f1de78cd4c026c381b6924d
-timestamp=2026-08-16T08:36:13Z
+diff_hash=ea30e49604a11ec13ab8f001f15f18fb9f618de300a4302033aafb033ab0643f
+timestamp=2026-08-16T09:50:34Z
 branch=agent/se332-handback-obligation
-head_commit=f7ee387d
-signature=e458a0c687e19ca14e948b4c1622835f26f52980b1ea88a7779b10f0f79c5f43
+head_commit=7f284db3
+signature=79cc59000dd5bf6b6f2a0d9f517d4332cb372beb2fa763a626e244b2562a7457

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=ea30e49604a11ec13ab8f001f15f18fb9f618de300a4302033aafb033ab0643f
-timestamp=2026-08-16T09:50:34Z
+timestamp=2026-08-16T10:00:17Z
 branch=agent/se332-handback-obligation
-head_commit=7f284db3
+head_commit=d943d87b
 signature=79cc59000dd5bf6b6f2a0d9f517d4332cb372beb2fa763a626e244b2562a7457

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=d2bf3ca4ba0e0a5f5e25954b731144906f89640f2f1de78cd4c026c381b6924d
-timestamp=2026-08-15T08:28:09Z
-branch=agent/evidence-first-20260815
-head_commit=1d0a4dd8
+timestamp=2026-08-16T08:36:13Z
+branch=agent/se332-handback-obligation
+head_commit=f7ee387d
 signature=e458a0c687e19ca14e948b4c1622835f26f52980b1ea88a7779b10f0f79c5f43

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=ea30e49604a11ec13ab8f001f15f18fb9f618de300a4302033aafb033ab0643f
-timestamp=2026-08-16T10:00:17Z
+diff_hash=8970fc392ecd6042b8db0699ae04bec0258b74d7348b18a6812d3340741176c9
+timestamp=2026-08-16T10:02:40Z
 branch=agent/se332-handback-obligation
-head_commit=d943d87b
-signature=79cc59000dd5bf6b6f2a0d9f517d4332cb372beb2fa763a626e244b2562a7457
+head_commit=f33fa5ce
+signature=844511e806178918994e27b05ded98bb00d639c161278df42a41653259bd34be

--- a/CHANGELOG.d/se332-handback-obligation.md
+++ b/CHANGELOG.d/se332-handback-obligation.md
@@ -1,0 +1,9 @@
+---
+version_bump: minor
+section: Changed
+---
+
+### Changed
+
+- SE-332 Handback Obligation: instancia autonoma bloqueada escala a su padre inmediato (cadena por modo), con artifact reference-first y registro de handback_to en audit trail
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1487,3 +1487,45 @@ PR #952 (SE-313/314/275) — DONE (merge 2026-08-09)
 | SE-330 | — | IMPLEMENTED | Context enrichment BM25+grafo (2026-08-14) |
 | SE-331 | — | IMPLEMENTED | Eval recuperación RAGAS-like (2026-08-14) |
 
+---
+
+## Era 204 — External Repo Intelligence: ai-project-system (2026-08-15)
+
+> Analisis de `panchew/ai-project-system` v7.1.0 (111 epics, 10 fases, dogfooding
+> publico). Es un espejo mas simple de Savia: gobernanza documental de ejecucion
+> con IA (Phase→Milestone→Epic, happy path de 8 pasos, hybrid frontier/local
+> models). Se apalancan 5 ideas: 1 especificada (SE-332), 4 candidatas.
+
+### Priorizacion (ROI)
+
+**Tier 0 — Alta prioridad (impacto inmediato, effort 3h)**
+
+| Spec | Concepto origen | Esfuerzo | Por que primero |
+|---|---|---|---|
+| SE-332 Handback Obligation | P10-M35 fleet-operator | 3h | Cierra gap real: escalacion de autoridad de agentes autonomos bloqueados. Savia hoy alcanza al humano "por esperanza" (AUTONOMOUS_REVIEWER estatico), no "por construccion". |
+
+**Tier 1 — Media (candidatas sin especificar, effort 4-8h c/u)**
+
+| Spec candidata | Concepto origen | Esfuerzo | Por que |
+|---|---|---|---|
+| Reference-first handoff | SN-23 | 4h | Handoffs por referencia (rutas), no eco de cuerpo — extiende agent-notes-protocol. Acoplada al artifact `handback` de SE-332. |
+| Default-accept epics limpios | PSG §11.6 | 6h | Reduce ceremonia de artefactos en tribunales cuando el DoD se cumple, preservando el gate humano (Layer 8). |
+| Model-routing policy desde telemetria | P9 measure-token-burn | 8h | Formaliza `model-routing-policy.md` alimentado por SE-313 telemetria. |
+| Execution matrix "mode is not authority" | P10-M35 | 4h | Ratifica matriz explicita: el modo agentico no confiere autoridad de merge. |
+
+### Orden de ejecucion recomendado
+
+```
+SE-332 (handback obligation) — APPROVED 2026-08-16, IMPLEMENTED (PR plan en output/pr-plans/)
+  → reference-first handoff (acoplada al contexto_ref del artifact handback)
+  → model-routing policy / default-accept / execution matrix (segun prioridad
+    de tribunales vs telemetria)
+```
+
+### Estado por PR
+
+| Spec | PR | Estado | Bloqueo |
+|---|---|---|---|
+| SE-332 | PR pendiente (PR plan en `output/pr-plans/`) | APPROVED 2026-08-16 · implementado en rama agent/* | Revisión humana + merge |
+| 4 candidatas | — | CANDIDATA | Sin especificar; listadas como follow-up en SE-332 |
+

--- a/docs/rules/domain/agent-handoff-protocol.md
+++ b/docs/rules/domain/agent-handoff-protocol.md
@@ -61,41 +61,38 @@ handoff:
 
 ## Handback (SE-332) — escalación reference-first
 
-Cuando una instancia autónoma queda **bloqueada** y escala a su padre (Handback
-Obligation, `autonomous-safety.md`), NO usa el `handoff:` canónico (que activa al
-destino) — emite un artifact `handback:` **reference-first**: solo rutas, nunca
-cuerpo. Permite al humano retomar sin re-derivar contexto.
+Instancia autónoma **bloqueada** que escala a su padre (Handback Obligation,
+`autonomous-safety.md`) NO usa `handoff:` canónico (que activa al destino) — emite
+artifact `handback:` **reference-first** (solo rutas, nunca cuerpo), permitiendo retomar
+sin re-derivar contexto.
 
 ```yaml
 ---
 handback:
   escalado_desde: overnight-sprint        # modo | agente que escaló (required)
   escalado_a: "@monica"                   # padre resuelto por handback-resolve.sh (required)
-  motivo: guardrail_rechazo               # recurso_no_disponible | guardrail_rechazo | modelo_mismatch | otro (required)
+  motivo: guardrail_rechazo               # recurso_no_disponible | guardrail_rechazo | modelo_mismatch | otro
   contexto_ref:                           # reference-first — rutas, no contenido (required, ≥1)
     - output/agent-runs/overnight-20260816-fix-x/run-record.jsonl
     - output/loop-state/overnight-20260816-fix-x/terminal-state.jsonl
-  intentos_restantes: 2                   # tras AGENT_MAX_CONSECUTIVE_FAILURES
-  timestamp: "2026-08-16T07:25:00Z"       # ISO-8601
+  intentos_restantes: 2
+  timestamp: "2026-08-16T07:25:00Z"
 ---
 ```
 
 | Campo | Tipo | Obligatorio | Descripción |
 |---|---|---|---|
-| `escalado_desde` | string | sí | Modo autónomo o agente que emite el handback |
+| `escalado_desde` | string | sí | Modo o agente que emite el handback |
 | `escalado_a` | string | sí | Padre resuelto por `scripts/handback-resolve.sh` |
 | `motivo` | enum | sí | `recurso_no_disponible` \| `guardrail_rechazo` \| `modelo_mismatch` \| `otro` |
-| `contexto_ref` | list[string] | sí | Rutas relativas a artifacts (run-record, terminal-state.jsonl). PROHIBIDO eco de cuerpo |
-| `intentos_restantes` | int | no | Reintentos de modelo restantes tras fallo consecutivo |
+| `contexto_ref` | list[string] | sí | Rutas a artifacts (run-record, terminal-state.jsonl). PROHIBIDO eco de cuerpo |
+| `intentos_restantes` | int | no | Reintentos de modelo restantes |
 | `timestamp` | string | sí | ISO-8601 de la escalación |
 
-**Reglas**:
-1. `escalado_a` lo resuelve `scripts/handback-resolve.sh` — NO se deriva a mano.
-2. `contexto_ref` son paths relativos al `REPO_ROOT`, sin `./` inicial; el orquestador
-   reanuda leyendo esos artifacts, no el cuerpo del handback.
-3. A diferencia de `handoff:` con `termination_reason: completed`, el `handback` **no
-   activa** al destino — requiere resolución humana explícita y registra `handback_to`
-   en el audit trail.
+**Reglas**: (1) `escalado_a` lo resuelve `handback-resolve.sh` — no a mano; (2) `contexto_ref`
+son paths relativos al `REPO_ROOT` sin `./`; el orquestador reanuda leyendo esos artifacts;
+(3) a diferencia de `handoff:` `completed`, el `handback` **no activa** al destino — requiere
+resolución humana explícita y registra `handback_to` en el audit trail.
 
 ## Validación
 
@@ -134,16 +131,10 @@ handoff:
 
 ## Relación con agent-notes-protocol.md
 
-Ambos protocolos coexisten:
-
-- **Handoff-as-function** (este doc): transiciones rápidas estructuradas.
-- **agent-notes-protocol**: threads longform, notas de contexto entre agentes, multi-turn.
-
-Un agente PUEDE producir **ambos** en un mismo output:
-1. Agent-notes con análisis extendido.
-2. Handoff-as-function YAML con destino claro.
-
-El orquestador lee primero `handoff:` (routing). Las notes son contexto secundario.
+Ambos coexisten: **handoff-as-function** (este doc) para transiciones rápidas
+estructuradas; **agent-notes-protocol** para threads longform multi-turn. Un agente
+PUEDE producir ambos: agent-notes con análisis + handoff YAML con destino. El
+orquestador lee primero `handoff:` (routing); las notes son contexto secundario.
 
 ## Integración con autonomous-safety.md
 

--- a/docs/rules/domain/agent-handoff-protocol.md
+++ b/docs/rules/domain/agent-handoff-protocol.md
@@ -59,6 +59,44 @@ handoff:
 4. **artifacts** son paths relativos al `REPO_ROOT`, sin `./` inicial.
 5. Handoff con `termination_reason` ≠ `completed` **no activa** al agente destino automáticamente — requiere resolución humana.
 
+## Handback (SE-332) — escalación reference-first
+
+Cuando una instancia autónoma queda **bloqueada** y escala a su padre (Handback
+Obligation, `autonomous-safety.md`), NO usa el `handoff:` canónico (que activa al
+destino) — emite un artifact `handback:` **reference-first**: solo rutas, nunca
+cuerpo. Permite al humano retomar sin re-derivar contexto.
+
+```yaml
+---
+handback:
+  escalado_desde: overnight-sprint        # modo | agente que escaló (required)
+  escalado_a: "@monica"                   # padre resuelto por handback-resolve.sh (required)
+  motivo: guardrail_rechazo               # recurso_no_disponible | guardrail_rechazo | modelo_mismatch | otro (required)
+  contexto_ref:                           # reference-first — rutas, no contenido (required, ≥1)
+    - output/agent-runs/overnight-20260816-fix-x/run-record.jsonl
+    - output/loop-state/overnight-20260816-fix-x/terminal-state.jsonl
+  intentos_restantes: 2                   # tras AGENT_MAX_CONSECUTIVE_FAILURES
+  timestamp: "2026-08-16T07:25:00Z"       # ISO-8601
+---
+```
+
+| Campo | Tipo | Obligatorio | Descripción |
+|---|---|---|---|
+| `escalado_desde` | string | sí | Modo autónomo o agente que emite el handback |
+| `escalado_a` | string | sí | Padre resuelto por `scripts/handback-resolve.sh` |
+| `motivo` | enum | sí | `recurso_no_disponible` \| `guardrail_rechazo` \| `modelo_mismatch` \| `otro` |
+| `contexto_ref` | list[string] | sí | Rutas relativas a artifacts (run-record, terminal-state.jsonl). PROHIBIDO eco de cuerpo |
+| `intentos_restantes` | int | no | Reintentos de modelo restantes tras fallo consecutivo |
+| `timestamp` | string | sí | ISO-8601 de la escalación |
+
+**Reglas**:
+1. `escalado_a` lo resuelve `scripts/handback-resolve.sh` — NO se deriva a mano.
+2. `contexto_ref` son paths relativos al `REPO_ROOT`, sin `./` inicial; el orquestador
+   reanuda leyendo esos artifacts, no el cuerpo del handback.
+3. A diferencia de `handoff:` con `termination_reason: completed`, el `handback` **no
+   activa** al destino — requiere resolución humana explícita y registra `handback_to`
+   en el audit trail.
+
 ## Validación
 
 Validación con `scripts/validate-handoff.sh --file handoff.yaml`:

--- a/docs/rules/domain/autonomous-safety.md
+++ b/docs/rules/domain/autonomous-safety.md
@@ -67,11 +67,9 @@ desde **fuentes locales gitignored** (NUNCA del repo público — Rule #20):
 ```
 
 scripts/savia-env.sh expone `savia_autonomous_reviewer()` que aplica esta cadena.
-
 ### Gate de arranque
 
 **Si tras la cadena no hay valor resoluble, el modo autónomo NO arranca.**
-El comando debe mostrar:
 
 ```
 ERROR: AUTONOMOUS_REVIEWER no resoluble.
@@ -102,13 +100,10 @@ Cada sesión autónoma genera `output/agent-runs/{modo}-{fecha}-audit.log`. Camp
 
 ## Auto Mode — Capa complementaria (Claude Code 2026-03-24)
 
-`claude --enable-auto-mode` activa un classifier pre-tool-call que bloquea
-acciones destructivas sin requerir `--dangerously-skip-permissions`. NO
-reemplaza los gates de esta regla (AUTONOMOUS_REVIEWER, ramas agent/*, PR
-Draft, AGENT_MAX_CONSECUTIVE_FAILURES) — añade defensa en profundidad.
-Recomendado en toda sesión que invoque `overnight-sprint`,
-`code-improvement-loop` o `tech-research-agent`. Desktop/VS Code: Settings
-→ Claude Code → Auto Mode. Ref: anthropic.com/engineering/claude-code-auto-mode
+`claude --enable-auto-mode` bloquea acciones destructivas pre-tool-call sin
+`--dangerously-skip-permissions`. NO reemplaza los gates de esta regla — añade
+defensa en profundidad. Desktop/VS Code: Settings → Claude Code → Auto Mode.
+Ref: anthropic.com/engineering/claude-code-auto-mode
 
 ## Escalamiento de modelo
 
@@ -122,7 +117,7 @@ OOM, timeout o error de infra: NO escalar — descartar y continuar.
 
 ## Emergency-mode (LocalAI fallback) — SPEC-122
 
-`/emergency-mode` cambia SOLO el endpoint (`ANTHROPIC_BASE_URL` → LocalAI), **no bypassa** los gates de esta regla. AUTONOMOUS_REVIEWER, rama `agent/*`, PR Draft siguen siendo obligatorios. Si el revisor humano no está disponible, el agente **espera**. Ver `.opencode/skills/emergency-mode/SKILL.md` y `docs/rules/domain/emergency-mode-protocol.md`.
+`/emergency-mode` cambia SOLO el endpoint (`ANTHROPIC_BASE_URL` → LocalAI), **no bypassa** los gates. AUTONOMOUS_REVIEWER, rama `agent/*`, PR Draft siguen obligatorios. Si el revisor no está disponible, el agente **espera**. Ver `emergency-mode/SKILL.md` y `emergency-mode-protocol.md`.
 
 ## Subagent Scope Guard — SE-146
 
@@ -134,41 +129,15 @@ Cuando un agente o skill se invoca como **subagente delegado** (recibe una tarea
 3. RETORNAR — no continuar en bucle ni lanzar sub-agentes adicionales
 ```
 
-**Por qué**: Las skills de alto impacto (overnight-sprint, code-improvement-loop, adversarial-security, etc.) tienen bucles de orquestación que, si un subagente los activa íntegramente, generan runs en cascada fuera de control.
+**Por qué**: las skills de alto impacto (overnight-sprint, code-improvement-loop, adversarial-security, etc.) tienen bucles de orquestación que, activados íntegramente por un subagente, generan runs en cascada fuera de control.
 
-**Detección de contexto subagente**: si se recibe una tarea vía `Task` tool, env var `SAVIA_SUBAGENT=1`, o flag `--subagent`, aplicar este guard.
+**Detección de contexto subagente**: tarea vía `Task` tool, env `SAVIA_SUBAGENT=1`, o flag `--subagent` → aplicar este guard.
 
 **Skills con este guard**: adversarial-security, code-improvement-loop, consensus-validation, dag-scheduling, overnight-sprint, spec-driven-development, tdd-vertical-slices, verification-lattice.
 
 ## Handback Obligation — SE-332
 
-Una instancia autónoma bloqueada **escala a su padre inmediato, un nivel a la vez**.
-Toda cadena termina en un nivel manual **POR CONSTRUCCIÓN** — no existen cadenas
-infinitas de agentes. La escalación de autoridad es independiente de la escalación
-de modelo (fast→mid→agent→abort) y de `AUTONOMOUS_REVIEWER` (que queda como fallback
-de primer nivel).
-
-### Cadena de escalación por modo
-
-| Modo autónomo | Padre inmediato | Manual terminal |
-|---|---|---|
-| overnight-sprint / code-improvement-loop / tech-research-agent | AUTONOMOUS_REVIEWER | operadora (perfil activo) |
-| court-orchestrator / truth-tribunal-orchestrator / recommendation-tribunal-orchestrator | dev-orchestrator | operadora (perfil activo) |
-| subagente delegado (SE-146, `BLOCKED`) | orquestador que lo invocó | operadora (perfil activo) |
-
-### Obligaciones
-
-1. Una instancia bloqueada NO aborta en silencio: emite handback con
-   `termination_reason: handback` (ver `terminal-state-protocol.md`).
-2. El handback es **reference-first**: `contexto_ref` contiene rutas a artifacts
-   (run-record, terminal-state.jsonl), nunca el cuerpo — ver
-   `agent-handoff-protocol.md`.
-3. La resolución del padre la hace `scripts/handback-resolve.sh`, que consulta
-   `savia_autonomous_reviewer()` en `scripts/savia-env.sh` (no re-deriva la cadena).
-4. Si la cadena NO termina en manual, `handback-resolve.sh` sale con exit 5 —
-   invariante de seguridad que garantiza "el humano se alcanza por construcción".
-5. Cada escalación se registra en el audit trail con el campo `handback_to`
-   (ver sección Auditoría).
+Instancia autónoma bloqueada **escala a su padre inmediato, un nivel a la vez**; toda cadena termina en manual **POR CONSTRUCCIÓN**. Resolución: `scripts/handback-resolve.sh`. Handback **reference-first** (`contexto_ref` solo rutas), `termination_reason: handback` (exit 6), `handback_to` en audit. Cadena por modo y schema: `agent-handoff-protocol.md`, `terminal-state-protocol.md`, spec SE-332.
 
 ## Doble opt-in para skills autónomas — SPEC-186
 

--- a/docs/rules/domain/autonomous-safety.md
+++ b/docs/rules/domain/autonomous-safety.md
@@ -98,6 +98,7 @@ Cada sesión autónoma genera `output/agent-runs/{modo}-{fecha}-audit.log`. Camp
 - Tareas intentadas (pr-created / discarded / crash / timeout)
 - Ramas creadas · PRs creados (URLs) · métricas agregadas
 - Razón de parada (completado / max-tasks / max-failures / timeout global / abort manual)
+- `handback_to` — a quién se escaló en cada handback (SE-332; vacío si no hubo escalación)
 
 ## Auto Mode — Capa complementaria (Claude Code 2026-03-24)
 
@@ -138,6 +139,36 @@ Cuando un agente o skill se invoca como **subagente delegado** (recibe una tarea
 **Detección de contexto subagente**: si se recibe una tarea vía `Task` tool, env var `SAVIA_SUBAGENT=1`, o flag `--subagent`, aplicar este guard.
 
 **Skills con este guard**: adversarial-security, code-improvement-loop, consensus-validation, dag-scheduling, overnight-sprint, spec-driven-development, tdd-vertical-slices, verification-lattice.
+
+## Handback Obligation — SE-332
+
+Una instancia autónoma bloqueada **escala a su padre inmediato, un nivel a la vez**.
+Toda cadena termina en un nivel manual **POR CONSTRUCCIÓN** — no existen cadenas
+infinitas de agentes. La escalación de autoridad es independiente de la escalación
+de modelo (fast→mid→agent→abort) y de `AUTONOMOUS_REVIEWER` (que queda como fallback
+de primer nivel).
+
+### Cadena de escalación por modo
+
+| Modo autónomo | Padre inmediato | Manual terminal |
+|---|---|---|
+| overnight-sprint / code-improvement-loop / tech-research-agent | AUTONOMOUS_REVIEWER | operadora (perfil activo) |
+| court-orchestrator / truth-tribunal-orchestrator / recommendation-tribunal-orchestrator | dev-orchestrator | operadora (perfil activo) |
+| subagente delegado (SE-146, `BLOCKED`) | orquestador que lo invocó | operadora (perfil activo) |
+
+### Obligaciones
+
+1. Una instancia bloqueada NO aborta en silencio: emite handback con
+   `termination_reason: handback` (ver `terminal-state-protocol.md`).
+2. El handback es **reference-first**: `contexto_ref` contiene rutas a artifacts
+   (run-record, terminal-state.jsonl), nunca el cuerpo — ver
+   `agent-handoff-protocol.md`.
+3. La resolución del padre la hace `scripts/handback-resolve.sh`, que consulta
+   `savia_autonomous_reviewer()` en `scripts/savia-env.sh` (no re-deriva la cadena).
+4. Si la cadena NO termina en manual, `handback-resolve.sh` sale con exit 5 —
+   invariante de seguridad que garantiza "el humano se alcanza por construcción".
+5. Cada escalación se registra en el audit trail con el campo `handback_to`
+   (ver sección Auditoría).
 
 ## Doble opt-in para skills autónomas — SPEC-186
 

--- a/docs/rules/domain/terminal-state-protocol.md
+++ b/docs/rules/domain/terminal-state-protocol.md
@@ -21,6 +21,7 @@ termination_reason:
   stop_hook           — hook de stop bloqueó la ejecución
   max_turns           — se alcanzó el límite de turnos configurado
   unrecoverable_error — error interno irrecuperable (crash, OOM)
+  handback            — instancia bloqueada escalada a su padre (SE-332)
 ```
 
 ## Definición de cada estado
@@ -75,6 +76,18 @@ fallo irrecuperable de herramienta esencial.
 - **Acción del orquestador**: escalar a humano inmediatamente, adjuntar logs.
 - **Ejemplo**: `"OOM at turn 12, process killed"`
 
+### `handback`
+La instancia autónoma quedó bloqueada (recurso no disponible, guardrail rechaza,
+modelo no coincide) y escala a su padre inmediato según la cadena normativa
+(SE-332). Emite artifact **reference-first** en
+`output/agent-runs/{modo}-{fecha}-handback.md`.
+
+- **Política de reintento**: NO reintentar — la escalación es la salida.
+- **Acción del orquestador**: resolver el padre (scripts/handback-resolve.sh),
+  reanudar desde los artifacts referenciados en `contexto_ref`, registrar
+  `handback_to` en el audit trail.
+- **Ejemplo**: `"handback: escalado_desde=overnight-sprint escalado_a=@monica"`
+
 ## Almacenamiento
 
 Cada emisión se apenda a:
@@ -102,7 +115,14 @@ historial completo de ejecuciones del mismo loop.
 | `stop_hook` | 3 |
 | `max_turns` | 4 |
 | `unrecoverable_error` | 5 |
+| `handback` | 6 |
 | razón desconocida | 1 |
+
+**Por qué `handback=6`**: es una terminación con causa distinta de `unrecoverable_error` —
+el proceso no crasheó, sino que escaló deliberadamente a un padre. El exit code 6 permite
+al orquestador distinguir "hay que leer el artifact handback" de "crash interno". No
+colisiona con `exit 5` de `handback-resolve.sh` (invariante de cadena no resoluble), que
+es un fallo del *script*, no del *estado* emitido.
 
 **Por qué `user_abort=0`**: desde el punto de vista del proceso, `user_abort`
 es una terminación limpia — el usuario decidió parar. El orquestador distingue

--- a/docs/rules/domain/terminal-state-protocol.md
+++ b/docs/rules/domain/terminal-state-protocol.md
@@ -77,15 +77,13 @@ fallo irrecuperable de herramienta esencial.
 - **Ejemplo**: `"OOM at turn 12, process killed"`
 
 ### `handback`
-La instancia autónoma quedó bloqueada (recurso no disponible, guardrail rechaza,
-modelo no coincide) y escala a su padre inmediato según la cadena normativa
-(SE-332). Emite artifact **reference-first** en
-`output/agent-runs/{modo}-{fecha}-handback.md`.
+Instancia bloqueada (recurso no disponible, guardrail rechaza, modelo no coincide)
+que escala a su padre según la cadena normativa (SE-332). Emite artifact
+**reference-first** en `output/agent-runs/{modo}-{fecha}-handback.md`.
 
 - **Política de reintento**: NO reintentar — la escalación es la salida.
-- **Acción del orquestador**: resolver el padre (scripts/handback-resolve.sh),
-  reanudar desde los artifacts referenciados en `contexto_ref`, registrar
-  `handback_to` en el audit trail.
+- **Acción del orquestador**: resolver el padre (`handback-resolve.sh`), reanudar
+  desde `contexto_ref`, registrar `handback_to` en el audit trail.
 - **Ejemplo**: `"handback: escalado_desde=overnight-sprint escalado_a=@monica"`
 
 ## Almacenamiento
@@ -118,16 +116,14 @@ historial completo de ejecuciones del mismo loop.
 | `handback` | 6 |
 | razón desconocida | 1 |
 
-**Por qué `handback=6`**: es una terminación con causa distinta de `unrecoverable_error` —
-el proceso no crasheó, sino que escaló deliberadamente a un padre. El exit code 6 permite
-al orquestador distinguir "hay que leer el artifact handback" de "crash interno". No
-colisiona con `exit 5` de `handback-resolve.sh` (invariante de cadena no resoluble), que
-es un fallo del *script*, no del *estado* emitido.
+**Por qué `handback=6`**: terminación con causa distinta de `unrecoverable_error` — el
+proceso no crasheó, escaló deliberadamente. Distingue "leer artifact handback" de "crash
+interno". No colisiona con `exit 5` de `handback-resolve.sh` (fallo del *script*, no del
+*estado*).
 
-**Por qué `user_abort=0`**: desde el punto de vista del proceso, `user_abort`
-es una terminación limpia — el usuario decidió parar. El orquestador distingue
-`completed` de `user_abort` leyendo el JSON (campo `reason`), no el exit code.
-El exit code 0 en ambos casos indica "no hay error de sistema".
+**Por qué `user_abort=0`**: `user_abort` es una terminación limpia (el usuario decidió
+parar). El orquestador distingue `completed` de `user_abort` leyendo el JSON (campo
+`reason`), no el exit code. El exit code 0 indica "no hay error de sistema".
 
 ## Integración con autonomous-safety.md
 
@@ -135,17 +131,13 @@ Este protocolo complementa `docs/rules/domain/autonomous-safety.md`:
 - `AGENT_MAX_CONSECUTIVE_FAILURES` sigue siendo el gate de abort en caliente.
 - `terminal-state-emit.sh` debe llamarse en el bloque `trap EXIT` del loop,
   garantizando emisión incluso ante señales.
-- El estado `unrecoverable_error` activa siempre escalamiento humano,
-  independientemente de `AGENT_MAX_CONSECUTIVE_FAILURES`.
+- El estado `unrecoverable_error` activa siempre escalamiento humano.
 
 ### Política de rotación del JSONL
 
-El fichero `terminal-state.jsonl` no tiene límite de tamaño automático.
-Se recomienda rotar con `loop-state-prune.sh` (SE-228 S1) cuando el fichero
-supere 500 líneas o 90 días de antigüedad.
-
-Si la última línea del JSONL no es JSON válido, `terminal-state-read.sh`
-devuelve exit 1 con mensaje `'could not parse reason from last entry'`.
+`terminal-state.jsonl` no tiene límite automático. Rotar con `loop-state-prune.sh`
+(SE-228 S1) al superar 500 líneas o 90 días. Si la última línea no es JSON válido,
+`terminal-state-read.sh` devuelve exit 1 con `'could not parse reason from last entry'`.
 
 ## Criterios de Aceptación
 

--- a/docs/specs/SE-332-handback-obligation.spec.md
+++ b/docs/specs/SE-332-handback-obligation.spec.md
@@ -1,0 +1,168 @@
+# Spec: SE-332 — Handback Obligation: escalación normativa de agentes autónomos bloqueados
+
+**Status:** APPROVED
+**Fecha:** 2026-08-15
+**Fecha aprobación:** 2026-08-16 (operadora, sesión opencode)
+**Area:** Autonomous safety / Escalación de autoridad / Handoff
+**Estimación:** 3h
+**Inspirado por:** ai-project-system v7.1.0 (github.com/panchew/ai-project-system) — P10-M35 `governance/systems/fleet-operator.md`, "handback obligation"
+
+**Developer Type:** agent-single
+**Asignado a:** claude-agent
+
+---
+
+## Origen
+
+El análisis de `panchew/ai-project-system` (v7.1.0, 111 epics, dogfooding público)
+reveló un mecanismo que Savia no tiene: la **handback obligation**. En su P10-M35,
+cuando una instancia autónoma queda bloqueada, "escala a su padre inmediato, un
+nivel a la vez, terminando en un nivel manual por construcción".
+
+Savia tiene piezas sueltas de esto, pero no la cadena:
+- `autonomous-safety.md` define `AUTONOMOUS_REVIEWER` como un **único valor estático**
+  resuelto en arranque. Si no resuelve, el modo autónomo "NO arranca". Si resuelve
+  pero el revisor no responde, el agente **espera** (SPEC-122) sin cadena de
+  escalación.
+- La escalación existente es de **modelo** (fast→mid→agent→abort), no de **autoridad**.
+- SE-146 (Subagent Scope Guard) devuelve `BLOCKED` al orquestador, pero no hay norma
+  que diga qué hace un orquestador cuando toda su cadena está bloqueada salvo
+  "requiere intervención humana" — sin artefacto que permita **retomar sin re-derivar
+  contexto**.
+- `terminal-state-protocol.md` enum `unrecoverable_error` → "escalar a humano
+  inmediatamente", pero no define **quién es el humano** (el padre) ni deja un
+  handback artifact.
+
+El gap de fondo: Savia no garantiza "alcanzar al humano **por construcción**". Hoy
+se alcanza "por esperanza" — asumiendo que el AUTONOMOUS_REVIEWER estático responde.
+
+## Problema actual
+
+- Un agente autónomo bloqueado (recurso no disponible, guardrail rechaza, modelo no
+  coincide) aborta silenciosamente o espera al revisor estático, sin escalar a su
+  padre inmediato.
+- No existe cadena de escalación normativa por modo autónomo.
+- Cuando un humano retoma una instancia bloqueada, re-deriva el contexto desde cero:
+  no hay handback artifact **reference-first** (rutas, no eco de cuerpo).
+- No hay registro en el audit trail de a quién se escaló (`handback_to`).
+
+## Diseño
+
+### 1. Nueva sección "Handback Obligation" en `autonomous-safety.md`
+
+Regla normativa + tabla de cadena por modo:
+
+```
+Una instancia autónoma bloqueada escala a su padre inmediato, un nivel a la
+vez. Toda cadena termina en un nivel manual POR CONSTRUCCIÓN — no existen
+cadenas infinitas de agentes.
+```
+
+| Modo autónomo | Padre inmediato | Manual terminal |
+|---|---|---|
+| overnight-sprint / code-improvement-loop / tech-research-agent | AUTONOMOUS_REVIEWER | operadora (perfil activo) |
+| court-orchestrator / truth-tribunal-orchestrator / recommendation-tribunal-orchestrator | dev-orchestrator | operadora (perfil activo) |
+| subagente delegado (SE-146, `BLOCKED`) | orquestador que lo invocó | operadora (perfil activo) |
+
+### 2. Nuevo `termination_reason: handback` + schema de artifact
+
+- Extender el enum en `terminal-state-protocol.md` con `handback`.
+- Extender `agent-handoff-protocol.md` (handoff-as-function) con un schema de
+  artifact **reference-first** — contiene rutas a artifacts, no el cuerpo:
+
+```yaml
+handback:
+  escalado_desde: <modo|agente>
+  escalado_a: <padre resuelto>
+  motivo: <recurso_no_disponible | guardrail_rechazo | modelo_mismatch | otro>
+  contexto_ref:                     # reference-first, no eco de cuerpo
+    - <ruta artifacts/run-record>
+    - <ruta terminal-state.jsonl>
+  intentos_restantes: <n>
+  timestamp: <ISO-8601>
+```
+
+### 3. Script determinista `scripts/handback-resolve.sh`
+
+Dado `--modo` + `--contexto-dir`, resuelve el padre de la cadena y emite el artifact:
+
+- Consulta `scripts/savia-env.sh` (`savia_autonomous_reviewer()`), no re-deriva la
+  cadena de fuentes.
+- Si la cadena NO termina en manual → `exit 5` (imposible por construcción; test de
+  seguridad que garantiza la invariante).
+- Emite artifact handback en `output/agent-runs/{modo}-{fecha}-handback.md`.
+
+### 4. Audit trail
+
+Añadir campo `handback_to` a `output/agent-runs/{modo}-{fecha}-audit.log`
+(campos mínimos ya definidos en `autonomous-safety.md`).
+
+## Acceptance criteria
+
+- [ ] AC-1 `autonomous-safety.md` tiene sección "Handback Obligation" con la tabla de cadena por modo.
+- [ ] AC-2 `terminal-state-protocol.md` enum añade `handback` con política de reintento (no reintentar) y acción del orquestador (escalar a padre).
+- [ ] AC-3 `agent-handoff-protocol.md` documenta el schema `handback` reference-first.
+- [ ] AC-4 `scripts/handback-resolve.sh` resuelve el padre correcto para los 3 modos autónomos (exit 0 + artifact).
+- [ ] AC-5 `handback-resolve.sh` devuelve exit 5 si la cadena no termina en manual (invariante de seguridad).
+- [ ] AC-6 El artifact handback contiene solo rutas (`contexto_ref`), no contenido de los artifacts.
+- [ ] AC-7 `audit.log` registra `handback_to` en cada escalación.
+- [ ] AC-8 Tests BATS: 8+ (resolución por modo, invariante exit 5, schema reference-first, enum, audit log).
+
+## Ficheros
+
+| Acción | Path |
+|---|---|
+| MODIFY | `docs/rules/domain/autonomous-safety.md` (sección Handback Obligation) |
+| MODIFY | `docs/rules/domain/terminal-state-protocol.md` (enum + exit code) |
+| MODIFY | `docs/rules/domain/agent-handoff-protocol.md` (schema handback) |
+| MODIFY | `scripts/savia-env.sh` (exponer `savia_handback_chain()`) |
+| CREATE | `scripts/handback-resolve.sh` |
+| CREATE | `tests/test-se-332-handback.bats` |
+| CREATE | `docs/specs/SE-332-handback-obligation.spec.md` |
+
+## No modifica
+
+- Escalación de **modelo** existente (fast→mid→agent→abort) — se mantiene ortogonal.
+- `AUTONOMOUS_REVIEWER` como fallback de primer nivel.
+- Subagent Scope Guard SE-146 (DONE/DONE_WITH_CONCERNS/BLOCKED) — la handback
+  obligation lo consume, no lo reemplaza.
+- `double-optin-protocol.md` y `maker-checker-protocol.md`.
+
+## OpenCode Implementation Plan
+
+### Bindings touched
+
+| Componente | Claude Code | OpenCode v1.14 |
+|---|---|---|
+| script handback | `scripts/handback-resolve.sh` | Mismo script bash (sin binding de frontend) |
+| reglas | `docs/rules/domain/*.md` | Leídas via CLAUDE.md lazy reference |
+| tests | BATS | Mismo runner bash |
+
+### Verification protocol
+
+- [ ] Funciona en runtime OpenCode (bash puro, sin dependencia de hook)
+- [ ] Tests BATS cubren resolución de cadena + invariante exit 5 + schema
+- [ ] No añade hooks nuevos (no requiere registro en plugin `savia-gates`)
+
+### Portability classification
+
+- [x] **PURE_BASH**: lógica en bash + docs + BATS, sin bindings de frontend.
+
+## Follow-up candidates (leverage de ai-project-system aún no especificado)
+
+1. **Reference-first handoff** (SN-23) — extender `agent-notes-protocol.md` para
+   mandatar handoffs por referencia en vez de eco de cuerpo (relacionado con este
+   spec pero de alcance propio).
+2. **Default-accept para epics limpios** (§11.6) — reducir ceremonia de artefactos
+   en tribunales cuando el DoD se cumple, preservando el gate humano (Layer 8).
+3. **Model-routing policy desde telemetría** — formalizar `model-routing-policy.md`
+   alimentado por SE-313 telemetría (espejo del P9 `measure-token-burn` de ai-project).
+4. **Execution matrix "mode is not authority"** — ratificar matriz explícita de qué
+   niveles ejecutan agenticamente sin que el modo confiera autoridad de merge.
+
+## Lesson learned (potencial)
+
+> ai-project-system documenta el gap con honestidad: "a blocked autonomous instance
+> can now hand back, normatively, with the human reached by construction rather than
+> by hope". Savia hoy alcanza al humano "por esperanza" — la handback obligation lo
+> convierte en garantía estructural.

--- a/scripts/handback-resolve.sh
+++ b/scripts/handback-resolve.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# handback-resolve.sh — SE-332 Handback Obligation
+#
+# Resolves the immediate parent of a blocked autonomous instance (escalation
+# chain defined in autonomous-safety.md, Handback Obligation) and emits the
+# reference-first handback artifact.
+#
+# Usage:
+#   bash scripts/handback-resolve.sh --modo <modo|agente> --contexto-dir <dir> \
+#       [--motivo <motivo>] [--intentos-restantes <n>]
+#
+# Exit codes:
+#   0 — artifact emitted, audit trail updated
+#   2 — usage error
+#   5 — chain does NOT terminate in manual (invariant SE-332)
+set -uo pipefail
+
+usage() {
+  echo "Usage: $0 --modo <modo|agente> --contexto-dir <dir> [--motivo <motivo>] [--intentos-restantes <n>]" >&2
+  exit 2
+}
+
+MODO=""
+CONTEXTO_DIR=""
+MOTIVO="otro"
+INTENTOS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --modo)              MODO="$2"; shift 2 ;;
+    --contexto-dir)      CONTEXTO_DIR="$2"; shift 2 ;;
+    --motivo)            MOTIVO="$2"; shift 2 ;;
+    --intentos-restantes) INTENTOS="$2"; shift 2 ;;
+    --help|-h)           usage ;;
+    *)                   usage ;;
+  esac
+done
+
+if [[ -z "$MODO" || -z "$CONTEXTO_DIR" ]]; then
+  usage
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/savia-env.sh
+source "$SCRIPT_DIR/savia-env.sh"
+
+# ── 1. Resolve immediate parent (authority chain, not re-derived by hand) ────
+PADRE="$(savia_handback_chain "$MODO")"
+RC=$?
+if [[ $RC -ne 0 ]]; then
+  echo "ERROR: handback chain for modo='$MODO' does not terminate in manual (invariant SE-332)" >&2
+  exit 5
+fi
+
+# ── 2. Sanity: contexto_dir must exist (artifact refs are not invented) ──────
+if [[ ! -d "$CONTEXTO_DIR" ]]; then
+  echo "ERROR: contexto-dir '$CONTEXTO_DIR' does not exist" >&2
+  exit 2
+fi
+
+# ── 3. Reference-first refs: paths only, resolved relative to REPO_ROOT ─────
+REPO_ROOT="${SAVIA_WORKSPACE_DIR:-$(_resolve_workspace)}"
+# shellcheck disable=SC2016
+REFS_DIR="$(cd "$CONTEXTO_DIR" && pwd)"
+if [[ "$REFS_DIR" == "$REPO_ROOT"* ]]; then
+  REL_PREFIX="${REPO_ROOT%/}/"
+  REL_DIR="${REFS_DIR#"$REL_PREFIX"}"
+else
+  REL_DIR="$(realpath --relative-to="$REPO_ROOT" "$REFS_DIR" 2>/dev/null || echo "$CONTEXTO_DIR")"
+fi
+
+REF_NAMES=()
+for n in run-record.jsonl run-record.json terminal-state.jsonl results.tsv audit.log; do
+  if [[ -f "$REFS_DIR/$n" ]]; then
+    REF_NAMES+=("$n")
+  fi
+done
+if [[ ${#REF_NAMES[@]} -eq 0 ]]; then
+  REF_NAMES+=("$(basename "$REFS_DIR")")
+fi
+
+# ── 4. Emit artifact (reference-first: routes, never body) ──────────────────
+FECHA="$(date +%Y%m%d)"
+TIMESTAMP="$(date +%Y-%m-%dT%H:%M:%S%z)"
+ARTIFACT_DIR="$REPO_ROOT/output/agent-runs"
+mkdir -p "$ARTIFACT_DIR"
+ARTIFACT="$ARTIFACT_DIR/${MODO}-${FECHA}-handback.md"
+
+{
+  echo "---"
+  echo "handback:"
+  echo "  escalado_desde: $MODO"
+  echo "  escalado_a: $PADRE"
+  echo "  motivo: $MOTIVO"
+  echo "  contexto_ref:"
+  for ref in "${REF_NAMES[@]}"; do
+    echo "    - ${REL_DIR}/${ref}"
+  done
+  if [[ -n "$INTENTOS" ]]; then
+    echo "  intentos_restantes: $INTENTOS"
+  fi
+  echo "  timestamp: $TIMESTAMP"
+  echo "---"
+} > "$ARTIFACT"
+
+# ── 5. Audit trail: handback_to (autonomous-safety.md, Auditoría) ────────────
+AUDIT="$ARTIFACT_DIR/${MODO}-${FECHA}-audit.log"
+{
+  echo "handback_to=$PADRE timestamp=$TIMESTAMP motivo=$MOTIVO artifact=$ARTIFACT"
+} >> "$AUDIT"
+
+echo "handback artifact: $ARTIFACT"
+echo "handback_to: $PADRE"
+exit 0

--- a/scripts/savia-env.sh
+++ b/scripts/savia-env.sh
@@ -277,6 +277,37 @@ savia_autonomous_reviewer() {
   printf '@local-user\n'
 }
 
+# ── Handback chain resolution (SE-332) ───────────────────────────────────────
+# Resolves the IMMEDIATE parent of a blocked autonomous instance, per the
+# escalation table in autonomous-safety.md (Handback Obligation, SE-332).
+# Authority escalation is independent of model escalation and of
+# AUTONOMOUS_REVIEWER (which stays as first-level fallback).
+#
+# Returns:
+#   0 + parent name  — parent resolved (chain ends in manual by construction)
+#   5               — unknown mode: chain does NOT terminate in manual (invariant)
+savia_handback_chain() {
+  local modo="${1:-}"
+  case "$modo" in
+    overnight-sprint|code-improvement-loop|tech-research-agent)
+      savia_autonomous_reviewer
+      return 0
+      ;;
+    court-orchestrator|truth-tribunal-orchestrator|recommendation-tribunal-orchestrator)
+      printf 'dev-orchestrator\n'
+      return 0
+      ;;
+    subagent|subagente|delegado|delegate)
+      printf '%s\n' "${SAVIA_HANDBACK_PARENT:-orquestador}"
+      return 0
+      ;;
+    *)
+      # Unknown mode: no guaranteed manual terminal — invariant violation.
+      return 5
+      ;;
+  esac
+}
+
 # ── Workspace .env loader ─────────────────────────────────────────────────────
 # Loads $SAVIA_WORKSPACE_DIR/.env if it exists. Variables already present in the
 # parent environment WIN over .env (precedence: explicit env > .env > defaults).

--- a/tests/test-se-332-handback.bats
+++ b/tests/test-se-332-handback.bats
@@ -1,0 +1,147 @@
+#!/usr/bin/env bats
+# tests/test-se-332-handback.bats — SE-332 Handback Obligation
+# Ref: docs/specs/SE-332-handback-obligation.spec.md
+# Covers: resolution per mode, invariant exit 5, reference-first schema,
+# enum, audit log, artifact emission.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../scripts/handback-resolve.sh"
+ENVSH="${BATS_TEST_DIRNAME}/../scripts/savia-env.sh"
+AUTOSAFE="${BATS_TEST_DIRNAME}/../docs/rules/domain/autonomous-safety.md"
+TSP="${BATS_TEST_DIRNAME}/../docs/rules/domain/terminal-state-protocol.md"
+
+setup() {
+  set -uo pipefail
+  TMP_DIR="$(mktemp -d)"
+  export TMP_DIR
+  export SAVIA_WORKSPACE_DIR="$TMP_DIR"
+  export SAVIA_AUTONOMOUS_REVIEWER="@test-reviewer"
+}
+
+teardown() {
+  [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]] && rm -rf "$TMP_DIR"
+}
+
+# --- AC-1 / AC-2: normative docs -------------------------------------------------
+
+@test "se-332: autonomous-safety.md has Handback Obligation section" {
+  grep -q "Handback Obligation" "$AUTOSAFE"
+}
+
+@test "se-332: terminal-state-protocol.md enum includes handback" {
+  grep -q "handback" "$TSP"
+}
+
+# --- Chain resolution per mode (AC-4) -------------------------------------------
+
+@test "se-332: overnight-sprint resolves to AUTONOMOUS_REVIEWER" {
+  source "$ENVSH"
+  run savia_handback_chain "overnight-sprint"
+  [ "$status" -eq 0 ]
+  [ "$output" = "@test-reviewer" ]
+}
+
+@test "se-332: code-improvement-loop resolves to AUTONOMOUS_REVIEWER" {
+  source "$ENVSH"
+  run savia_handback_chain "code-improvement-loop"
+  [ "$status" -eq 0 ]
+  [ "$output" = "@test-reviewer" ]
+}
+
+@test "se-332: tech-research-agent resolves to AUTONOMOUS_REVIEWER" {
+  source "$ENVSH"
+  run savia_handback_chain "tech-research-agent"
+  [ "$status" -eq 0 ]
+  [ "$output" = "@test-reviewer" ]
+}
+
+@test "se-332: court-orchestrator resolves to dev-orchestrator" {
+  source "$ENVSH"
+  run savia_handback_chain "court-orchestrator"
+  [ "$status" -eq 0 ]
+  [ "$output" = "dev-orchestrator" ]
+}
+
+@test "se-332: truth-tribunal-orchestrator resolves to dev-orchestrator" {
+  source "$ENVSH"
+  run savia_handback_chain "truth-tribunal-orchestrator"
+  [ "$status" -eq 0 ]
+  [ "$output" = "dev-orchestrator" ]
+}
+
+@test "se-332: recommendation-tribunal-orchestrator resolves to dev-orchestrator" {
+  source "$ENVSH"
+  run savia_handback_chain "recommendation-tribunal-orchestrator"
+  [ "$status" -eq 0 ]
+  [ "$output" = "dev-orchestrator" ]
+}
+
+@test "se-332: subagent resolves to invoking orchestrator (env override)" {
+  export SAVIA_HANDBACK_PARENT="dev-orchestrator"
+  source "$ENVSH"
+  run savia_handback_chain "subagent"
+  [ "$status" -eq 0 ]
+  [ "$output" = "dev-orchestrator" ]
+}
+
+# --- Invariant exit 5 (AC-5) ----------------------------------------------------
+
+@test "se-332: unknown mode returns exit 5 (chain not manual)" {
+  source "$ENVSH"
+  run savia_handback_chain "unknown-mode"
+  [ "$status" -eq 5 ]
+}
+
+@test "se-332: handback-resolve.sh exits 5 for unknown mode" {
+  run bash "$SCRIPT" --modo "bogus-mode" --contexto-dir "$TMP_DIR"
+  [ "$status" -eq 5 ]
+}
+
+# --- Artifact emission + reference-first schema (AC-4/AC-6) -----------------------
+
+@test "se-332: emits artifact with reference-first contexto_ref (paths only)" {
+  mkdir -p "$TMP_DIR/runctx"
+  touch "$TMP_DIR/runctx/run-record.jsonl" "$TMP_DIR/runctx/terminal-state.jsonl"
+  run bash "$SCRIPT" --modo "overnight-sprint" --contexto-dir "$TMP_DIR/runctx" \
+    --motivo "guardrail_rechazo" --intentos-restantes 2
+  [ "$status" -eq 0 ]
+  artifact="$TMP_DIR/output/agent-runs/overnight-sprint-$(date +%Y%m%d)-handback.md"
+  [ -f "$artifact" ]
+  grep -q "escalado_a: @test-reviewer" "$artifact"
+  grep -q "motivo: guardrail_rechazo" "$artifact"
+  grep -q "intentos_restantes: 2" "$artifact"
+  grep -q "contexto_ref:" "$artifact"
+  # reference-first: contains routes, not bodies
+  grep -q "runctx/run-record.jsonl" "$artifact"
+  grep -q "runctx/terminal-state.jsonl" "$artifact"
+  ! grep -q '{"' "$artifact"
+}
+
+@test "se-332: artifact is emitted under output/agent-runs/" {
+  mkdir -p "$TMP_DIR/ctx"
+  touch "$TMP_DIR/ctx/terminal-state.jsonl"
+  bash "$SCRIPT" --modo "court-orchestrator" --contexto-dir "$TMP_DIR/ctx" >/dev/null
+  [ -d "$TMP_DIR/output/agent-runs" ]
+}
+
+# --- Audit trail (AC-7) -----------------------------------------------------------
+
+@test "se-332: audit log records handback_to" {
+  mkdir -p "$TMP_DIR/ctx"
+  touch "$TMP_DIR/ctx/terminal-state.jsonl"
+  bash "$SCRIPT" --modo "court-orchestrator" --contexto-dir "$TMP_DIR/ctx" >/dev/null
+  audit="$TMP_DIR/output/agent-runs/court-orchestrator-$(date +%Y%m%d)-audit.log"
+  [ -f "$audit" ]
+  grep -q "handback_to=dev-orchestrator" "$audit"
+}
+
+# --- Usage / failure paths ---------------------------------------------------------
+
+@test "se-332: missing --contexto-dir is a usage error (exit 2)" {
+  run bash "$SCRIPT" --modo "overnight-sprint"
+  [ "$status" -eq 2 ]
+}
+
+@test "se-332: nonexistent contexto-dir is a usage error (exit 2)" {
+  run bash "$SCRIPT" --modo "overnight-sprint" --contexto-dir "$TMP_DIR/nope"
+  [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Cuando una tarea automática se queda bloqueada — un recurso no está disponible, una protección la rechaza o el modelo no coincide — antes podía terminar en silencio o esperar eternamente a un único revisor. Este cambio introduce una escalación en cadena: la tarea bloqueada avisa a su responsable inmediato, y si este tampoco puede, sube un nivel más, terminando siempre en una persona real. Nadie queda esperando sin saber quién debe reaccionar.

Para que quien retome la tarea no tenga que reconstruir todo desde cero, se genera un "parte de entrega" que apunta a los archivos de trabajo (y solo a las rutas, sin volcar su contenido) y deja constancia en el registro de auditoría de a quién se escaló.

No se pierde nada: los límites y revisores existentes se mantienen tal cual; esta es una capa adicional de garantía. Es un cambio interno de automatización, sin interfaz nueva, y no requiere activación por parte de quien usa el sistema.

---

## Summary

SE-332 Handback Obligation: escalación de autoridad de agentes autónomos bloqueados hacia su padre inmediato, con artifact reference-first y registro de handback_to en el audit trail. 8/8 acceptance criteria cubiertos, 16 tests BATS.

**Spec:** docs/specs/SE-332-handback-obligation.spec.md (APPROVED)
**Rama:** agent/se332-handback-obligation
**Reviewer:** @monica