### PR TITLE
docs(roadmap): conciliar estado SE-317/318/323 (IMPLEMENTED)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=fdf0028a563368b789b564db90a5d9973f2234cfe19610b28a6191f2fb95e7f1
-timestamp=2026-08-22T21:48:43Z
-branch=agent/se036-status-reconcile
-head_commit=0aa78462
-signature=5770dfb0a4ab60abf456e3c757c4b22817501019ae0fea0f937230b4bcaf693b
+diff_hash=f05c81673f59306dae68eac95fe5a746e53e90a52793775e1a889bdaa1b29ad7
+timestamp=2026-08-22T22:07:22Z
+branch=agent/roadmap-se317-status
+head_commit=e2b2b55e
+signature=f8e40d59288fc81d62c6911fe329b7d217e9b5c8a647124ec232e3871489f0cb

--- a/CHANGELOG.d/agent-roadmap-se317.md
+++ b/CHANGELOG.d/agent-roadmap-se317.md
@@ -1,0 +1,9 @@
+---
+version_bump: patch
+section: Changed
+---
+
+### Changed
+
+- ROADMAP: conciliacion de estado SE-317/318/323 — 'DONE PR pendiente' -> IMPLEMENTED (specs en main); LP de drift registrada.
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1461,9 +1461,9 @@ SE-308 (merge PR #942) ✅
 PR #952 (SE-313/314/275) — DONE (merge 2026-08-09)
   → SE-316 (eval-lint) — DONE (merge #953)
   → SE-315 (scope creep) — DONE (merge #955)
-  → SE-323 (incident RCA) — DONE (commit 717e55d7, PR pendiente)
-  → SE-318 (blast-radius) — DONE (commit, PR pendiente)
-  → SE-317 (memoria reflexiva) — DONE (commit, PR pendiente)
+  → SE-323 (incident RCA) — IMPLEMENTED
+  → SE-318 (blast-radius) — IMPLEMENTED
+  → SE-317 (memoria reflexiva) — IMPLEMENTED
   → SE-321 (speech-to-speech) — requiere validacion HW (probe S1)
   → SE-319 / SE-320 / SE-322 (baja)
   → SE-327..SE-331 (SaviaVaults mejoras: PPR, dual-mode, entity resolution,

--- a/docs/learning-proposals/LP-20260822-0ef2f1b9.md
+++ b/docs/learning-proposals/LP-20260822-0ef2f1b9.md
@@ -1,0 +1,39 @@
+---
+id: LP-20260822-0ef2f1b9
+type: learning_proposal
+provenance: INFERRED
+lifecycle: proposed
+origin: drift de estado en ROADMAP 2026-08-22: SE-317/318/323 marcadas 'DONE, PR pendiente' cuando estan IMPLEMENTED en main desde antes
+trigger: contradiction
+target: skill
+criterion_id: 
+evidence_hash: 0ef2f1b95cb8ea9126301ec868f3ccaf8ff2bbe41a229df3a04fef13feb7b138
+created_utc: 2026-08-22T22:06:02Z
+expected_p_consistent: 
+---
+
+# Learning Proposal LP-20260822-0ef2f1b9
+
+## Origen
+
+drift de estado en ROADMAP 2026-08-22: SE-317/318/323 marcadas 'DONE, PR pendiente' cuando estan IMPLEMENTED en main desde antes
+
+## Evidencia
+
+docs/ROADMAP.md:docs/propuestas/SE-317-memoria-reflexiva.md
+
+## Diagnóstico
+
+El bloque de Estado del ROADMAP se quedo con redaccion obsoleta (PR pendiente) mientras las specs ya estaban IMPLEMENTED. Sin conciliacion, la vista de roadmap induce a creer que hay PRs abiertos que no existen.
+
+## Cambio propuesto
+
+Al actualizar un ROADMAP, verificar cada claim de estado contra la spec (status:) o los artefactos; 'DONE/PR pendiente' sin PR real es un estado provisional que debe marcarse o cerrarse.
+
+## Destino
+
+skill
+
+## Métrica esperada
+
+sin baseline declarado


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Corrige una ficción en el mapa del proyecto. El plano decía que tres piezas de trabajo estaban "terminadas pero a la espera de ser revisadas en un trámite pendiente". Al comprobarlo, las tres están ya incorporadas al repositorio principal desde hace tiempo — el trámite ya se cerró, solo la nota seguía diciendo que pendía.

Este cambio corrige la nota para que refleje la realidad, y deja registrada una advertencia sobre el fallo que lo causó: un plano no debería decir "pendiente" sin verificar que la pieza existe en su lugar definitivo.

Por qué importa: un mapa que dice que algo está pendiente cuando ya está hecho confunde las decisiones siguientes (se puede rehacer trabajo, o no contar con algo que ya está). Mejor que el mapa diga la verdad.

Qué se pierde: nada — es sólo corrección de estado en la documentación del plan.

Cómo desactivarlo: quitar el cambio es revertir el fichero del plan y la nota.

Scope-trace: skip — conciliacion documental de estado en roadmap, no implementacion de SE-317
## Summary
docs(roadmap): conciliar estado SE-317/318/323 (IMPLEMENTED)
### Changes
- e2b2b55e docs(roadmap): conciliar estado SE-317/318/323 — DONE PR pendiente no era real, IMPLEMENTED
### Stats
4 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed
