### PR TITLE
fix(opencode): remove provider coupling

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=624541a0e26862213f05afa95d79ce41c08d3c81f7dce5741e3b30f96bbb4804
-timestamp=2026-08-17T21:21:34Z
-branch=agent/gpt56-openai-compat-20260817
-head_commit=a3eba32a
-signature=6b4f32b71bab2638dcdac92caeb31612a4c98ccbdc1658de1c875cc91d61cf8a
+diff_hash=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+timestamp=2026-08-17T21:51:34Z
+branch=
+head_commit=
+signature=6ff0205cea015e5edef16aa28ef132aa8ae0bd97324bc96c17fa47ca0bb927b0

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-timestamp=2026-08-17T21:51:34Z
-branch=
-head_commit=
-signature=6ff0205cea015e5edef16aa28ef132aa8ae0bd97324bc96c17fa47ca0bb927b0
+diff_hash=5960fcdf834cf6dc28626b2fefb8fd3f625980da19a22ae71ed3aa26963e75c2
+timestamp=2026-08-17T21:52:17Z
+branch=agent/gpt56-openai-compat-20260817
+head_commit=8047d251
+signature=801e2f0c4981f1146bb116128d0c687701bcf28498f6d49fb60fb63905c75d96

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=2096a9aede28c26e06ae0502c902e62d6cf2b4e97b49b171e54b8565e6e92487
-timestamp=2026-08-17T19:22:28Z
-branch=agent/scl-001-aprendizaje-continuo
-head_commit=482fe809
-signature=dfabacbbabfa3753a06df5600e1ec8e7e9148787ea06cc76605641ca9cdcde8f
+diff_hash=624541a0e26862213f05afa95d79ce41c08d3c81f7dce5741e3b30f96bbb4804
+timestamp=2026-08-17T21:21:34Z
+branch=agent/gpt56-openai-compat-20260817
+head_commit=a3eba32a
+signature=6b4f32b71bab2638dcdac92caeb31612a4c98ccbdc1658de1c875cc91d61cf8a

--- a/.opencode/plugins/__tests__/dispatch-trace.test.ts
+++ b/.opencode/plugins/__tests__/dispatch-trace.test.ts
@@ -30,16 +30,16 @@ let prevPrefs: string | undefined;
 const SAMPLE_PREFS = [
   "version: 1",
   "frontend: opencode",
-  "provider: deepseek",
-  "model_heavy: deepseek/deepseek-v4-pro",
-  "model_mid:   deepseek/deepseek-v4-pro",
-  "model_fast:  deepseek/deepseek-v4-flash",
+  "provider: test-provider",
+  "model_heavy: test-provider/reasoning-model",
+  "model_mid:   test-provider/balanced-model",
+  "model_fast:  test-provider/fast-model",
 ].join("\n") + "\n";
 
 const SAMPLE_REGISTRY = {
   schema: "savia.model-registry/1.0",
   generated_at: "2026-08-08T00:00:00Z",
-  models: ["deepseek/deepseek-v4-pro", "deepseek/deepseek-v4-flash"],
+  models: ["test-provider/reasoning-model", "test-provider/balanced-model", "test-provider/fast-model"],
 };
 
 beforeAll(() => {
@@ -107,12 +107,12 @@ test("AC-7.3: dispatch.resolved para tier mid (dotnet-developer)", async () => {
   expect(events.length).toBe(before + 1);
   expect(events[events.length - 1].event).toBe("dispatch.resolved");
   expect(events[events.length - 1].agent_name).toBe("dotnet-developer");
-  expect(events[events.length - 1].resolved_model).toBe("deepseek/deepseek-v4-pro");
+  expect(events[events.length - 1].resolved_model).toBe("test-provider/balanced-model");
   expect(events[events.length - 1].schema).toBe("savia.event/1.0");
   expect(events[events.length - 1].trace_id).toBeTruthy();
   // SE-313 S3: atributos GenAI semconv presentes con provider + modelo real.
-  expect(events[events.length - 1].gen_ai_system).toBe("deepseek");
-  expect(events[events.length - 1].gen_ai_response_model).toBe("deepseek/deepseek-v4-pro");
+  expect(events[events.length - 1].gen_ai_system).toBe("test-provider");
+  expect(events[events.length - 1].gen_ai_response_model).toBe("test-provider/balanced-model");
 });
 
 test("AC-7.3: dispatch.resolved hereda ID con prefijo (explore→mid default)", async () => {
@@ -126,9 +126,9 @@ test("AC-7.3: dispatch.resolved hereda ID con prefijo (explore→mid default)", 
 });
 
 test("AC-7.6/7.7: modelo no resolubible emite dispatch.failed sin bloquear", async () => {
-  // Registry solo contiene deepseek/*; un modelo inexistente debe fallar.
+  // Registry solo contiene los modelos del fixture; uno inexistente debe fallar.
   const before = readEvents().length;
-  await dispatchTrace(taskInput("fake-agent", "claude-3-7-sonnet-20250219"), taskOutput("fake-agent", "claude-3-7-sonnet-20250219"));
+  await dispatchTrace(taskInput("fake-agent", "missing-model"), taskOutput("fake-agent", "missing-model"));
   const after = readEvents();
   expect(after.length).toBe(before + 1);
   const last = after[after.length - 1];
@@ -145,12 +145,12 @@ test("AC-7.3: guard ignora tools que no son task (no escribe telemetría)", asyn
 
 test("AC-7.3: modelo con prefijo directo se usa tal cual si existe", async () => {
   const before = readEvents().length;
-  await dispatchTrace(taskInput("direct", "deepseek/deepseek-v4-flash"), taskOutput("direct", "deepseek/deepseek-v4-flash"));
+  await dispatchTrace(taskInput("direct", "test-provider/fast-model"), taskOutput("direct", "test-provider/fast-model"));
   const events = readEvents();
   expect(events.length).toBe(before + 1);
   const last = events[events.length - 1];
   expect(last.event).toBe("dispatch.resolved");
-  expect(last.resolved_model).toBe("deepseek/deepseek-v4-flash");
+  expect(last.resolved_model).toBe("test-provider/fast-model");
 });
 
 test("SAVIA_DISPATCH_GATE=block: falla el dispatch con modelo irresoluble", async () => {
@@ -158,7 +158,7 @@ test("SAVIA_DISPATCH_GATE=block: falla el dispatch con modelo irresoluble", asyn
   process.env.SAVIA_DISPATCH_GATE = "block";
   let threw = false;
   try {
-    await dispatchTrace(taskInput("nope", "gpt-4o"), taskOutput("nope", "gpt-4o"));
+    await dispatchTrace(taskInput("nope", "missing-model"), taskOutput("nope", "missing-model"));
   } catch {
     threw = true;
   } finally {

--- a/.opencode/plugins/__tests__/gpt56-openai-compat.test.ts
+++ b/.opencode/plugins/__tests__/gpt56-openai-compat.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test";
+import {
+  Gpt56OpenAiCompatPlugin,
+  normalizeGpt56Request,
+} from "../gpt56-openai-compat.ts";
+
+test("renames legacy max_tokens for GPT-5.6 chat completions", () => {
+  const body = normalizeGpt56Request({ max_tokens: 8000 });
+
+  expect(body.max_tokens).toBeUndefined();
+  expect(body.max_completion_tokens).toBe(8000);
+});
+
+test("is idempotent when the SDK already sends the supported parameter", () => {
+  const body: Record<string, unknown> = {
+    max_tokens: 8000,
+    max_completion_tokens: 4000,
+  };
+
+  normalizeGpt56Request(body);
+  normalizeGpt56Request(body);
+
+  expect(body).toEqual({ max_completion_tokens: 4000 });
+});
+
+test("removes reasoning_effort rejected by constrained endpoints", () => {
+  const body = normalizeGpt56Request({ reasoning_effort: "high" });
+
+  expect(body.reasoning_effort).toBeUndefined();
+});
+
+test("config hook preserves an existing request transformer", async () => {
+  const unrelatedOptions = {};
+  const config = {
+    provider: {
+      unrelated: {
+        npm: "@ai-sdk/openai-compatible",
+        models: { "other-model": { name: "Other model" } },
+        options: unrelatedOptions,
+      },
+      compatible: {
+        npm: "@ai-sdk/openai-compatible",
+        models: { "gpt-5.6-example": { name: "GPT-5.6 Example" } },
+        options: {
+          transformRequestBody: (body: Record<string, unknown>) => ({
+            ...body,
+            existing: true,
+          }),
+        },
+      },
+    },
+  };
+  const plugin = await (Gpt56OpenAiCompatPlugin as any)({});
+
+  await plugin.config!(config as any);
+  const transform = config.provider.compatible.options
+    .transformRequestBody as (body: Record<string, unknown>) => Record<string, unknown>;
+  const body = transform({ max_tokens: 42 });
+
+  expect(body).toEqual({ existing: true, max_completion_tokens: 42 });
+  expect(unrelatedOptions).toEqual({});
+});
+
+test("ignores GPT-5.6 models from providers using another SDK", async () => {
+  const options = {};
+  const config = {
+    provider: {
+      incompatible: {
+        npm: "@ai-sdk/openai",
+        models: { "gpt-5.6-example": { name: "GPT-5.6 Example" } },
+        options,
+      },
+    },
+  };
+  const plugin = await (Gpt56OpenAiCompatPlugin as any)({});
+
+  await plugin.config!(config as any);
+
+  expect(options).toEqual({});
+});

--- a/.opencode/plugins/gpt56-openai-compat.ts
+++ b/.opencode/plugins/gpt56-openai-compat.ts
@@ -1,0 +1,35 @@
+import type { Plugin } from "@opencode-ai/plugin";
+
+type RequestBody = Record<string, unknown>;
+type RequestTransformer = (body: RequestBody) => RequestBody;
+
+export function normalizeGpt56Request(body: RequestBody): RequestBody {
+  if (body.max_tokens != null) {
+    body.max_completion_tokens ??= body.max_tokens;
+    delete body.max_tokens;
+  }
+
+  delete body.reasoning_effort;
+  return body;
+}
+
+export const Gpt56OpenAiCompatPlugin = (async () => ({
+  config: async (config: any) => {
+    for (const provider of Object.values(config.provider ?? {}) as any[]) {
+      const isOpenAiCompatible = provider.npm === "@ai-sdk/openai-compatible";
+      const hasGpt56Model = Object.entries(provider.models ?? {}).some(
+        ([id, model]: [string, any]) =>
+          `${id} ${model?.name ?? ""}`.toLowerCase().includes("gpt-5.6"),
+      );
+      if (!isOpenAiCompatible || !hasGpt56Model || !provider.options) continue;
+
+      const previous = provider.options.transformRequestBody as
+        | RequestTransformer
+        | undefined;
+      provider.options.transformRequestBody = (body: RequestBody) =>
+        normalizeGpt56Request(previous ? previous(body) : body);
+    }
+  },
+})) satisfies Plugin;
+
+export default Gpt56OpenAiCompatPlugin;

--- a/.opencode/plugins/guards/dispatch-trace.ts
+++ b/.opencode/plugins/guards/dispatch-trace.ts
@@ -60,17 +60,8 @@ async function loadTierMap(): Promise<Record<string, string>> {
   }
 }
 
-function withProviderPrefix(id: string, tierMap: Record<string, string>): string {
-  if (!id) return id;
-  if (id.includes("/")) return id;
-  const provider = tierMap.provider ?? "deepseek";
-  return `${provider}/${id}`;
-}
-
 function resolveModel(raw: string, tierMap: Record<string, string>): string {
-  const tier = tierMap[raw];
-  if (tier) return withProviderPrefix(tier, tierMap);
-  return withProviderPrefix(raw, tierMap);
+  return tierMap[raw] ?? raw;
 }
 
 // ── Registry check ──────────────────────────────────────────────────────────
@@ -80,7 +71,7 @@ async function registryHas(id: string): Promise<boolean> {
     const { readFile } = await import("node:fs/promises");
     const raw = await readFile(registryPath(), "utf-8");
     const reg: Registry = JSON.parse(raw);
-    if (reg.models?.includes(id)) return true;
+    if (Array.isArray(reg.models)) return reg.models.includes(id);
   } catch {
     // fall through to runtime query
   }
@@ -143,7 +134,9 @@ export async function dispatchTrace(input: ToolInput, output: ToolOutput): Promi
 
     const ok = await registryHas(resolved);
     // SE-313 S3: atributos GenAI semconv — system provider + modelo real.
-    const provider = tierMap.provider ?? "deepseek";
+    const provider = resolved.includes("/")
+      ? resolved.slice(0, resolved.indexOf("/"))
+      : (tierMap.provider ?? "unknown");
     const genAi: Record<string, string | number> = {
       gen_ai_system: provider,
       gen_ai_request_model: String(configured),

--- a/CHANGELOG.d/gpt56-openai-compat.md
+++ b/CHANGELOG.d/gpt56-openai-compat.md
@@ -1,0 +1,6 @@
+---
+version_bump: patch
+section: Fixed
+---
+
+- **OpenCode model dispatch**: replace provider-specific fallbacks with portable model tiers and normalize GPT-5.6 OpenAI-compatible requests.

--- a/opencode.json
+++ b/opencode.json
@@ -27,7 +27,7 @@
  "agent": {
    "build": {
     "mode": "primary",
-    "model": "deepseek/deepseek-v4-pro",
+    "model": "mid",
    "permission": {
     "edit": "allow",
     "task": "allow",
@@ -59,7 +59,7 @@
   },
    "plan": {
     "mode": "primary",
-    "model": "deepseek/deepseek-v4-pro",
+    "model": "mid",
    "permission": {
     "edit": "deny",
     "bash": "deny",

--- a/tests/structure/test-opencode-bootstrap.bats
+++ b/tests/structure/test-opencode-bootstrap.bats
@@ -123,6 +123,10 @@ d = json.load(open('$CONFIG'))
 # model and provider should be empty/absent so user's preferences.yaml decides
 assert 'model' not in d or not d['model'], 'model should not be pinned'
 assert 'provider' not in d or not d['provider'], 'provider should not be pinned'
+tiers = {'heavy', 'mid', 'fast'}
+invalid = {name: cfg.get('model') for name, cfg in d.get('agent', {}).items()
+           if cfg.get('model') not in tiers}
+assert not invalid, f'agent models must use capability tiers: {invalid}'
 "
 }
 


### PR DESCRIPTION
## QuÃ© hace este PR (en lenguaje no tÃ©cnico)

Este cambio permite que cada instalaciÃ³n elija sus propios modelos de inteligencia artificial sin que el repositorio imponga un proveedor concreto. Las tareas normales y de planificaciÃ³n pasan a pedir una capacidad equilibrada, y la instalaciÃ³n traduce esa capacidad al modelo configurado por cada persona. TambiÃ©n corrige el registro de ejecuciones para que identifique el proveedor real a partir del modelo resuelto y no invente uno cuando falta configuraciÃ³n. AdemÃ¡s, adapta las peticiones de una familia reciente de modelos cuando se usa un servicio compatible que todavÃ­a espera nombres de parÃ¡metros distintos. Esto evita errores al iniciar tareas o generar respuestas largas. El riesgo restante es que una instalaciÃ³n sin preferencias vÃ¡lidas seguirÃ¡ sin poder resolver sus modelos; en ese caso se conserva el aviso explÃ­cito y no se oculta el fallo. La adaptaciÃ³n se aplica automÃ¡ticamente al reiniciar OpenCode y solo actÃºa sobre servicios compatibles que declaren esa familia de modelos; retirarla consiste en eliminar el complemento.

Scope-trace: skip -- correcciÃ³n de compatibilidad y neutralidad de proveedor sin spec asociada.


## Summary

- replace provider-specific primary-agent models with capability tiers
- resolve dispatch telemetry without an implicit provider fallback
- normalize GPT-5.6 requests for compatible endpoints
- add regression coverage for model neutrality and request transformation

## Verification

- bun test: 11 passed, 0 failed
- local CI: 6 passed, 0 failed, 1 warning
- pr-plan dry run: 19 passed, 0 failed, 3 warnings
- confidentiality signature: verified
