### PR TITLE
fix(claude-settings): valid hook schema for Claude Code + re-anchor path

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -767,12 +767,16 @@
         ]
       },
       {
-        "type": "command",
-        "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/post-digestion-kg-extract.sh",
-        "async": true,
-        "timeout": 30,
-        "statusMessage": "Extracting knowledge graph...",
-        "matcher": "Task|Bash"
+        "matcher": "Task|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/post-digestion-kg-extract.sh",
+            "async": true,
+            "timeout": 30,
+            "statusMessage": "Extracting knowledge graph..."
+          }
+        ]
       }
     ],
     "Stop": [
@@ -1032,61 +1036,6 @@
             "statusMessage": "Reloading config..."
           }
         ]
-      }
-    ],
-    "PostTurn": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/context-condenser.sh --session-log \"${CLAUDE_PROJECT_DIR:-$(pwd)}/output/session-action-log.jsonl\" 2>/dev/null &",
-            "async": true,
-            "timeout": 10,
-            "statusMessage": "SE-200: comprobando ventana de contexto...",
-            "_spec": "SE-200",
-            "_default": "off \u2014 opt-in via SAVIA_CONDENSER_ENABLED=true"
-          }
-        ]
-      },
-      {
-        "type": "command",
-        "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/post-turn-tabular-audit.sh",
-        "async": true,
-        "timeout": 10,
-        "statusMessage": "Tabular self-audit..."
-      }
-    ],
-    "PreTurn": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "[ -z \"${SAVIA_SKILL_TRIGGERS:-}\" ] || bash \"$CLAUDE_PROJECT_DIR\"/scripts/skill-keyword-detector.sh --json \"${CLAUDE_HUMAN_TURN_INPUT:-}\" 2>/dev/null | grep -v '^\\[\\]$' >&2 || true",
-            "async": true,
-            "timeout": 5,
-            "statusMessage": "SE-203: detectando skill triggers...",
-            "_spec": "SE-203",
-            "_default": "off \u2014 opt-in via SAVIA_SKILL_TRIGGERS=true"
-          }
-        ]
-      }
-    ],
-    "PreLLM": [
-      {
-        "type": "command",
-        "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/pre-llm-tabular-detect.sh",
-        "async": true,
-        "timeout": 10,
-        "statusMessage": "Detecting tabular data..."
-      }
-    ],
-    "PreCommit": [
-      {
-        "type": "command",
-        "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/pre-commit-no-new-features.sh",
-        "async": false,
-        "timeout": 10,
-        "statusMessage": "Checking for new features in open PR..."
       }
     ]
   },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -877,7 +877,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"\"/.opencode/hooks/re-anchor-redlines.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/re-anchor-redlines.sh",
             "timeout": 5,
             "statusMessage": "SPEC-193: re-anchor L1-L5 periodico..."
           }

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=8970fc392ecd6042b8db0699ae04bec0258b74d7348b18a6812d3340741176c9
-timestamp=2026-08-16T10:02:40Z
-branch=agent/se332-handback-obligation
-head_commit=f33fa5ce
-signature=844511e806178918994e27b05ded98bb00d639c161278df42a41653259bd34be
+diff_hash=68fd4799d4fce39a6424ff497c372b5e8827b124ac27c125a38b501f1e6c78ae
+timestamp=2026-08-16T13:33:11Z
+branch=agent/review-ivan-963
+head_commit=e1d9ee22
+signature=847f608771876703d07c21f651fcb44b76a1b2fd8d54f4eaa40b307c9e1ae369

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=68fd4799d4fce39a6424ff497c372b5e8827b124ac27c125a38b501f1e6c78ae
-timestamp=2026-08-16T13:33:11Z
+diff_hash=0632b9a3ccb3a4839cd6f143b6fcfdd18a261542192f52bc525d0db89f42dab2
+timestamp=2026-08-16T13:51:17Z
 branch=agent/review-ivan-963
-head_commit=e1d9ee22
-signature=847f608771876703d07c21f651fcb44b76a1b2fd8d54f4eaa40b307c9e1ae369
+head_commit=627bef12
+signature=2ed7c58caff4176a7eb4ad60fcc7f895612d53a1b164d279dd4c5fb9b784445d

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=0632b9a3ccb3a4839cd6f143b6fcfdd18a261542192f52bc525d0db89f42dab2
-timestamp=2026-08-16T13:51:17Z
+diff_hash=358c69df7cca741b7b94e58dfd36a558387b99aeb8483c7abc684bc9a07afca4
+timestamp=2026-08-16T13:55:03Z
 branch=agent/review-ivan-963
-head_commit=627bef12
-signature=2ed7c58caff4176a7eb4ad60fcc7f895612d53a1b164d279dd4c5fb9b784445d
+head_commit=c1c7f7b0
+signature=59ba5654a7f331b21e7ee2ad6bce67a363ab13397ee55a31696fba285057e087

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: 3a4550d01de2 | resources: 1364
-> 294 commands · 127 skills · 83 agents · 860 scripts
+> hash: 2025309f47f0 | resources: 1365
+> 294 commands · 127 skills · 83 agents · 861 scripts
 
 [analysis] Trace Optimize — across,distributed,optimize,rates,sampling — cmd:.claude/commands/trace-optimize.md
 [analysis] agent-activity — activity,agent,executions,recent,show — cmd:.claude/commands/agent-activity.md
@@ -773,6 +773,7 @@
 [planning] guided-work — acompaña,adaptando,guiado,necesidades,paso — cmd:.claude/commands/guided-work.md
 [planning] hallucination-fast-judge — actually,calls,cited,commands,draft — agent:.opencode/agents/hallucination-fast-judge.md
 [planning] hallucination-judge — consistency,detects,facts,invented,judge — agent:.opencode/agents/hallucination-judge.md
+[planning] handback-resolve — handback,obligation,resolve — script:scripts/handback-resolve.sh
 [planning] hashline-edit — edit,file,hashline,protection,safe — script:scripts/hashline-edit.sh
 [planning] hashline-guard — agent,edits,file,guard,hashline — script:scripts/hashline-guard.sh
 [planning] health-dashboard — adaptada,dashboard,muestra,proyecto,rápida — cmd:.claude/commands/health-dashboard.md

--- a/.scm/categories/planning.scm
+++ b/.scm/categories/planning.scm
@@ -1,5 +1,5 @@
 # planning — Savia Capability Map (L1)
-> 578 resources
+> 579 resources
 
 - **/decide-architecture** (cmd): Clasifica una tarea como WORKFLOW (deterministica) o AGENT (loop). Bias hacia workflow per Anthropic. Sugiere plantilla inicial. Mide accuracy contra corpus curado de 20 tareas.
 - **_template** (skill): TEMPLATE — copia este directorio para crear una skill nueva. NO se carga en runtime.
@@ -245,6 +245,7 @@
 - **guided-work** (cmd): Trabajo guiado — Savia te acompaña paso a paso con preguntas, adaptando el ritmo a tus necesidades
 - **hallucination-fast-judge** (agent): Recommendation Tribunal judge — verifies that entities cited in a draft (files, functions, flags, libs, paths, commands) actually exist via tool calls
 - **hallucination-judge** (agent): Truth Tribunal judge — detects invented facts via SelfCheck-style consistency
+- **handback-resolve** (script): handback-resolve.sh — SE-332 Handback Obligation
 - **hashline-edit** (script): hashline-edit.sh — Safe edit wrapper with stale-file protection (SE-149)
 - **hashline-guard** (script): hashline-guard.sh — Stale-file protection for L3 agent edits (SE-149)
 - **health-dashboard** (cmd): Dashboard de salud del proyecto unificado — Savia muestra una vista rápida adaptada al rol

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "8928b7292baa",
-  "total": 1364,
+  "hash": "46edd5acf55a",
+  "total": 1365,
   "resources": [
     {
       "category": "analysis",
@@ -10201,6 +10201,18 @@
       "kind": "agent",
       "path": ".opencode/agents/hallucination-judge.md",
       "description": "Truth Tribunal judge — detects invented facts via SelfCheck-style consistency"
+    },
+    {
+      "category": "planning",
+      "name": "handback-resolve",
+      "intents": [
+        "handback",
+        "obligation",
+        "resolve"
+      ],
+      "kind": "script",
+      "path": "scripts/handback-resolve.sh",
+      "description": "handback-resolve.sh — SE-332 Handback Obligation"
     },
     {
       "category": "planning",

--- a/CHANGELOG.d/fix-claude-settings-hooks.md
+++ b/CHANGELOG.d/fix-claude-settings-hooks.md
@@ -1,0 +1,9 @@
+---
+version_bump: patch
+section: Fixed
+---
+
+### Fixed
+
+- settings.json: wrapper hooks en PostToolUse[19], eliminar events OpenCode-only (PostTurn/PreTurn/PreLLM/PreCommit), fix path re-anchor
+

--- a/docs/hooks-coverage-matrix.md
+++ b/docs/hooks-coverage-matrix.md
@@ -6,7 +6,7 @@
 
 | Total hooks | TS Guards | Git Hook mitigated | CI Job mitigated | NONE |
 |---|---|---|---|---|
-| 109 | 17 (15.6%) | 4 | 5 | 83 |
+| 108 | 17 (15.7%) | 4 | 5 | 82 |
 
 ## Bloqueantes sin cobertura ni mitigacion
 
@@ -14,10 +14,10 @@ Ninguno — AC-2.2 satisfecho.
 
 ## Cobertura real OpenCode
 
-- **TS Guards activos**: 17/109 (15.6%)
-- **Hooks sin cobertura TS**: 83 (76.1%)
+- **TS Guards activos**: 17/108 (15.7%)
+- **Hooks sin cobertura TS**: 82 (75.9%)
   - De los cuales son bloqueantes sin ninguna mitigacion: 0
-  - Eventos no disponibles en OpenCode (degradacion aceptada): 29
+  - Eventos no disponibles en OpenCode (degradacion aceptada): 27
 
 ## Full matrix
 
@@ -56,13 +56,13 @@ Ninguno — AC-2.2 satisfecho.
 | PostToolUse | ast-quality-gate-hook.sh | no | CI_JOB | warning | CI validate-ci-local.sh |
 | PostToolUse | bus-factor-warn.sh | no | NONE | warning | degradacion_documentada: solo Claude Code |
 | PostToolUse | compress-agent-output.sh | no | NONE | warning | degradacion_documentada: solo Claude Code |
+| PostToolUse | post-digestion-kg-extract.sh | no | NONE | warning | degradacion_documentada: solo Claude Code |
 | PostToolUse | post-edit-lint.sh | no | CI_JOB | warning | CI validate-ci-local.sh |
 | PostToolUse | post-write-validate.sh | no | NONE | warning | degradacion_documentada: solo Claude Code |
 | PostToolUse | propuestas-index-refresh.sh | no | NONE | warning | degradacion_documentada: solo Claude Code |
 | PostToolUse | speculative-pre-execute.sh | no | NONE | warning | degradacion_documentada: solo Claude Code |
 | PostToolUse | twin-posttooluse.sh | no | NONE | warning | degradacion_documentada: solo Claude Code |
 | PostToolUseFailure | post-tool-failure-log.sh | no | NONE | telemetria | evento PostToolUseFailure no disponible en OpenCode — degradacion_documentada |
-| PostTurn | context-condenser.sh | no | NONE | warning | evento PostTurn no disponible en OpenCode — degradacion_documentada |
 | PreCompact | pre-compact-backup.sh | no | NONE | warning | evento PreCompact no disponible en OpenCode — degradacion_documentada |
 | PreToolUse | acm-enforcement.sh | no | NONE | bloqueante | degradacion_documentada: solo Claude Code; ACM enforcement no portado — candidato SE-254 |
 | PreToolUse | agent-dispatch-validate.sh | no | NONE | bloqueante | degradacion_documentada: solo Claude Code; agent dispatch sin gate en OpenCode — candidato SE-254 |
@@ -109,7 +109,6 @@ Ninguno — AC-2.2 satisfecho.
 | PreToolUse | auto-zoom-out.sh | si | TS_GUARD | warning | autoZoomOut |
 | PreToolUse | blast-radius-hook.sh | no | NONE | warning | degradacion_documentada: solo Claude Code |
 | PreToolUse | plan-gate.sh | no | CI_JOB | warning | CI validate-ci-local.sh |
-| PreTurn | skill-keyword-detector.sh | no | NONE | warning | evento PreTurn no disponible en OpenCode — degradacion_documentada |
 | SessionEnd | session-end-memory.sh | no | NONE | telemetria | evento SessionEnd no disponible en OpenCode — degradacion_documentada |
 | SessionStart | emergency-mode-readiness.sh | no | NONE | telemetria | evento SessionStart no disponible en OpenCode — degradacion_documentada |
 | SessionStart | session-init.sh | no | NONE | telemetria | evento SessionStart no disponible en OpenCode — degradacion_documentada |


### PR DESCRIPTION
Claude Code was ignoring parts of .claude/settings.json on every startup:

- `PostToolUse[19]` (post-digestion-kg-extract.sh) was a flat hook object without the `{matcher, hooks:[...]}` wrapper the schema requires, so the knowledge-graph hook never ran.
- `PostTurn`, `PreTurn`, `PreLLM` and `PreCommit` are OpenCode-only events; Claude Code logs a warning for each on every session start. Their scripts under `.opencode/hooks/` are untouched and keep working from OpenCode's own config.
- The SPEC-193 re-anchor hook command was `""/.opencode/hooks/re-anchor-redlines.sh` (empty quoted string), so it never executed.

The derived `docs/hooks-coverage-matrix.md` is regenerated in the same branch (hooks-coverage-matrix.sh --check would fail otherwise).

Verified: `jq` schema checks pass, BATS hook tests and the coverage-matrix check pass on the fork's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)