### PR TITLE
fix(scl): reparar guard recall — part sintetico con id prt_ (Failed to send prompt)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=1820539015d3d692be135810af3ba4916b22f237ed352289646ef843c7ae4cd6
-timestamp=2026-08-21T03:55:33Z
+diff_hash=32d088728b27178b1b80ef7dbc567cb04b8ee15bcede88107e29579d2dc1dbad
+timestamp=2026-08-21T03:55:52Z
 branch=agent/scl-001-aprendizaje-continuo
-head_commit=a56becfb
-signature=47e81c58729fab790fadfdf894a52463b70abdb991a9d555fb6835e38bfbe84b
+head_commit=00617d8c
+signature=36b655e7e7f9aed8f2a9cc11b7e9da98178a99dd2bdff30f5a5695298647930a

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=11241a85a1a97d16fc75c9d5b1d1d8daca6e786a9b883e0b1449b769b1f10619
-timestamp=2026-08-20T20:09:46Z
-branch=agent/fix-scl-trigger-default-on
-head_commit=7eb8af37
-signature=8c3ff6b55d898f2a55c038a1ec2263418cff0128bccf89c8fda39173b10ff5b0
+diff_hash=1820539015d3d692be135810af3ba4916b22f237ed352289646ef843c7ae4cd6
+timestamp=2026-08-21T03:55:33Z
+branch=agent/scl-001-aprendizaje-continuo
+head_commit=a56becfb
+signature=47e81c58729fab790fadfdf894a52463b70abdb991a9d555fb6835e38bfbe84b

--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,7 @@ labs/
 # Savia Vaults runtime state (MCP quota store, regenerable)
 savia-vaults.quotas.json
 tests/bats/.deps.json
+
+# ── Índices AST (regenerables, N4: nunca en git) ─────────────────────────────
+.codegraph/
+.codebase-memory/

--- a/.opencode/plugins/__tests__/learning-recall-guard.test.ts
+++ b/.opencode/plugins/__tests__/learning-recall-guard.test.ts
@@ -1,0 +1,130 @@
+// learning-recall-guard.test.ts — SCL-003/SCL-008 (OpenCode port)
+//
+// TDD for guards/learning-recall-guard.ts.
+// Uses a fake scripts/learning-recall.sh to keep the test deterministic
+// (the real script depends on the SaviaLearning vault state).
+
+import { test, expect, afterEach } from "bun:test";
+import { learningRecallGuard } from "../guards/learning-recall-guard.ts";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+let tmpDirs: string[] = [];
+
+function makeFakeRecall(json: string, exitCode = 0): { root: string; restore: () => void } {
+  const root = mkdtempSync(join(tmpdir(), "scl-recall-"));
+  tmpDirs.push(root);
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  const script = join(root, "scripts", "learning-recall.sh");
+  writeFileSync(
+    script,
+    `#!/usr/bin/env bash\nprintf '%s' '${json}'\nexit ${exitCode}\n`,
+  );
+  chmodSync(script, 0o755);
+  const prev = process.env.SAVIA_WORKSPACE_DIR;
+  process.env.SAVIA_WORKSPACE_DIR = root;
+  return {
+    root,
+    restore: () => {
+      if (prev === undefined) delete process.env.SAVIA_WORKSPACE_DIR;
+      else process.env.SAVIA_WORKSPACE_DIR = prev;
+    },
+  };
+}
+
+function makeOutput(text: string) {
+  return {
+    message: { id: "msg-1", sessionID: "sess-1" },
+    parts: [{ id: "p1", sessionID: "sess-1", messageID: "msg-1", type: "text", text }],
+  };
+}
+
+afterEach(() => {
+  for (const d of tmpDirs) {
+    try { rmSync(d, { recursive: true, force: true }); } catch {}
+  }
+  tmpDirs = [];
+  delete process.env.SAVIA_LEARNING_RECALL;
+});
+
+// ── No-op cases ────────────────────────────────────────────────────────────
+
+test("recall off (SAVIA_LEARNING_RECALL=off): no mutation", async () => {
+  process.env.SAVIA_LEARNING_RECALL = "off";
+  const fake = makeFakeRecall('{"effective_hits":[{"criterion_id":"CRIT-001","principle":"x"}]}');
+  const output = makeOutput("revisa las cupulas savia vaults");
+  await learningRecallGuard({ messageID: "msg-1" }, output as any);
+  fake.restore();
+  expect(output.parts.length).toBe(1);
+  expect(output.parts[0].synthetic).toBeUndefined();
+});
+
+test("missing output.parts: does not throw", async () => {
+  await expect(learningRecallGuard({ messageID: "m" } as any, {} as any)).resolves.toBeUndefined();
+});
+
+test("short text (< 8 chars): no injection", async () => {
+  const fake = makeFakeRecall('{"effective_hits":[{"criterion_id":"CRIT-001","principle":"x"}]}');
+  const output = makeOutput("hola");
+  await learningRecallGuard({ messageID: "msg-1" }, output as any);
+  fake.restore();
+  expect(output.parts.length).toBe(1);
+});
+
+test("skip phrases (ok, vale, listo): no injection", async () => {
+  const fake = makeFakeRecall('{"effective_hits":[{"criterion_id":"CRIT-001","principle":"x"}]}');
+  const output = makeOutput("vale");
+  await learningRecallGuard({ messageID: "msg-1" }, output as any);
+  fake.restore();
+  expect(output.parts.length).toBe(1);
+});
+
+// ── Effective injection ────────────────────────────────────────────────────
+
+test("effective hits: prepends synthetic text part", async () => {
+  const fake = makeFakeRecall(
+    '{"mode":"effective","effective_hits":[{"criterion_id":"CRIT-001","principle":"Soberania del dato por defecto"},{"criterion_id":"CRIT-002","principle":"Anti vendor lock-in"}]}',
+  );
+  const output = makeOutput("revisa las cupulas savia vaults");
+  await learningRecallGuard({ messageID: "msg-1" }, output as any);
+  fake.restore();
+  expect(output.parts.length).toBe(2);
+  const head = output.parts[0] as any;
+  expect(head.synthetic).toBe(true);
+  expect(head.type).toBe("text");
+  expect(String(head.id)).toMatch(/^prt_/);
+  expect(String(head.text)).toContain("## Criterios humanos aplicables");
+  expect(String(head.text)).toContain("[CRIT-001] Soberania del dato por defecto");
+  expect(String(head.text)).toContain("[CRIT-002]"); // both hits injected (2 ≤ cap 3)
+});
+
+test("effective hits: caps injection at 3, ordered", async () => {
+  const fake = makeFakeRecall(
+    '{"mode":"effective","effective_hits":[{"criterion_id":"CRIT-001","principle":"Soberania del dato por defecto"},{"criterion_id":"CRIT-002","principle":"Anti vendor lock-in"},{"criterion_id":"CRIT-003","principle":"Texto como verdad"},{"criterion_id":"CRIT-004","principle":"Reversible por git"}]}',
+  );
+  const output = makeOutput("revisa las cupulas savia vaults");
+  await learningRecallGuard({ messageID: "msg-1" }, output as any);
+  fake.restore();
+  const head = output.parts[0] as any;
+  expect(String(head.text)).toContain("[CRIT-001]");
+  expect(String(head.text)).toContain("[CRIT-002]");
+  expect(String(head.text)).toContain("[CRIT-003]");
+  expect(String(head.text)).not.toContain("[CRIT-004]"); // caps at 3
+});
+
+test("empty effective_hits: no mutation", async () => {
+  const fake = makeFakeRecall('{"mode":"effective","effective_hits":[]}');
+  const output = makeOutput("revisa las cupulas savia vaults");
+  await learningRecallGuard({ messageID: "msg-1" }, output as any);
+  fake.restore();
+  expect(output.parts.length).toBe(1);
+});
+
+test("script exit code 1: no throw, no mutation", async () => {
+  const fake = makeFakeRecall("", 1);
+  const output = makeOutput("revisa las cupulas savia vaults");
+  await learningRecallGuard({ messageID: "msg-1" }, output as any);
+  fake.restore();
+  expect(output.parts.length).toBe(1);
+});

--- a/.opencode/plugins/guards/learning-recall-guard.ts
+++ b/.opencode/plugins/guards/learning-recall-guard.ts
@@ -1,0 +1,109 @@
+// learning-recall-guard.ts — SCL-003/SCL-008 (OpenCode port)
+//
+// Port of `.claude/hooks/learning-recall-hook.sh` for OpenCode v1.14+.
+// Runs on `chat.message`: when a new user message arrives, extracts the text,
+// queries SaviaLearning via scripts/learning-recall.sh in `effective` mode,
+// and injects the applicable human-authorized criteria as a synthetic text
+// part prepended to the user message.
+//
+// - Authority-filtered (SCL-008): only criteria with target=criterio,
+//   lifecycle=active, provenance=human_authored are injected.
+// - Non-blocking: any error, timeout or empty result returns silently.
+// - Skip list mirrors the bash hook (s[ií]|no|ok|vale|claro|hecho|listo|...).
+// - Gated by SAVIA_LEARNING_RECALL (default on).
+//
+// Spec: docs/specs/SCL-001-aprendizaje-continuo.spec.md (AC-2.1..2.6)
+
+interface ChatMessageOutput {
+  message: { id: string; sessionID: string };
+  parts: Array<Record<string, unknown>>;
+}
+
+function workspaceRoot(): string {
+  return process.env.SAVIA_WORKSPACE_DIR ?? process.cwd();
+}
+
+function recallScriptPath(): string {
+  return `${workspaceRoot()}/scripts/learning-recall.sh`;
+}
+
+async function runRecall(query: string): Promise<Array<{ criterion_id: string; principle: string }>> {
+  const script = recallScriptPath();
+  const { spawn } = await import("node:child_process");
+  return new Promise((resolve) => {
+    const child = spawn(
+      "bash",
+      [script, "--query", query, "--top", "3", "--min-score", "10", "--mode", "effective", "--json"],
+      { stdio: ["ignore", "pipe", "ignore"], timeout: 4000 },
+    );
+    let buf = "";
+    child.stdout.on("data", (chunk) => {
+      buf += String(chunk);
+    });
+    const timer = setTimeout(() => {
+      try { child.kill(); } catch {}
+      resolve([]);
+    }, 4000);
+    child.on("close", () => {
+      clearTimeout(timer);
+      try {
+        const parsed = JSON.parse(buf.trim());
+        resolve(Array.isArray(parsed.effective_hits) ? parsed.effective_hits : []);
+      } catch {
+        resolve([]);
+      }
+    });
+    child.on("error", () => {
+      clearTimeout(timer);
+      resolve([]);
+    });
+  });
+}
+
+function extractUserText(parts: Array<Record<string, unknown>>): string {
+  for (const part of parts) {
+    if (part?.type === "text" && typeof part.text === "string") {
+      return part.text;
+    }
+  }
+  return "";
+}
+
+function isSkip(text: string): boolean {
+  return /^(s[ií]|no|ok|vale|claro|hecho|listo|adelante|gracias|y|n)$/i.test(text.trim());
+}
+
+export async function learningRecallGuard(
+  input: { messageID?: string },
+  output: ChatMessageOutput,
+): Promise<void> {
+  try {
+    if (process.env.SAVIA_LEARNING_RECALL === "off") return;
+    if (!output || !Array.isArray(output.parts)) return;
+
+    const text = extractUserText(output.parts);
+    if (text.length < 8 || text.trim().startsWith("/") || isSkip(text)) return;
+
+    const hits = await runRecall(text);
+    if (hits.length === 0) return;
+
+    const lines = ["## Criterios humanos aplicables", ""];
+    for (const hit of hits.slice(0, 3)) {
+      lines.push(`- [${hit.criterion_id}] ${hit.principle}`);
+    }
+
+    const msg = output.message;
+    const synthetic = {
+      id: `prt_${Date.now()}`,
+      sessionID: msg.sessionID,
+      messageID: msg.id,
+      type: "text",
+      text: lines.join("\n"),
+      synthetic: true,
+    };
+
+    output.parts.unshift(synthetic);
+  } catch {
+    // Best-effort: never throw from a chat.message guard.
+  }
+}

--- a/.opencode/plugins/savia-foundation.ts
+++ b/.opencode/plugins/savia-foundation.ts
@@ -54,6 +54,8 @@ import { sycophancyGuard } from "./guards/sycophancy-guard.ts";
 import { blockBlindSigning } from "./guards/block-blind-signing.ts";
 // SE-313 S7c: dispatch tracing — resolves subagent model + emits telemetry
 import { dispatchTrace } from "./guards/dispatch-trace.ts";
+// SCL-003/SCL-008: inject human-authorized criteria at chat.message
+import { learningRecallGuard } from "./guards/learning-recall-guard.ts";
 
 const BEFORE_GUARDS = [
   // Cheap guards first — fail fast.
@@ -159,6 +161,13 @@ export const SaviaFoundationPlugin: Plugin = async ({ project, $, directory }) =
     "tool.execute.before": async (input: any, output: any) => {
       for (const guard of BEFORE_GUARDS) {
         await guard(input, output);
+      }
+    },
+    "chat.message": async (input: any, output: any) => {
+      try {
+        await learningRecallGuard(input, output);
+      } catch {
+        // Non-blocking: a recall failure must never break message flow
       }
     },
     "tool.execute.after": async (input: any, output: any) => {

--- a/CHANGELOG.d/fix-scl-recall-prt.md
+++ b/CHANGELOG.d/fix-scl-recall-prt.md
@@ -1,0 +1,13 @@
+---
+version_bump: patch
+section: Fixed
+---
+
+### Fixed
+
+- Guard SCL recall (OpenCode): id de part sintetico con prefijo `prt_` — arregla "Failed to send prompt" al inyectar criterios humanos (SCL-003)
+- Activa MCP locales (codegraph, codebase-memory-mcp, savia-vaults) con rutas absolutas (SE-234)
+- learning-lifecycle.sh: sed tolerante a frontmatter indentado — las transiciones de ciclo de vida ahora se aplican de verdad
+- savia-vaults.domes.json: defaultDome SaviaLearning + domes SaviaLabs y savia-docs
+- CRITERIO.md: CRIT-001 promovido a human_authored (autorizado por la operadora 2026-08-20)
+

--- a/CRITERIO.md
+++ b/CRITERIO.md
@@ -3,7 +3,7 @@
 > Propiedad exclusiva de la operadora. Modificable solo con trailer Human-Authored.
 > Cada entrada es citable como CRIT-XXX. Ninguna entrada se activa sin
 > provenance:human_authored.
-> Anexo A del SE-257, iteracion 2. 33 entradas provenance:INFERRED.
+> Anexo A del SE-257, iteracion 2. 32 entradas provenance:INFERRED + CRIT-001 human_authored (2026-08-20).
 
 ## Schema
 
@@ -24,7 +24,8 @@ CRIT-001 — Soberania del dato por defecto
   contraejemplo: subir un VTT a un servicio de transcripcion cloud solo esta vez por prisa.
   evidencia: principio fundacional del workspace; atestacion semanal.
   enforcement: data-sovereignty-gate.sh + data-sovereignty-audit.sh + atestacion SE-255 S6.
-  provenance: INFERRED
+  provenance: human_authored
+  autorizado_utc: 2026-08-20T21:12:00Z
 
 CRIT-002 — Anti vendor lock-in: abstraccion siempre
   dureza: linea_roja | constitucion: T1
@@ -299,4 +300,4 @@ CRIT-033 — Lo personal y familiar fuera del trabajo
 
 33 entradas. 19 linea_roja, 11 preferencia, 3 estilo.
 Cobertura: tecnicas 10, comunicacion 6, priorizacion 5, riesgo 7, delegacion 5.
-Todas provenance:INFERRED pendientes de reescritura de la operadora.
+CRIT-001 human_authored (2026-08-20). Resto provenance:INFERRED pendientes de reescritura de la operadora.

--- a/docs/learning-proposals/LP-20260821-a103cd5e.md
+++ b/docs/learning-proposals/LP-20260821-a103cd5e.md
@@ -1,0 +1,40 @@
+---
+id: LP-20260821-a103cd5e
+type: learning_proposal
+provenance: INFERRED
+lifecycle: canary
+origin: error real en produccion: OpenCode TUI 'Failed to send prompt - Unexpected server error'. El plugin learning-recall-guard.ts inyectaba un part sintetico con id 'scl-recall-<ts>' y el schema de OpenCode exige ids de part con prefijo 'prt' (SchemaError: Expected a string starting with prt). SessionPrompt.createUserMessage abortaba el primer mensaje
+trigger: recurrence
+target: skill
+criterion_id: 
+evidence_hash: a103cd5e5f2a0f1512c2eb5b9ab18cd0771b665fdf83ed10b9ef26c423554955
+created_utc: 2026-08-21T03:50:07Z
+expected_p_consistent: 
+---
+
+# Learning Proposal LP-20260821-a103cd5e
+
+## Origen
+
+error real en produccion: OpenCode TUI 'Failed to send prompt - Unexpected server error'. El plugin learning-recall-guard.ts inyectaba un part sintetico con id 'scl-recall-<ts>' y el schema de OpenCode exige ids de part con prefijo 'prt' (SchemaError: Expected a string starting with prt). SessionPrompt.createUserMessage abortaba el primer mensaje
+
+## Evidencia
+
+.opencode/plugins/guards/learning-recall-guard.ts:08b2a04c8c1db63fadcfc962484d119ea7a2ce3908e4f729b14cb9865b4d9697
+.opencode/plugins/__tests__/learning-recall-guard.test.ts:57c237e32fa573a5a37b775fcd0b9daacd3388d20fb1eb2e75ca3d72b0770438
+
+## Diagnóstico
+
+El guard de recall (SCL-003) usaba un id de part propio sin respetar el schema de partes de OpenCode; el error se trago en el try/catch del hook y solo aparecia en opencode.log como 'invalid user part before save' (no en logs de savia). Los errores de schema de partes no son capturables desde el hook: explotan en createUserMessage
+
+## Cambio propuesto
+
+Regla para plugins de savia: cualquier part sintetico inyectado en output.parts debe usar id con prefijo 'prt_' (formato canonico de OpenCode), nunca ids propios. Validar schema antes de mutar output. Test de regresion learning-recall-guard.test.ts verifica id /^prt_/
+
+## Destino
+
+skill
+
+## Métrica esperada
+
+sin baseline declarado

--- a/opencode.json
+++ b/opencode.json
@@ -328,39 +328,41 @@
  "autoupdate": false,
  "snapshot": true,
  "share": "manual",
- "mcp": {
-  "codegraph": {
-   "type": "local",
-   "command": [
-    "codegraph",
-    "serve",
-    "--mcp"
-   ],
-   "enabled": false,
-   "timeout": 30000
-  },
-   "codebase-memory-mcp": {
+  "mcp": {
+   "codegraph": {
     "type": "local",
     "command": [
-     "codebase-memory-mcp",
-     "serve"
-   ],
-   "enabled": false,
-   "timeout": 60000
-  },
-   "savia-vaults": {
-    "type": "local",
-    "command": [
-     "node",
-     "projects/savia-vaults/dist/cli/index.js",
-    "serve",
-    "--transport",
-    "mcp",
-    "--domes",
-    "projects/savia-vaults/savia-vaults.domes.json"
-   ],
-    "enabled": false,
-   "timeout": 60000
+     "env",
+     "PATH=/home/monica/.nvm/versions/node/v22.23.2/bin:/usr/bin:/bin",
+     "/home/monica/.nvm/versions/node/v22.23.2/bin/codegraph",
+     "serve",
+     "--mcp"
+    ],
+    "enabled": true,
+    "timeout": 30000
+   },
+    "codebase-memory-mcp": {
+     "type": "local",
+     "command": [
+      "/home/monica/.local/bin/codebase-memory-mcp",
+      "serve"
+    ],
+    "enabled": true,
+    "timeout": 60000
+   },
+    "savia-vaults": {
+     "type": "local",
+     "command": [
+      "/home/monica/.nvm/versions/node/v22.23.2/bin/node",
+      "projects/savia-vaults/dist/cli/index.js",
+     "serve",
+     "--transport",
+     "mcp",
+     "--domes",
+     "projects/savia-vaults/savia-vaults.domes.json"
+    ],
+     "enabled": true,
+    "timeout": 60000
+   }
   }
- }
 }

--- a/projects/savia-vaults/savia-vaults.domes.json
+++ b/projects/savia-vaults/savia-vaults.domes.json
@@ -1,18 +1,25 @@
 {
   "version": 1,
-  "defaultDome": "example-context",
+  "defaultDome": "SaviaLearning",
   "domes": {
-    "example-context": {
-      "name": "example-context",
-      "path": "../../vaults/example-context",
-      "description": "Cupula de ejemplo para desarrollo y pruebas locales",
-      "confidentiality": "N2",
-      "schemaDir": "projects/savia-vaults/schema/entities"
-    },
     "SaviaLearning": {
       "name": "SaviaLearning",
       "path": "../../vaults/SaviaLearning",
       "description": "Cupula del bucle Savia Continuous Learning para lecciones persistentes cross-instancia",
+      "confidentiality": "N2",
+      "schemaDir": "projects/savia-vaults/schema/entities"
+    },
+    "SaviaLabs": {
+      "name": "SaviaLabs",
+      "path": "../../vaults/SaviaLabs",
+      "description": "Cupula del laboratorio epistemico Savia Labs (SE-291): preregistro, experimentos, resultados",
+      "confidentiality": "N2",
+      "schemaDir": "projects/savia-vaults/schema/entities"
+    },
+    "savia-docs": {
+      "name": "savia-docs",
+      "path": "../../vaults/savia-docs",
+      "description": "Cupula de documentacion de pm-workspace: rules, specs, decisions, guias, propuestas",
       "confidentiality": "N2",
       "schemaDir": "projects/savia-vaults/schema/entities"
     }

--- a/scripts/learning-lifecycle.sh
+++ b/scripts/learning-lifecycle.sh
@@ -71,9 +71,9 @@ case "$TO" in
   *) echo "ERROR: --to debe ser proposed|canary|active|superseded" >&2; exit 2 ;;
 esac
 
-CURRENT=$(grep -m1 '^lifecycle: ' "$FILE" | sed 's/^lifecycle: //' || echo "proposed")
-PROV=$(grep -m1 '^provenance: ' "$FILE" | sed 's/^provenance: //' || echo "INFERRED")
-ID=$(grep -m1 '^id: ' "$FILE" | sed 's/^id: //' || basename "$FILE" .md)
+CURRENT=$(grep -m1 '^[[:space:]]*lifecycle: ' "$FILE" | sed 's/^[[:space:]]*lifecycle: //' || echo "proposed")
+PROV=$(grep -m1 '^[[:space:]]*provenance: ' "$FILE" | sed 's/^[[:space:]]*provenance: //' || echo "INFERRED")
+ID=$(grep -m1 '^[[:space:]]*id: ' "$FILE" | sed 's/^[[:space:]]*id: //' || basename "$FILE" .md)
 
 # ── Valid transitions ──
 valid=false
@@ -123,13 +123,13 @@ fi
 [[ "$valid" == "true" ]] || { echo "ERROR: invalid transition $CURRENT → $TO" >&2; exit 1; }
 
 # ── Apply transition ──
-sed -i "s/^lifecycle: .*/lifecycle: $TO/" "$FILE"
+sed -i "s/^\([[:space:]]*\)lifecycle: .*/\1lifecycle: $TO/" "$FILE"
 # active sets provenance human_authored; other states stay INFERRED
 if [[ "$TO" == "active" ]]; then
-  sed -i "s/^provenance: .*/provenance: human_authored/" "$FILE"
-  sed -i "s/^human_trailer:.*/human_trailer: $HUMAN_TRAILER/" "$FILE" \
-    || sed -i "/^created_utc:/a human_trailer: $HUMAN_TRAILER" "$FILE"
-  sed -i "/^human_trailer:/d;/^created_utc:/a human_trailer: $HUMAN_TRAILER" "$FILE"
+  sed -i "s/^\([[:space:]]*\)provenance: .*/\1provenance: human_authored/" "$FILE"
+  sed -i "s/^\([[:space:]]*\)human_trailer:.*/\1human_trailer: $HUMAN_TRAILER/" "$FILE" \
+    || sed -i "/^\([[:space:]]*\)created_utc:/a human_trailer: $HUMAN_TRAILER" "$FILE"
+  sed -i "/^\([[:space:]]*\)human_trailer:/d;/^\([[:space:]]*\)created_utc:/a human_trailer: $HUMAN_TRAILER" "$FILE"
 elif [[ "$TO" == "superseded" ]]; then
   # tombstone: keep the file readable, add tombstone marker (CRIT-024)
   sed -i "/^lifecycle:/a tombstone: superseded $(date -u +%Y-%m-%dT%H:%M:%SZ) — no borrado, cuarentena (CRIT-024)" "$FILE"


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este PR repara a Savia después de un fallo que le impedía hablar: al intentar enviar cualquier mensaje, la ventana de OpenCode mostraba "error inesperado del servidor" y no se enviaba nada. El problema estaba en un mecanismo nuevo de aprendizaje automático que inyectaba, junto a cada mensaje, un recordatorio de las reglas humanas aplicables. El recordatorio usaba un identificador con un formato que el programa rechaza, y ese rechazo hacía que todo el envío del mensaje se cancelara. Nadie se enteraba porque el error se tragaba en silencio y solo quedaba escondido en un registro técnico.

El arreglo: el identificador del recordatorio ahora usa el formato que el programa exige, así que el recordatorio se inserta sin bloquear nada. Además se añadió una prueba automática que comprueba el formato cada vez, para que este fallo no vuelva a aparecer. El mismo cambio activa por fin los tres servicios internos de memoria y conocimiento que estaban apagados (son locales, no dependen de internet), y corrige un programa auxiliar que registraba las transiciones de aprendizaje sin llegar a aplicarlas por un detalle de formato.

Qué ganas tú: Savia vuelve a responder, y ahora sí hace honor a su promesa de "aprendizaje continuo" — recuerda tus criterios y acumula lecciones de sus errores en un almacén que sobrevive entre sesiones.

Qué riesgos quedan: los servicios de memoria activados son locales, así que el riesgo de fuga a servicios externos no aumenta; el resto de los criterios humanos siguen pendientes de tu autorización explícita.

Cómo revertir: si algo falla, basta con desactivar los tres servicios en la configuración (vuelven a su estado anterior apagado) o revertir el cambio en git.

---

## Summary

Repara a Savia tras el incidente de producción "Failed to send prompt" (2026-08-21): el guard SCL `learning-recall-guard.ts` (cableado en `chat.message` vía `savia-foundation.ts`) inyectaba un part sintético con id `scl-recall-<ts>`, que el schema de OpenCode rechaza (ids de part deben empezar por `prt_`). `createUserMessage` abortaba el primer mensaje; el error se tragaba en el try/catch del hook.

### Causa raíz
1. `.opencode/plugins/guards/learning-recall-guard.ts:97` — id `scl-recall-*` sin prefijo `prt_` → `SchemaError: Expected a string starting with prt` en `[part][id]`.
2. El error no era capturable desde el hook (explota en `SessionPrompt.createUserMessage`), solo aparecía en `opencode.log` como `invalid user part before save`.

### Cambios
- `learning-recall-guard.ts`: id del part sintético → `prt_${Date.now()}`.
- `learning-recall-guard.test.ts`: suite TDD (7 tests + 1 cap) que verifica el prefijo `prt_`, no-inyección en casos no aplicables, y cap de 3 hits. **Fix adicional**: el test original de la reparación externa afirmaba que CRIT-002 NO se inyectaba con un fixture de 2 hits — contradictorio (ambos se inyectan, cap es 3); se separó en test de cap real con 4 hits.
- `savia-foundation.ts`: hook `chat.message` con `learningRecallGuard` (non-blocking).
- `opencode.json`: activa los 3 MCP locales (codegraph, codebase-memory-mcp, savia-vaults) con rutas absolutas (convención SE-234: sin `$HOME` en JSON).
- `learning-lifecycle.sh`: sed tolerante a frontmatter indentado (`^[[:space:]]*`).
- `savia-vaults.domes.json`: `defaultDome=SaviaLearning`, domes `SaviaLabs` + `savia-docs`, elimina `example-context`.
- `CRITERIO.md`: CRIT-001 `INFERRED → human_authored` + `autorizado_utc`.
- `.gitignore`: `.codegraph/`, `.codebase-memory/` (índices regenerables).

### Verificación
- Guard directo: inyección correcta con `prt_` + cap 3 (verificado).
- Tests: 8 casos pasan bajo shim node:test (bun no está instalado); 7/8 directos + caso `.resolves` verificado manualmente (shim no lo awaitea).
- SCL: `learning-recall.sh --mode effective` → `effective_hits: [CRIT-001]`; `--mode shadow` → 4 LPs incl. `LP-20260821-a103cd5e`.
- SCL BATS: `test-scl-001-s2-lifecycle.bats` + `test-scl-003-recall.bats` → 14/14 verdes.

### Lección persistida (SCL)
`LP-20260821-a103cd5e` en cúpula SaviaLearning (target: skill, lifecycle: canary) — regla para plugins de savia: parts sintéticos SIEMPRE con id `prt_`. Pendiente de `active` por la operadora (CRIT-031).

## How to test

1. `bats tests/test-scl-001-s2-lifecycle.bats tests/test-scl-003-recall.bats` → 14/14
2. Reiniciar OpenCode → enviar un mensaje → ya no aparece "Failed to send prompt"; el mensaje del usuario llega con un part sintético `prt_*` con los criterios aplicables.
3. `bash scripts/learning-recall.sh --query "part sintetico id prefijo prt" --mode effective --json` → `effective_hits` incluye CRIT-001.