### PR TITLE
docs(se036): conciliar estado SPEC-SE-036 (DRAFT, sin artefactos)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=b2ce75913072ef54470690996e1cd4496f8be6d1586155063fac71d82e04040a
-timestamp=2026-08-22T21:33:44Z
-branch=agent/se337-commit-guard
-head_commit=6b25311e
-signature=1169ecf4978058cbdd37298a0a90f8d5038f6ce173265ddde9b2728bb51bbd89
+diff_hash=fdf0028a563368b789b564db90a5d9973f2234cfe19610b28a6191f2fb95e7f1
+timestamp=2026-08-22T21:48:43Z
+branch=agent/se036-status-reconcile
+head_commit=0aa78462
+signature=5770dfb0a4ab60abf456e3c757c4b22817501019ae0fea0f937230b4bcaf693b

--- a/CHANGELOG.d/agent-se036-status.md
+++ b/CHANGELOG.d/agent-se036-status.md
@@ -1,0 +1,9 @@
+---
+version_bump: patch
+section: Changed
+---
+
+### Changed
+
+- SPEC-SE-036: conciliacion de estado — frontmatter IMPLEMENTED->DRAFT (no habia artefactos de JWT mint); nota de reconciliacion + LP de drift registrada.
+

--- a/docs/learning-proposals/LP-20260822-1f291b2d.md
+++ b/docs/learning-proposals/LP-20260822-1f291b2d.md
@@ -1,0 +1,39 @@
+---
+id: LP-20260822-1f291b2d
+type: learning_proposal
+provenance: INFERRED
+lifecycle: proposed
+origin: drift de status 2026-08-22: SPEC-SE-036 (JWT mint) tiene frontmatter status: IMPLEMENTED pero el cuerpo dice Draft y no existen los scripts de mint — status contradictorio
+trigger: contradiction
+target: skill
+criterion_id: 
+evidence_hash: 1f291b2d74116c0fcc84948ba109cce627f53c40df68eb2c2e047ee8caf0b3d6
+created_utc: 2026-08-22T21:46:55Z
+expected_p_consistent: 
+---
+
+# Learning Proposal LP-20260822-1f291b2d
+
+## Origen
+
+drift de status 2026-08-22: SPEC-SE-036 (JWT mint) tiene frontmatter status: IMPLEMENTED pero el cuerpo dice Draft y no existen los scripts de mint — status contradictorio
+
+## Evidencia
+
+docs/propuestas/savia-enterprise/SPEC-SE-036-api-key-jwt-mint.md:docs/rules/domain/savia-enterprise/agent-jwt-mint.md
+
+## Diagnóstico
+
+La spec declara IMPLEMENTED en frontmatter sin implementacion real (solo existe la regla de diseno agent-jwt-mint.md). El cuerpo sigue en Draft. Sin conciliacion, un agente podria creer que la migracion PAT->JWT esta hecha cuando no.
+
+## Cambio propuesto
+
+Marcar frontmatter a Draft (o Implemented con evidencia de scripts) segun el estado real; el patron de trazabilidad de status de specs debe verificar existencia de artefactos, no solo frontmatter.
+
+## Destino
+
+skill
+
+## Métrica esperada
+
+sin baseline declarado

--- a/docs/propuestas/savia-enterprise/SPEC-SE-036-api-key-jwt-mint.md
+++ b/docs/propuestas/savia-enterprise/SPEC-SE-036-api-key-jwt-mint.md
@@ -1,5 +1,6 @@
 ---
-status: IMPLEMENTED
+status: DRAFT
+status_reconcile_note: "2026-08-22: frontmatter decia IMPLEMENTED pero no existen artefactos de mint (scripts/jwt) — estado real DRAFT. LP-20260822-1f291b2d. La migracion PAT->JWT no esta implementada."
 ---
 
 # SPEC-SE-036: API-Key → Short-Lived JWT Mint for Agent CLIs


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Corrige una nota que decía una cosa y otra. En el inventario de proyectos, una propuesta sobre cómo guardar credenciales de forma más segura figuraba como "terminada", pero en realidad está sin hacer: solo existe su diseño, no su implementación. Ese fallo de etiquetado es peligroso porque un sistema que confíe en el inventario podría creer que la migración de credenciales ya ocurrió cuando no ocurrió.

Este cambio corrige la etiqueta a su estado real y deja anotada la advertencia. También registra una lección sobre el patrón que causó el error: no basta que un documento diga "terminado" — hay que comprobar que los archivos de la implementación existen.

Por qué importa: en un proyecto donde muchas decisiones dependen de lo que dicen los inventarios, una etiqueta falsa puede hacer que se asuma un trabajo de seguridad que no está hecho. Mejor un inventario honesto que uno optimista.

Qué se pierde: nada. No se implementa la migración (eso requiere tu aprobación y es trabajo aparte); solo se corrige el estado documentado.

Cómo desactivarlo: quitar el cambio es revertir dos ficheros de texto.

Scope-trace: skip — LP de leccion de drift, no artefacto de SE-036; documento correlacionado
## Summary
docs(se036): conciliar estado SPEC-SE-036 (DRAFT, sin artefactos)
### Changes
- 0aa78462 docs(se036): conciliar estado SPEC-SE-036 — frontmatter IMPLEMENTED->DRAFT (sin artefactos de mint)
### Stats
4 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed
