### PR TITLE
feat(l13): recalibracion desde senal real — meta-recalibra-ledger (L13 F4)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=94890a459cfc0c418244d5975a448ebaee3e2e29cb0b25a0a0fe3e5091a48daf
-timestamp=2026-08-23T01:13:34Z
-branch=agent/se334-cierre-verificacion
-head_commit=c8261c6d
-signature=b494f903506fea30f84ebb651196a2fe2316a8fc5798b878d6dc1dc2e8da3897
+diff_hash=da39ae6e8c1d04eb468e6e915f523856400312a8f922e24614998bd3362c9401
+timestamp=2026-08-23T01:28:32Z
+branch=agent/l13-f4-recalibra-ledger
+head_commit=859016e6
+signature=8d86f93ac15af2ba139a78d65425829e7490b364140c3a6ca6974304efb5434d

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=da39ae6e8c1d04eb468e6e915f523856400312a8f922e24614998bd3362c9401
-timestamp=2026-08-23T01:28:32Z
+diff_hash=134beee90efc9daf024978ef0ed0f4533943e7d23958a52563ea7c765943ef19
+timestamp=2026-08-23T01:40:50Z
 branch=agent/l13-f4-recalibra-ledger
-head_commit=859016e6
-signature=8d86f93ac15af2ba139a78d65425829e7490b364140c3a6ca6974304efb5434d
+head_commit=c45f6f18
+signature=63f993f856ea3e2dd55ec1076681e6d8000ce9f7aa2c38cde18de7fdc032740a

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=134beee90efc9daf024978ef0ed0f4533943e7d23958a52563ea7c765943ef19
-timestamp=2026-08-23T01:40:50Z
-branch=agent/l13-f4-recalibra-ledger
-head_commit=c45f6f18
-signature=63f993f856ea3e2dd55ec1076681e6d8000ce9f7aa2c38cde18de7fdc032740a
+timestamp=2026-08-23T01:56:12Z
+branch=HEAD
+head_commit=391d620f
+signature=36a527dec235f274b582b6e62b3b89bf195687c80f99f051e86e87d5d5f65606

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: 33a3da3e14e5 | resources: 1387
-> 294 commands · 127 skills · 83 agents · 883 scripts
+> hash: 7ab58fccbc2f | resources: 1388
+> 294 commands · 127 skills · 83 agents · 884 scripts
 
 [analysis] Trace Optimize — across,distributed,optimize,rates,sampling — cmd:.claude/commands/trace-optimize.md
 [analysis] agent-activity — activity,agent,executions,recent,show — cmd:.claude/commands/agent-activity.md
@@ -856,6 +856,7 @@
 [planning] memvid-backup — backup,crea,externa,memoria,portable — skill:.claude/skills/memvid-backup/SKILL.md
 [planning] meta-control — control,meta,metacognitivo,orquestador,sagi — script:scripts/meta-control.sh
 [planning] meta-monitor — juicio,meta,metacognitivo,monitor,monitoreo — script:scripts/meta-monitor.sh
+[planning] meta-recalibra-ledger — ledger,meta,real,recalibra,recalibración — script:scripts/meta-recalibra-ledger.sh
 [planning] meta-recalibrate — juicio,meta,metacognitivo,recalibración,recalibrate — script:scripts/meta-recalibrate.sh
 [planning] mobile-developer —  — agent:.opencode/agents/mobile-developer.md
 [planning] model-capability-resolver — capabilities,capability,model,registry,resolve — script:scripts/model-capability-resolver.sh

--- a/.scm/categories/planning.scm
+++ b/.scm/categories/planning.scm
@@ -1,5 +1,5 @@
 # planning — Savia Capability Map (L1)
-> 594 resources
+> 595 resources
 
 - **/decide-architecture** (cmd): Clasifica una tarea como WORKFLOW (deterministica) o AGENT (loop). Bias hacia workflow per Anthropic. Sugiere plantilla inicial. Mide accuracy contra corpus curado de 20 tareas.
 - **_template** (skill): TEMPLATE — copia este directorio para crear una skill nueva. NO se carga en runtime.
@@ -322,6 +322,7 @@
 - **memvid-backup** (skill): Usar cuando se crea un backup portable de la memoria externa de Savia.
 - **meta-control** (script): meta-control.sh — L13 F2: control metacognitivo sobre el orquestador SAGI.
 - **meta-monitor** (script): meta-monitor.sh — L13 F1: juicio metacognitivo de monitoreo.
+- **meta-recalibra-ledger** (script): meta-recalibra-ledger.sh — L13 F4: recalibración desde señal real (ledger).
 - **meta-recalibrate** (script): meta-recalibrate.sh — L13 F1: recalibración del juicio metacognitivo.
 - **mobile-developer** (agent): >
 - **model-capability-resolver** (script): model-capability-resolver.sh — Resolve model capabilities from YAML registry

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "a526941e0989",
-  "total": 1387,
+  "hash": "300a9521811c",
+  "total": 1388,
   "resources": [
     {
       "category": "analysis",
@@ -11293,6 +11293,20 @@
       "kind": "script",
       "path": "scripts/meta-monitor.sh",
       "description": "meta-monitor.sh — L13 F1: juicio metacognitivo de monitoreo."
+    },
+    {
+      "category": "planning",
+      "name": "meta-recalibra-ledger",
+      "intents": [
+        "ledger",
+        "meta",
+        "real",
+        "recalibra",
+        "recalibración"
+      ],
+      "kind": "script",
+      "path": "scripts/meta-recalibra-ledger.sh",
+      "description": "meta-recalibra-ledger.sh — L13 F4: recalibración desde señal real (ledger)."
     },
     {
       "category": "planning",

--- a/CHANGELOG.d/agent-l13-meta-f4.md
+++ b/CHANGELOG.d/agent-l13-meta-f4.md
@@ -1,0 +1,8 @@
+---
+version_bump: minor
+section: Added
+---
+
+### Added
+
+- L13 Savia Metacognition F4: recalibración desde señal real — `meta-recalibra-ledger.sh` convierte el ledger de ciclo de vida del bucle SCL (activación humana canary→active = success; revert = fail) en entradas de calibración para `meta-recalibrate.sh`. Cierra el bucle sin LLM (CRIT-001); la curva nutrida la consulta meta-monitor. 8 tests BATS.

--- a/docs/learning-proposals/LP-20260823-l13-f4.md
+++ b/docs/learning-proposals/LP-20260823-l13-f4.md
@@ -1,0 +1,49 @@
+---
+id: LP-20260823-l13-f4
+type: learning_proposal
+provenance: INFERRED
+lifecycle: proposed
+origin: L13 F4 recalibracion desde senal real 2026-08-23: la curva de calibracion se nutre del ledger del bucle (activacion humana y revert), no de fixtures
+trigger: recurrence
+target: skill
+criterion_id:
+evidence_hash: f328343ddb136d2e
+created_utc: 2026-08-23T03:30:00Z
+expected_p_consistent:
+---
+
+# Learning Proposal LP-20260823-l13-f4
+
+## Origen
+
+L13 F4 recalibracion desde senal real 2026-08-23: la curva de calibracion del
+juicio metacognitivo se alimenta del ledger de ciclo de vida del bucle SCL
+(promocion humana canary→active = exito; revert = fallo), cerrando el bucle
+sin LLM y en infraestructura propia (CRIT-001).
+
+## Evidencia
+
+scripts/meta-recalibra-ledger.sh:scripts/meta-recalibrate.sh:output/learning-loop/lifecycle.jsonl
+
+## Diagnóstico
+
+Hasta ahora la curva de calibracion (meta-monitor) se nutria solo de fixtures o
+de entradas manuales. El conector del ledger traduce senal real del bucle en
+curva: una leccion que la operadora activa tras validacion es evidencia de
+acierto; un revert es evidencia de error introducido. Eso hace que el juicio
+metacognitivo se recailibre con la realidad operativa, no con datos sinteticos.
+
+## Cambio propuesto
+
+Integrar el conector como paso del ciclo de aprendizaje: tras registrar
+transiciones en el lifecycle ledger, alimentar la curva (por ejemplo en la
+automatizacion diaria del orquestador, tras el cierre del ciclo). La capa
+propone; la activacion sigue siendo humana (CRIT-031).
+
+## Destino
+
+skill
+
+## Métrica esperada
+
+sin baseline declarado

--- a/scripts/meta-recalibra-ledger.sh
+++ b/scripts/meta-recalibra-ledger.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# meta-recalibra-ledger.sh — L13 F4: recalibración desde señal real (ledger).
+#
+# Cierro el bucle F4: convierte la señal REAL del bucle SCL (ledger de ciclo de
+# vida en output/learning-loop/lifecycle.jsonl) en entradas de calibración para
+# meta-recalibrate.sh. La promoción canary→active por la operadora es "éxito"
+# (el sistema acertó: la lección sobrevivió la validación humana); el revert es
+# "fallo" (el cambio introdujo error). Sin LLM, sin red, CRIT-001.
+#
+# La curva así nutrida es la que meta-monitor.sh consulta después: el juicio
+# metacognitivo se recalibra con la realidad del bucle, no con fixtures.
+#
+# Usage:
+#   meta-recalibra-ledger.sh [--ledger PATH] [--calibration-file PATH]
+#     [--predicted 70] [--task-type default]
+# Exit: 0 ok (siempre; reporta) · 2 input inválido · 3 dependencia ausente
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEFAULT_LEDGER="$ROOT/output/learning-loop/lifecycle.jsonl"
+DEFAULT_CAL_FILE="$ROOT/output/meta/calibration.json"
+RECAL="$ROOT/scripts/meta-recalibrate.sh"
+
+LEDGER="$DEFAULT_LEDGER"
+CAL_FILE="$DEFAULT_CAL_FILE"
+PREDICTED="70"
+TASK_TYPE="default"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ledger) LEDGER="${2:-}"; shift 2 ;;
+    --calibration-file) CAL_FILE="${2:-}"; shift 2 ;;
+    --predicted) PREDICTED="${2:-}"; shift 2 ;;
+    --task-type) TASK_TYPE="${2:-}"; shift 2 ;;
+    *) echo "usage: $0 [--ledger P] [--calibration-file P] [--predicted N] [--task-type T]" >&2; exit 2 ;;
+  esac
+done
+
+[[ -x "$RECAL" ]] || { echo "ERROR: falta $RECAL (L13 F1)" >&2; exit 3; }
+[[ -f "$LEDGER" ]] || { echo "ERROR: ledger no encontrado: $LEDGER" >&2; exit 3; }
+
+mkdir -p "$(dirname "$CAL_FILE")"
+
+processed=0
+success=0
+fail=0
+skipped=0
+
+# Leer el ledger JSONL y traducir la señal ¬metadata.
+python3 - "$LEDGER" "$RECAL" "$CAL_FILE" "$PREDICTED" "$TASK_TYPE" <<'PY'
+import json, subprocess, sys
+ledger, rec, cal, predicted, task_type = sys.argv[1:]
+
+def recalibrate(task, outcome, predicted):
+    r = subprocess.run(
+        ["bash", rec, "--task", task, "--predicted", str(predicted),
+         "--outcome", outcome, "--calibration-file", cal],
+        capture_output=True, text=True,
+    )
+    return r.returncode == 0
+
+counts = {"processed": 0, "success": 0, "fail": 0, "skipped": 0}
+with open(ledger, encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except Exception:
+            counts["skipped"] += 1
+            continue
+        lp_id = ev.get("id", "")
+        if not lp_id:
+            counts["skipped"] += 1
+            continue
+        fr = ev.get("from", "")
+        to = ev.get("to", "")
+        revert = ev.get("revert", "false")
+        actor = ev.get("actor", "")
+        # Señal de "éxito": la operadora ha activado la lección (→active).
+        if to == "active" and actor == "operadora":
+            ok = recalibrate(f"{task_type}:{lp_id}", "success", predicted)
+            counts["success"] += ok
+        elif revert == "true" or (to == "proposed" and fr in ("canary", "active")):
+            # Señal de "fallo": reintrodujo error (revert) o fue reverted.
+            ok = recalibrate(f"{task_type}:{lp_id}", "fail", predicted)
+            counts["fail"] += ok
+        # Promociones agent→canary (o eventos sin señal humana) se omiten.
+        counts["processed"] += 1
+
+print(f"ledger_rows={counts['processed']} signal_success={counts['success']} signal_fail={counts['fail']} skipped={counts['skipped']}")
+PY

--- a/tests/test-l13-meta-recalibra-ledger.bats
+++ b/tests/test-l13-meta-recalibra-ledger.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+# L13 F4 — meta-recalibra-ledger (recalibración desde señal real del bucle SCL)
+# Linea: labs/roadmaps/l13-savia-metacognition.md (F4) / protocolo L13
+
+RECAL="scripts/meta-recalibra-ledger.sh"
+
+setup() {
+  cd "$(dirname "$BATS_TEST_FILENAME")/.." || exit 1
+  FIXDIR=$(mktemp -d)
+  cat > "$FIXDIR/lifecycle.jsonl" <<'EOF'
+{"id":"LP-A","from":"proposed","to":"canary","actor":"agent","revert":"false"}
+{"id":"LP-A","from":"canary","to":"active","actor":"operadora","revert":"false"}
+{"id":"LP-B","from":"canary","to":"active","actor":"operadora","revert":"false"}
+{"id":"LP-C","from":"proposed","to":"canary","actor":"agent","revert":"false"}
+{"id":"LP-C","from":"canary","to":"proposed","actor":"operadora","revert":"true"}
+EOF
+}
+
+teardown() {
+  rm -rf "$FIXDIR"
+}
+
+@test "existe, bash -n, sin vendor cloud names, PURE_BASH" {
+  [[ -x "$RECAL" ]]
+  bash -n "$RECAL"
+  run grep -niE "api\.openai\.com|api\.anthropic\.com|api\.deepseek\.com|api\.google\.com|api\.mistral\.ai" "$RECAL"
+  [[ "$status" -ne 0 ]]
+}
+
+@test "sin dependencia meta-recalibrate → exit 3" {
+  mkdir -p "$FIXDIR/empty"
+  cp "$RECAL" "$FIXDIR/empty/r.sh"
+  chmod +x "$FIXDIR/empty/r.sh"
+  run bash "$FIXDIR/empty/r.sh" --ledger "$FIXDIR/lifecycle.jsonl" --calibration-file "$FIXDIR/cal.json"
+  [[ "$status" -eq 3 ]]
+  [[ "$output" == *"meta-recalibrate.sh"* ]]
+}
+
+@test "ledger ausente → exit 3 (no inventar señal)" {
+  run bash "$RECAL" --ledger "$FIXDIR/no-existe.jsonl" --calibration-file "$FIXDIR/cal.json"
+  [[ "$status" -eq 3 ]]
+}
+
+@test "F4: activacion humana canary→active = señal success; revert = fail" {
+  run bash "$RECAL" --ledger "$FIXDIR/lifecycle.jsonl" \
+    --calibration-file "$FIXDIR/cal.json" --predicted 70
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"signal_success=2"* ]]
+  [[ "$output" == *"signal_fail=1"* ]]
+  local runs
+  runs=$(python3 -c "import json;d=json.load(open('$FIXDIR/cal.json'));print(len(d['runs']))")
+  [[ "$runs" -eq 3 ]]
+  python3 - "$FIXDIR/cal.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+out = sorted((r['task'].split(':')[-1], r['outcome']) for r in d['runs'])
+assert out == [('LP-A', 'success'), ('LP-B', 'success'), ('LP-C', 'fail')], out
+PY
+}
+
+@test "F4: señal escrita en curva alimenta meta-monitor (juicio recalibrado)" {
+  bash "$RECAL" --ledger "$FIXDIR/lifecycle.jsonl" \
+    --calibration-file "$FIXDIR/cal.json" --predicted 70 >/dev/null
+  # tarea tipo default con curva nutrida → calibración leída por meta-monitor
+  run bash scripts/meta-monitor.sh --task "default:LP-A" --confidence 80 \
+    --divergence 0.2 --evidence 0.9 --calibration-file "$FIXDIR/cal.json"
+  [[ "$status" -eq 0 ]]
+  echo "$output" | python3 -c "import sys,json;d=json.load(sys.stdin);print('calib',d['calibration']);assert d['calibration']>0"
+}
+
+@test "CRIT-031: el conector solo escribe la curva, nunca toca CRITERIO/ledger" {
+  local crit_before crit_after
+  crit_before=$(sha256sum CRITERIO.md 2>/dev/null | cut -d' ' -f1)
+  run bash "$RECAL" --ledger "$FIXDIR/lifecycle.jsonl" --calibration-file "$FIXDIR/cal.json"
+  crit_after=$(sha256sum CRITERIO.md 2>/dev/null | cut -d' ' -f1)
+  [[ "$crit_before" == "$crit_after" ]]
+  # el ledger original queda intacto
+  run python3 -c "
+import hashlib
+a=hashlib.sha256(open('$FIXDIR/lifecycle.jsonl','rb').read()).hexdigest()
+b=hashlib.sha256(b'''{\"id\":\"LP-A\",\"from\":\"proposed\",\"to\":\"canary\",\"actor\":\"agent\",\"revert\":\"false\"}\n{\"id\":\"LP-A\",\"from\":\"canary\",\"to\":\"active\",\"actor\":\"operadora\",\"revert\":\"false\"}\n{\"id\":\"LP-B\",\"from\":\"canary\",\"to\":\"active\",\"actor\":\"operadora\",\"revert\":\"false\"}\n{\"id\":\"LP-C\",\"from\":\"proposed\",\"to\":\"canary\",\"actor\":\"agent\",\"revert\":\"false\"}\n{\"id\":\"LP-C\",\"from\":\"canary\",\"to\":\"proposed\",\"actor\":\"operadora\",\"revert\":\"true\"}\n''').hexdigest()
+assert a==b, (a,b)
+"
+}
+
+@test "input inválido (arg desconocido) → exit 2" {
+  run bash "$RECAL" --bogus-flag x
+  [[ "$status" -eq 2 ]]
+}
+
+@test "reproducible: dos runs → misma curva" {
+  bash "$RECAL" --ledger "$FIXDIR/lifecycle.jsonl" --calibration-file "$FIXDIR/cal1.json" --predicted 70 >/dev/null
+  bash "$RECAL" --ledger "$FIXDIR/lifecycle.jsonl" --calibration-file "$FIXDIR/cal2.json" --predicted 70 >/dev/null
+  python3 -c "
+import json
+a=json.load(open('$FIXDIR/cal1.json')); b=json.load(open('$FIXDIR/cal2.json'))
+assert a['runs']==b['runs']
+"
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este PR cierra el último paso de la capa de "autoconfianza" de Savia: hacer que el sistema ajuste su predicción de "cuánto me fío de lo que respondo" usando datos reales de su propio funcionamiento, no pruebas de laboratorio.

Hasta ahora, la curva que usa Savia para calibrar su confianza se alimentaba de ejercicios sintéticos. Este PR añade un puente: cada vez que la operadora activa una lección aprendida (es decir, la valida como buena), eso cuenta como un acierto en la curva de calibración; cada vez que una lección se revierte (porque introdujo un error), cuenta como fallo. Ese historial ya se registraba en la bitácora interna del bucle de aprendizaje; ahora se aprovecha.

El efecto práctico es que la confianza de Savia deja de ser un número declarado y pasa a estar respaldada por su historial real de aciertos y errores. Con el tiempo, la capa que decide "puedo emitir, o mejor me detengo y pido más información" se vuelve más precisa sobre su propio desempeño, todo ejecutado en la máquina local sin llamar a ningún proveedor ni sacar datos del workspace.

No cambia ningún comportamiento existente: no toca los criterios publicados, ni la constitución, ni la bitácora. Solo añade el mecanismo que convierte esa bitácora en señal de confianza, con sus pruebas automáticas, y documenta la lección en el registro de aprendizaje como propuesta sin activar. El siguiente paso natural (dejado para la operadora y para la línea de investigación) es decidir con qué frecuencia integrar este puente en el ciclo diario.