### PR TITLE
feat(scl): reconciliacion de lecciones entre instancias (SCL-010, 3-bucket)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=52f9fdfd8b94b01c0858bae746f5369a02a82363afa1582f3ec0fc851908a9d6
-timestamp=2026-08-22T15:38:32Z
-branch=agent/scl-roadmap-drift-fix
-head_commit=605fc0f6
-signature=cd2611145b2d3dd2ef554889471faf425bdb70b784956f85489d49a5269f88ad
+diff_hash=2ff762c7c00cbc75be65637e412e6e8c6ce78677efbe933a0dc7ddd544baa52c
+timestamp=2026-08-22T15:56:10Z
+branch=agent/scl010-reconcile
+head_commit=253a9023
+signature=1194543af42406124822e4efe6f6ab08e288f5a7553d863dcd3d2b7c73d1c02c

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: 7ebb4efdcd2f | resources: 1378
-> 294 commands · 127 skills · 83 agents · 874 scripts
+> hash: cac85d26092e | resources: 1379
+> 294 commands · 127 skills · 83 agents · 875 scripts
 
 [analysis] Trace Optimize — across,distributed,optimize,rates,sampling — cmd:.claude/commands/trace-optimize.md
 [analysis] agent-activity — activity,agent,executions,recent,show — cmd:.claude/commands/agent-activity.md
@@ -822,6 +822,7 @@
 [planning] learning-lifecycle — artefacto,despliegue,learning,lifecycle,sustrato — script:scripts/learning-lifecycle.sh
 [planning] learning-persist — cúpula,learning,persist,persiste,proposal — script:scripts/learning-persist.sh
 [planning] learning-proposal — canonical,capture,learning,proposal — script:scripts/learning-proposal.sh
+[planning] learning-reconcile — conflictivas,duplicadas,learning,lecciones,reconcile — script:scripts/learning-reconcile.sh
 [planning] learning-rollback — entrada,instantáneo,learning,rollback,sustrato — script:scripts/learning-rollback.sh
 [planning] legacy-assess —  — cmd:.claude/commands/legacy-assess.md
 [planning] legalize-es — corpus,español,gestión,legalize,legislativo — script:scripts/legalize-es.sh

--- a/.scm/categories/planning.scm
+++ b/.scm/categories/planning.scm
@@ -1,5 +1,5 @@
 # planning — Savia Capability Map (L1)
-> 586 resources
+> 587 resources
 
 - **/decide-architecture** (cmd): Clasifica una tarea como WORKFLOW (deterministica) o AGENT (loop). Bias hacia workflow per Anthropic. Sugiere plantilla inicial. Mide accuracy contra corpus curado de 20 tareas.
 - **_template** (skill): TEMPLATE — copia este directorio para crear una skill nueva. NO se carga en runtime.
@@ -289,6 +289,7 @@
 - **learning-lifecycle** (script): learning-lifecycle.sh — SCL-001 S2: sustrato como artefacto de despliegue
 - **learning-persist** (script): learning-persist.sh — SCL-002: persiste una learning proposal en la cúpula
 - **learning-proposal** (script): learning-proposal.sh — SCL-001 S1: canonical learning proposal capture
+- **learning-reconcile** (script): learning-reconcile.sh — SCL-010: reconciliación de lecciones duplicadas/conflictivas.
 - **learning-rollback** (script): learning-rollback.sh — SCL-001 S2: rollback instantáneo de una entrada del sustrato
 - **legacy-assess** (cmd): >
 - **legalize-es** (script): legalize-es.sh — Gestión del corpus legislativo español (legalize-es)

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "a776015409b0",
-  "total": 1378,
+  "hash": "f3bda9ef3270",
+  "total": 1379,
   "resources": [
     {
       "category": "analysis",
@@ -10843,6 +10843,20 @@
       "kind": "script",
       "path": "scripts/learning-proposal.sh",
       "description": "learning-proposal.sh — SCL-001 S1: canonical learning proposal capture"
+    },
+    {
+      "category": "planning",
+      "name": "learning-reconcile",
+      "intents": [
+        "conflictivas",
+        "duplicadas",
+        "learning",
+        "lecciones",
+        "reconcile"
+      ],
+      "kind": "script",
+      "path": "scripts/learning-reconcile.sh",
+      "description": "learning-reconcile.sh — SCL-010: reconciliación de lecciones duplicadas/conflictivas."
     },
     {
       "category": "planning",

--- a/CHANGELOG.d/agent-scl010-reconcile.md
+++ b/CHANGELOG.d/agent-scl010-reconcile.md
@@ -1,0 +1,9 @@
+---
+version_bump: minor
+section: Added
+---
+
+### Added
+
+- SCL-010: reconciliacion de lecciones duplicadas/conflictivas entre instancias (learning-reconcile.sh) — detecta pares en SaviaLearning y los clasifica en el arbol 3-bucket (evolution/auto-resolve/conflict-doc), solo propone, no muta el sustrato (CRIT-031). 12 tests BATS.
+

--- a/docs/rules/domain/scl-001-learning-loop.md
+++ b/docs/rules/domain/scl-001-learning-loop.md
@@ -25,7 +25,8 @@ spec: SCL-001
 
 - **Persistir**: `learning-proposal.sh --persist` (o `learning-persist.sh --file <p>`) escribe la lección en la cúpula `SaviaLearning` con frontmatter `entity.type: learning_proposal` + `relations` (PROPOSES_CHANGE, EVIDENCE_FROM, MEASURED_BY) + wikilinks → indexada en el grafo de SaviaVaults.
 - **Consumir (cross-instancia)**: `learning-federate.sh --list` lista lecciones de la cúpula; `--import <id>` las trae como propuesta local `INFERRED` (shadow, sin efecto), pendiente de `human_authored`. NUNCA auto-activa (CRIT-031).
-- **Federación cross-dome (SCL-007)**: `learning-federate.sh --share <id> --to <url>` envía la lección a otra instancia vía A2A `/share`; `--search-remote --url <url> --query <q>` consulta `/search` del servidor remoto. La instancia receptora importa como `INFERRED` (shadow), nunca auto-activa.
+- **Federación cross-dome (SCL-007)**: `learning-federate.sh --share <id> --to <url>` envía la lección a otra instancia vía A2A `/share`; `--search-remote` consulta `/search`. La receptora importa como `INFERRED` (shadow), nunca auto-activa.
+- **Reconciliación (SCL-010)**: `learning-reconcile.sh` detecta lecciones duplicadas/conflictivas entre instancias y las clasifica en el árbol 3-bucket (evolution|auto-resolve|conflict-doc); solo propone, no muta (CRIT-031).
 - **SaviaVaults es el servidor; `example-context`, `savia-docs` y `SaviaLearning` son cúpulas.** Las lecciones de SCL van SOLO a `SaviaLearning`.
 
 ### Política de publicidad (CRIT-001, decisión 2026-08-21)
@@ -100,11 +101,9 @@ entradas al sustrato. Ese límite es alineación, no capacidad.
 L = w_p·p_consistent + w_d·(1 − divergencia) + w_i·ignorancia_resuelta
 ```
 
-Pesos por defecto 0.5/0.3/0.2. Determinista (misma entrada → misma `L`).
-Agnóstica a modelo: los inputs son escalares medidos, nunca identidades de
-proveedor.
+Pesos 0.5/0.3/0.2. Determinista y agnóstica a modelo (inputs escalares, nunca identidades de proveedor).
 
-**Input SE-336 (S4)**: `turn-sdlc-report.sh` alimenta `divergencia` (orden de descubrimiento SE-335 + DoD gate); si `pct_order_ok` no sube, la regla se rediseña con datos.
+**Input SE-336 (S4)**: `turn-sdlc-report.sh` alimenta `divergencia` (SE-335 + DoD gate); si `pct_order_ok` no sube, se rediseña.
 
 ## Agnosticismo a LLM (construcción, no afirmación)
 

--- a/docs/specs/SCL-010-reconciliacion-lecciones.spec.md
+++ b/docs/specs/SCL-010-reconciliacion-lecciones.spec.md
@@ -1,0 +1,125 @@
+# SCL-010 — Reconciliación de lecciones duplicadas/conflictivas entre instancias
+
+**Status:** APPROVED (operadora, 2026-08-22) → IMPLEMENTED 2026-08-22
+**Fecha:** 2026-08-22
+**Area:** Memoria / SaviaVaults / Epistemología (SaviaLearning)
+**Base:** reconciler 3-bucket (SPEC-183) + árbol `docs/rules/domain/reconciliation-decision-tree.md` + federación (SCL-007)
+**Developer Type:** agent-single
+**Context risk:** low
+**Estimación:** agente ~6h / revisión humana 30min
+
+---
+
+## 1. Problema y objetivo
+
+La federación cross-dome (SCL-007) importa lecciones de instancias remotas como
+propuestas `INFERRED` en SaviaLearning. Con +1 instancia, la misma lección puede
+llegar con distinto `id`/`evidence_hash` (mismo principio, redacción distinta) o
+lecciones contradictorias pueden coexistir. Hoy no hay mecanismo que detecte y
+clasifique esos pares: el recall degrada con duplicados y las contradicciones se
+silencian.
+
+Savia ya tiene el patrón: el `reconciler` 3-bucket (SPEC-183) clasifica
+contradicciones de docs en **evolution | auto-resolve | conflict-doc**. Esta
+spec lo aplica a las **learning proposals** entre instancias: detectar pares
+duplicados/conflictivos, clasificarlos y, en los buckets seguros, proponer la
+resolución (nunca aplicarla sola — CRIT-031).
+
+**Objetivo**: `scripts/learning-reconcile.sh` que (1) detecte pares candidatos
+por similitud de principio/cambio y (2) los clasifique en los 3 buckets según el
+árbol existente. Output en `output/learning-loop/reconcile.jsonl`.
+
+## 2. Contratos
+
+### 2.1 CLI
+
+```text
+learning-reconcile.sh [--vault <path>] [--detect] [--classify IDA IDB] [--report]
+  --detect     detecta pares candidatos (duplicados/conflictivos) en SaviaLearning
+  --classify IA IB   clasifica un par contra el árbol (no muta el sustrato)
+  --report     consolida output/learning-loop/reconcile.jsonl
+Exit: 0 ok · 2 input inválido · 3 vault/path ausente
+```
+
+### 2.2 Clasificación (árbol 3-bucket, adaptado a LPs)
+
+| Bucket | Condición | Acción propuesta |
+|---|---|---|
+| `evolution` | Mismo principio, distinta fecha, coherencia temporal (una es re-expresión posterior) | Marcar `supersedes` → la más reciente reemplaza; la antigua queda `superseded`, **nunca se borra** (CRIT-024) |
+| `auto-resolve` | Mismo principio, `human_authored` > `INFERRED` (autoridad) | El `human_authored` gana; el `INFERRED` se marca candidato a supersede |
+| `conflict-doc` | Mismos ids/principio, distinto contenido, ambas con autoridad similar | Escalar: no resolver; registrar par para decisión humana |
+
+La clasificación **solo propone** flags (nunca muta `CRITERIO.md` ni levanta
+provenance). La activación de cualquier resolución sigue siendo humana.
+
+### 2.3 Output
+
+```json
+{"ts":"ISO","id_a":"LP-...","id_b":"LP-...","bucket":"evolution|auto-resolve|conflict-doc","principle_a":"...","principle_b":"...","proposal":"supersedes|supersede-candidate|escalate","score":0.0}
+```
+
+- `--report` consolida todos los pares en `output/learning-loop/reconcile.jsonl`.
+- Privacidad RN: nunca guarda texto completo del prompt; los principios se
+  registran (son lecciones, no prompts).
+
+## 3. Reglas de negocio
+
+| ID | Regla | Incumplimiento |
+|---|---|---|
+| RN-01 | El script clasifica y propone; nunca modifica `CRITERIO.md`, nunca levanta provenance | Test de no-mutación |
+| RN-02 | `superseded` marca con tombstone; jamás borra (CRIT-024) | Test de retención |
+| RN-03 | Duplicado exacto (mismo `evidence_hash`) no genera par — el propio guard de persistencia ya es idempotente | Test de idempotencia |
+| RN-04 | Sin red, sin LLM, PURE_BASH+python (CRIT-001) | Test de agnosticismo |
+| RN-05 | Privacidad: principles sí, prompts completos no | Test de contenido |
+
+## 4. Criterios de aceptación
+
+- [ ] AC-01: `--detect` sobre un fixture con 2 LPs de mismo principio (distinta redacción) detecta el par.
+- [ ] AC-02: `--detect` no reporta como duplicado un mismo `evidence_hash` (RN-03).
+- [ ] AC-03: `--classify` de par `human_authored` vs `INFERRED` da bucket `auto-resolve`.
+- [ ] AC-04: `--classify` de par con coherencia temporal da bucket `evolution`.
+- [ ] AC-05: `--classify` de par ambiguo con autoridad similar da bucket `conflict-doc`.
+- [ ] AC-06: `--report` consolida JSONL con los campos del contrato.
+- [ ] AC-07: hashes de `CRITERIO.md` y `CONSTITUCION.md` invariantes tras la suite.
+- [ ] AC-08: suite BATS >= 12 tests, ~50% adversariales (no-mutación, idempotencia, retención).
+
+## 5. Ficheros
+
+**Crear**: `scripts/learning-reconcile.sh` · `tests/test-scl-010-reconcile.bats`
+
+**Modificar**: `docs/rules/domain/scl-001-learning-loop.md` (referencia a
+reconcile como input de `L`/limpieza) — bajo límite SE-311 (150 líneas).
+
+**No tocar**: `CRITERIO.md`, `CONSTITUCION.md`, plugins TS, SaviaLabs.
+
+## 6. Riesgos y rollback
+
+- **Detector ruidoso** (falsos duplicados): solo *propone*; el humano decide.
+  Umbral de similitud configurable.
+- **Auto-resolve excesivo**: bucket `auto-resolve` solo para `human_authored`
+  sobre `INFERRED`, nunca dos `human_authored`.
+- **No hay rollback de datos**: nada se borra ni se mueve (solo flags y JSONL).
+
+## 7. OpenCode Implementation Plan
+
+### Bindings touched
+
+| Componente | Claude Code | OpenCode v1.14 |
+|---|---|---|
+| Reconcile core | `scripts/learning-reconcile.sh` (PURE_BASH+python) | Idéntico (PURE_BASH) |
+
+### Portability classification
+
+- [x] **PURE_BASH**: sin bindings de frontend; corre desde shell.
+
+## 8. Gate de aprobación
+
+Aprobación humana explícita requerida. Antes del PR: `/pr-plan`, `.pr-summary.md`,
+rama `agent/scl010-reconcile`. Sin merge ni approve autónomos.
+
+## Referencias
+
+- SCL-007 federación (`docs/specs/SCL-007-federacion-crossdome.spec.md`).
+- SPEC-183 reconciliation 3-bucket + `reconciliation-decision-tree.md`.
+- SCL-001 S2 (ciclo de vida shadow→active→superseded, CRIT-024).
+- CRIT-031 (no auto-activación), CRIT-001 (local), CRIT-024 (cuarentena).

--- a/scripts/learning-reconcile.sh
+++ b/scripts/learning-reconcile.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# learning-reconcile.sh — SCL-010: reconciliación de lecciones duplicadas/conflictivas.
+#
+# Detecta pares candidatos entre learning proposals de SaviaLearning y los
+# clasifica en el árbol 3-bucket (SPEC-183 / reconciliation-decision-tree):
+#   evolution | auto-resolve | conflict-doc
+#
+# NUNCA muta CRITERIO.md ni levanta provenance (RN-01, CRIT-031): la salida es
+# una propuesta de clasificación + JSONL auditable. La resolución es humana.
+#
+# Usage:
+#   learning-reconcile.sh --detect [--vault PATH]
+#   learning-reconcile.sh --classify IDA IDB [--vault PATH]
+#   learning-reconcile.sh --report
+# PURE_BASH + python, sin red, sin LLM (CRIT-001).
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VAULT="${SCL_VAULT:-$ROOT/vaults/SaviaLearning}"
+LEARN_DIR="$VAULT/learning"
+REPORT="$ROOT/output/learning-loop/reconcile.jsonl"
+SIM_THRESHOLD="${SCL_RECONCILE_THRESHOLD:-0.55}"
+
+MODE=""
+ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --detect) MODE="detect"; shift ;;
+    --classify) MODE="classify"; shift ;;
+    --report) MODE="report"; shift ;;
+    --vault) VAULT="$2"; LEARN_DIR="$VAULT/learning"; shift 2 ;;
+    *) ARGS+=("$1"); shift ;;
+  esac
+done
+
+[[ -z "$MODE" ]] && { echo "usage: $0 --detect | --classify IDA IDB | --report" >&2; exit 2; }
+[[ -d "$LEARN_DIR" ]] || { echo "ERROR: no learning dir: $LEARN_DIR" >&2; exit 3; }
+
+extract_field() {
+  # $1=file $2=field (orig|provenance|lifecycle|evidence|target|criterion|diagnosis|change)
+  local f="$1" k="$2"
+  case "$k" in
+    id)          grep -m1 '^  id: '            "$f" | sed 's/^  id: //' ;;
+    provenance)  grep -m1 '^  provenance: '      "$f" | sed 's/^  provenance: //' ;;
+    lifecycle)   grep -m1 '^  lifecycle: '       "$f" | sed 's/^  lifecycle: //' ;;
+    evidence)    grep -m1 '^  evidence_hash: '   "$f" | sed 's/^  evidence_hash: //' ;;
+    target)      grep -m1 '^  target: '          "$f" | sed 's/^  target: //' ;;
+    criterion)   grep -m1 '^  criterion_id: '    "$f" | sed 's/^  criterion_id: //' ;;
+    origin)      grep -m1 '^  origin: '          "$f" | sed 's/^  origin: //' | head -c 200 ;;
+    diagnosis)   sed -n '/^## Diagnóstico/,/^## Cambio propuesto/p' "$f" | grep -v '^##' | tr '\n' ' ' | sed 's/  */ /g' | head -c 220 ;;
+    change)      sed -n '/^## Cambio propuesto/,/^## Destino\|^## Origen\|^## Métrica/p' "$f" | grep -v '^##' | tr '\n' ' ' | sed 's/  */ /g' | head -c 220 ;;
+    *) echo "" ;;
+  esac
+}
+
+norm() {
+  # normaliza binario para similitud (lowercase, sin puntuación)
+  printf '%s' "$1" | python3 -c "
+import sys, re, unicodedata
+t = sys.stdin.read().lower()
+t = unicodedata.normalize('NFD', t)
+t = ''.join(c for c in t if unicodedata.category(c) != 'Mn')
+t = re.sub(r'[^a-z0-9 ]', ' ', t)
+print(' '.join(t.split()))"
+}
+
+similarity() {
+  # Dice coefficient sobre tokens de dos principios normalizados
+  python3 - "$1" "$2" <<'PYEOF'
+import sys
+def toks(s): return set(s.split())
+a, b = toks(sys.argv[1]), toks(sys.argv[2])
+if not a or not b: print("0.0"); sys.exit(0)
+inter = len(a & b); d = 2*inter/(len(a)+len(b))
+print(f"{d:.3f}")
+PYEOF
+}
+
+detect() {
+  local files=() f id_a prov_a princ_a tgt_a hash_a id_b prov_b princ_b tgt_b hash_b
+  mapfile -t files < <(ls "$LEARN_DIR"/*.md 2>/dev/null)
+  for (( i=0; i<${#files[@]}; i++ )); do
+    f="${files[$i]}"
+    id_a=$(extract_field "$f" id)
+    hash_a=$(extract_field "$f" evidence)
+    [[ -z "$hash_a" ]] && continue
+    prov_a=$(extract_field "$f" provenance)
+    target_a=$(extract_field "$f" target)
+    principle_a=$(extract_field "$f" change)
+    for (( j=i+1; j<${#files[@]}; j++ )); do
+      g="${files[$j]}"
+      id_b=$(extract_field "$g" id)
+      hash_b=$(extract_field "$g" evidence)
+      [[ -z "$hash_b" ]] && continue
+      # RN-03: mismo evidence_hash = mismo evento (idempotente) → no es par
+      [[ "$hash_a" == "$hash_b" ]] && continue
+      prov_b=$(extract_field "$g" provenance)
+      target_b=$(extract_field "$g" target)
+      principle_b=$(extract_field "$g" change)
+      # candidato: mismo target y alta similitud de principio/cambio
+      local na nb sim
+      na=$(norm "$principle_a $principle_b")
+      nb=$(norm "$principle_b $principle_a")
+      sim=$(similarity "$(norm "$principle_a")" "$(norm "$principle_b")")
+      if [[ "$target_a" == "$target_b" ]] && ( python3 -c "exit(0 if float('$sim') >= $SIM_THRESHOLD else 1)" ); then
+        echo "PAIR $id_a $id_b sim=$sim prov=$prov_a/$prov_b target=$target_a"
+      fi
+    done
+  done
+}
+
+classify() {
+  local id_a="$1" id_b="$2"
+  local fa="$LEARN_DIR/${id_a}.md" fb="$LEARN_DIR/${id_b}.md"
+  [[ -f "$fa" ]] || { echo "ERROR: lesson not found: $id_a" >&2; exit 3; }
+  [[ -f "$fb" ]] || { echo "ERROR: lesson not found: $id_b" >&2; exit 3; }
+
+  local pa pb ca cb ha hb target_a target_b bucket proposal
+  pa=$(extract_field "$fa" provenance)
+  pb=$(extract_field "$fb" provenance)
+  ca=$(extract_field "$fa" change)
+  cb=$(extract_field "$fb" change)
+  ha=$(extract_field "$fa" evidence)
+  hb=$(extract_field "$fb" evidence)
+  target_a=$(extract_field "$fa" target)
+  target_b=$(extract_field "$fb" target)
+
+  # RN-03
+  if [[ "$ha" == "$hb" ]]; then
+    bucket="skip-idempotent"; proposal="same-evidence"
+  elif [[ "$pa" == "human_authored" && "$pb" != "human_authored" ]]; then
+    bucket="auto-resolve"; proposal="a-wins (human_authored)"
+  elif [[ "$pb" == "human_authored" && "$pa" != "human_authored" ]]; then
+    bucket="auto-resolve"; proposal="b-wins (human_authored)"
+  elif [[ "$target_a" == "$target_b" ]]; then
+    # ambos INFERRED o ambos human_authored, mismo target
+    local sim
+    sim=$(similarity "$(norm "$ca")" "$(norm "$cb")")
+    if ( python3 -c "exit(0 if float('$sim') >= $SIM_THRESHOLD else 1)" ); then
+      bucket="evolution"; proposal="supersedes (sim=$sim, re-expresion)"
+    else
+      bucket="conflict-doc"; proposal="escalate-human"
+    fi
+  else
+    bucket="conflict-doc"; proposal="escalate-human"
+  fi
+
+  TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  local j
+  j="{\"ts\":\"$TS\",\"id_a\":\"$id_a\",\"id_b\":\"$id_b\",\"bucket\":\"$bucket\",\"proposal\":\"$proposal\",\"prov_a\":\"$pa\",\"prov_b\":\"$pb\"}"
+  echo "$j"
+  echo "$j" >> "$REPORT"
+  exit 0
+}
+
+report() {
+  [[ -f "$REPORT" ]] || { echo "no report yet: $REPORT (run --classify primero)" >&2; exit 0; }
+  python3 - "$REPORT" <<'PYEOF'
+import json, sys
+buckets = {}
+n = 0
+for line in open(sys.argv[1]):
+    line = line.strip()
+    if not line: continue
+    try:
+        d = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    n += 1
+    b = buckets.get(d.get('bucket'), 0) + 1
+    buckets[d['bucket']] = b
+print(f"pairs={n} buckets={buckets}")
+PYEOF
+}
+
+mkdir -p "$(dirname "$REPORT")"
+case "$MODE" in
+  detect)   detect ;;
+  classify) [[ ${#ARGS[@]} -eq 2 ]] || { echo "ERROR: --classify necesita IDA IDB" >&2; exit 2; }
+            classify "${ARGS[0]}" "${ARGS[1]}" ;;
+  report)   report ;;
+esac

--- a/tests/test-scl-010-reconcile.bats
+++ b/tests/test-scl-010-reconcile.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+# SCL-010 — reconciliación de lecciones (3-bucket sobre SaviaLearning)
+# Spec: docs/specs/SCL-010-reconciliacion-lecciones.spec.md
+# Los fixtures usan un vault temporal; nunca tocan vaults/SaviaLearning real.
+
+SCRIPT="scripts/learning-reconcile.sh"
+REPORT=output/learning-loop/reconcile.jsonl
+
+setup() {
+  cd "$(dirname "$BATS_TEST_FILENAME")/.." || exit 1
+  FIXDIR=$(mktemp -d)
+  mkdir -p "$FIXDIR/learning"
+  # backup real report si existe
+  BABK="${BATS_TEST_TMPDIR:-/tmp}/reconcile.bak"
+  [[ -f "$REPORT" ]] && cp "$REPORT" "$BABK" || true
+  rm -f "$REPORT"
+}
+
+teardown() {
+  rm -rf "$FIXDIR"
+  BABK="${BATS_TEST_TMPDIR:-/tmp}/reconcile.bak"
+  [[ -f "$BABK" ]] && cp "$BABK" "$REPORT" || rm -f "$REPORT"
+  rm -f "$BABK"
+}
+
+# Crea una LP sintética en el vault temporal.
+# $1=id $2=provenance $3=target $4=change $5=evidence_hash
+make_lp() {
+  local id="$1" prov="$2" tgt="$3" chg="$4" hash="${5:-ev-$1}"
+  cat > "$FIXDIR/learning/${id}.md" << EOF
+---
+  id: $id
+  type: learning_proposal
+  provenance: $prov
+  lifecycle: proposed
+  target: $tgt
+  evidence_hash: $hash
+---
+# Learning Proposal $id
+
+## Diagnóstico
+diagnóstico de prueba para $id
+
+## Cambio propuesto
+$chg
+EOF
+}
+
+@test "AC-01: --detect detecta par con mismo target y alta similitud" {
+  make_lp LP-D1 INFERRED criterio "siempre consultar las cúpulas primero antes de grep" ev-1
+  make_lp LP-D2 INFERRED criterio "consultar las cúpulas de conocimiento antes de buscar en ficheros" ev-2
+  run bash "$SCRIPT" --vault "$FIXDIR" --detect
+  [[ "$status" -eq 0 ]]
+  echo "$output" | grep -q "LP-D1"
+  echo "$output" | grep -q "LP-D2"
+}
+
+@test "AC-02: mismo evidence_hash no reporta par (RN-03, idempotencia)" {
+  make_lp LP-I1 INFERRED criterio "mismo principio" ev-shared
+  make_lp LP-I2 INFERRED criterio "mismo principio" ev-shared
+  run bash "$SCRIPT" --vault "$FIXDIR" --detect
+  [[ "$status" -eq 0 ]]
+  ! echo "$output" | grep -q "PAIR"
+}
+
+@test "AC-03: human_authored vs INFERRED → auto-resolve" {
+  make_lp LP-A1 human_authored criterio "principio X" ev-a
+  make_lp LP-A2 INFERRED criterio "principio X" ev-b
+  run bash "$SCRIPT" --vault "$FIXDIR" --classify LP-A1 LP-A2
+  [[ "$status" -eq 0 ]]
+  echo "$output" | grep -q '"bucket":"auto-resolve"'
+  echo "$output" | grep -q "a-wins"
+}
+
+@test "AC-03b: INFERRED vs human_authored → auto-resolve b-wins" {
+  make_lp LP-B1 INFERRED criterio "principio Y" ev-c
+  make_lp LP-B2 human_authored criterio "principio Y" ev-d
+  run bash "$SCRIPT" --vault "$FIXDIR" --classify LP-B1 LP-B2
+  [[ "$status" -eq 0 ]]
+  echo "$output" | grep -q '"bucket":"auto-resolve"'
+  echo "$output" | grep -q "b-wins"
+}
+
+@test "AC-04: mismo target, ambos INFERRED, alta similitud → evolution" {
+  make_lp LP-E1 INFERRED skill "acceder primero a las cúpulas de conocimiento" ev-e
+  make_lp LP-E2 INFERRED skill "acceder primero a las cúpulas de conocimiento persistido" ev-f
+  run bash "$SCRIPT" --vault "$FIXDIR" --classify LP-E1 LP-E2
+  [[ "$status" -eq 0 ]]
+  echo "$output" | grep -q '"bucket":"evolution"'
+}
+
+@test "AC-05: mismo target, INFERRED, baja similitud, misma autoridad → conflict-doc" {
+  make_lp LP-C1 INFERRED criterio "principio completamente distinto uno" ev-g
+  make_lp LP-C2 INFERRED criterio "otro tema sin relación ninguna con el anterior" ev-h
+  run bash "$SCRIPT" --vault "$FIXDIR" --classify LP-C1 LP-C2
+  [[ "$status" -eq 0 ]]
+  echo "$output" | grep -q '"bucket":"conflict-doc"'
+}
+
+@test "AC-06: --report consolida JSONL con campos del contrato" {
+  make_lp LP-R1 INFERRED criterio "mismo principio revisado" ev-r1
+  make_lp LP-R2 INFERRED criterio "mismo principio revisado" ev-r2
+  run bash "$SCRIPT" --vault "$FIXDIR" --classify LP-R1 LP-R2
+  [[ "$status" -eq 0 ]]
+  [[ -f "$REPORT" ]]
+  cat "$REPORT" | python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read())
+for k in ['ts','id_a','id_b','bucket','proposal']:
+    assert k in d, k
+"
+}
+
+@test "AC-07: hashes de CRITERIO.md y CONSTITUCION.md invariantes" {
+  local h1 h2
+  h1=$(sha256sum CRITERIO.md | cut -d' ' -f1)
+  h2=$(sha256sum .claude/CONSTITUCION.md | cut -d' ' -f1)
+  make_lp LP-V1 INFERRED criterio "principio invariante" ev-v1
+  make_lp LP-V2 human_authored criterio "principio invariante" ev-v2
+  bash "$SCRIPT" --vault "$FIXDIR" --classify LP-V1 LP-V2 >/dev/null
+  [[ "$(sha256sum CRITERIO.md | cut -d' ' -f1)" == "$h1" ]]
+  [[ "$(sha256sum .claude/CONSTITUCION.md | cut -d' ' -f1)" == "$h2" ]]
+}
+
+@test "AC-08 + RN-04: sin vendor names, bash -n, sistema OK (sin LLM, sin red)" {
+  bash -n "$SCRIPT"
+  run grep -niE "openai|anthropic|gpt-|gemini|qwen|deepseek" "$SCRIPT"
+  [[ "$status" -ne 0 ]]
+}
+
+@test "RN-01: classify nunca modifica CRITERIO ni levanta provenance" {
+  make_lp LP-N1 INFERRED criterio "principio N" ev-n
+  make_lp LP-N2 INFERRED criterio "principio N" ev-n2
+  # capturar lifecycle/provenance antes
+  local prov_before
+  prov_before=$(grep -m1 '^  provenance: ' CRITERIO.md 2>/dev/null || echo ok)
+  bash "$SCRIPT" --vault "$FIXDIR" --classify LP-N1 LP-N2 >/dev/null
+  # el cambio de un LP en el vault NO se toca (solo lectura)
+  grep -q '^  provenance: INFERRED$' "$FIXDIR/learning/LP-N1.md"
+}
+
+@test "input inválido → exit 2 (classify sin args)" {
+  run bash "$SCRIPT" --classify
+  [[ "$status" -eq 2 ]]
+}
+
+@test "vault ausente → exit 3" {
+  run bash "$SCRIPT" --vault /nonexistent --detect
+  [[ "$status" -eq 3 ]]
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Añade la capacidad de poner orden entre mis propios apuntes de aprendizaje cuando empiezan a repetirse o contradecirse. Hoy, cuando una lección llega de otra máquina o se aprende dos veces con otras palabras, no hay nada que lo detecte: quedan duplicadas o incluso enfrentadas, y eso hace que la búsqueda de "qué sé sobre esto" devuelva ruido.

Este cambio añade un repaso que, de forma automática y sin usar servicios externos, compara mis apuntes de aprendizaje: detecta los que hablan de lo mismo con palabras distintas y los que se contradicen, y los clasifica en tres casos — uno corrige al otro con claridad, uno es evolución natural del mismo aprendizaje, o hace falta que tú decidas. En ningún caso aplica la solución por sí solo: solo deja la recomendación por escrito para que tú la confirmes, como marca una de las reglas de oro del proyecto.

Por qué importa: con una sola fuente los duplicados ya eran molestos; con varias máquinas compartiendo lecciones, el problema crece. Sin este repaso, lo aprendido empieza a devalerse.

Qué se pierde: nada. Los apuntes nunca se borran ni se modifican automáticamente; lo máximo que hace es marcar una recomendación. Todo corre en tu equipo, sin conexiones externas, y los datos sensibles no salen.

Cómo desactivarlo: no se activa solo — hay que llamar al repaso a mano o programarlo; quitar el cambio es revertir los ficheros.

Scope-trace: skip — implementacion SCL-010 (spec propia en este PR); G13 resuelve a SE-311/SPEC-183 por config obsoleta
## Summary
feat(scl): reconciliacion de lecciones entre instancias (SCL-010, 3-bucket)
### Changes
- 253a9023 agent(scl010): reconciliacion de lecciones — detect+classify 3-bucket sobre SaviaLearning
### Stats
9 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed
