### PR TITLE
fix(scl): restringir guard URL de learning-federate a modos remotos (SCL-009)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=b5eee9ade13df3732811e6d2e3ae0804c62ec8281d05cfba1f0930a2f3e3cfa3
-timestamp=2026-08-23T08:28:54Z
-branch=agent/consolidacion-node-requisito
-head_commit=d2b322b3
-signature=12b5b894615e446712c00405a604e98cd9c7831c6b3bf2772b1f11557dd0b7c4
+diff_hash=14fb202b2e3b13fc1552d5bff41bff10c51d6db3d0307b821f61c78ed37436c2
+timestamp=2026-08-23T09:37:01Z
+branch=agent/fix-scl009-federate-modos-locales
+head_commit=01739dab
+signature=8123d6a8ac3260030555bd07bcd5935b02eedf58ad890a524f21b066fd869c2a

--- a/CHANGELOG.d/fix-scl009-federate-modos-locales.md
+++ b/CHANGELOG.d/fix-scl009-federate-modos-locales.md
@@ -1,0 +1,9 @@
+---
+version_bump: minor
+section: Fixed
+---
+
+### Fixed
+
+- Corrige regresión SCL-009: guard de URL de learning-federate aplicado solo a modos remotos (--share/--search-remote); --list/--import locales vuelven a funcionar
+

--- a/docs/learning-proposals/LP-20260823-c3d6c721.md
+++ b/docs/learning-proposals/LP-20260823-c3d6c721.md
@@ -1,0 +1,39 @@
+---
+id: LP-20260823-c3d6c721
+type: learning_proposal
+provenance: INFERRED
+lifecycle: proposed
+origin: savia-orchestrator (SCL-011): tarea 'fixture bats orquestador'
+trigger: recurrence
+target: skill
+criterion_id: 
+evidence_hash: c3d6c72118c28f8e93d7df08bf8df68c34da609f8f2b4c31b646d899861ca601
+created_utc: 2026-08-23T09:27:20Z
+expected_p_consistent: 
+---
+
+# Learning Proposal LP-20260823-c3d6c721
+
+## Origen
+
+savia-orchestrator (SCL-011): tarea 'fixture bats orquestador'
+
+## Evidencia
+
+/home/monica/savia/scripts/savia-orchestrator.sh:db4d7a7764cbb198ca1252c2a2545bad98f62206d41455b8a5e98e1a7c1bb589
+
+## Diagnóstico
+
+orquestador SCL-011 procesó la tarea; propuesta de aprendizaje generada (propuesta determinista shadow)
+
+## Cambio propuesto
+
+propuesta determinista shadow
+
+## Destino
+
+skill
+
+## Métrica esperada
+
+sin baseline declarado

--- a/scripts/learning-federate.sh
+++ b/scripts/learning-federate.sh
@@ -57,6 +57,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 # ── SCL-009: resolver URL desde el registry si no se pasó --url/--to ────────
+# Requisito de URL SOLO para modos remotos (--share/--search-remote). Los modos
+# locales (--list/--import) leen la cúpula local y no necesitan REMOTE_URL.
 if { $SEARCH_REMOTE || [[ -n "$SHARE_ID" ]]; } && [[ -z "$REMOTE_URL" ]]; then
   REG="${SCL_FEDERATION_REGISTRY:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.savia-vault/federation.json}"
   if [[ -f "$REG" ]]; then
@@ -73,10 +75,10 @@ print('')
 PYEOF
     )
   fi
-fi
-if [[ -z "$REMOTE_URL" ]]; then
-  echo "ERROR: no --url/--to y ninguna instancia healthy en el registry — usa federation-discover.sh --check" >&2
-  exit 2
+  if [[ -z "$REMOTE_URL" ]]; then
+    echo "ERROR: no --url/--to y ninguna instancia healthy en el registry — usa federation-discover.sh --check" >&2
+    exit 2
+  fi
 fi
 
 # ── Modo search-remote (SCL-007): busca en un dome remoto via /search ──


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este PR corrige una regresión introducida en la federación de lecciones aprendidas
(SCL-009). Al añadir auto-descubrimiento de servidores remotos, se dejó un control
de seguridad que se aplicaba a todas las operaciones — incluido listar e importar
lecciones de la cúpula local de Savia, que nunca necesitan conexión con ningún
servidor externo. Consecuencia: ver listado de lecciones o importarlas localmente
fallaba con un error de "servidor no encontrado". Este cambio limita ese control a
las operaciones que sí requieren red (compartir y buscar en remoto), devolviendo a
las operaciones locales su funcionamiento normal. Se añade una propuesta de
aprendizaje determinista generada por el orquestador SCL-011 durante la verificación.
## Summary
fix(scl): restringir guard URL de learning-federate a modos remotos (SCL-009)
### Changes
- 01739dab docs(changelog): fragment fix-scl009 para PR
- 9d84d290 agent(scl): LP shadow determinista del orquestador — fixture bats SCL-011
- dee0afbf fix(scl): restringir guard URL de federate a modos remotos --share/--search-remote
### Stats
4 files changed across 3 commits.
## Test plan
- [x] CI passed  - [x] Signed
