### PR TITLE
docs(domains): catalogo Savia Domains + spec SE-342 capa de datos local

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=23e0586230d6c13c83fc91f47e5e9831bcd702040eeaa677c9fa9fb2d0a0b505
-timestamp=2026-08-23T13:52:47Z
-branch=agent/l13-cierre-metacognicion
-head_commit=a9005801
-signature=4cc1cebf872859080eed7963fcf019c754d3f22edab494ae5e3141ab151d3448
+diff_hash=955516a0a3a161458d19a725a37c7c505f3d4874b33cf7b8b0faaa68f725ae54
+timestamp=2026-08-24T07:15:20Z
+branch=agent/se342-domains-data-intelligence-20260823
+head_commit=727fd5be
+signature=528447de8ff1af435e98e887a613f062bb555d3ca13061903e2ff690b1f0f94f

--- a/CHANGELOG.d/se342-data-intelligence-local.md
+++ b/CHANGELOG.d/se342-data-intelligence-local.md
@@ -1,0 +1,22 @@
+---
+version_bump: patch
+section: Added
+---
+
+### Added
+
+- **SE-342 Capa de Inteligencia de Datos Local** — `docs/specs/SE-342-data-intelligence-local.spec.md`:
+  - Analisis de capacidades de datos + IA de la plataforma lakehouse de
+    referencia (22 capacidades) y mapeo contra el stack local de Savia
+    (15 cubiertas, 3 parciales, 4 gaps).
+  - 5 slices priorizados + 1 opcional (S1-S6): catálogo de activos de datos con
+    lineage, experiment tracking, monitor de calidad + feature store, gateway de
+    modelos, prediccion asistida local y vector store hibrido en cupulas.
+  - CRIT-001 explicito: sin datos fuera de infraestructura propia.
+- **Savia Domains — `docs/domains/savia-domains-catalog.md`** (Labs L23):
+  - Catalogo abierto N1 de 34 dominios / 11 categorias para cupulas de
+    conocimiento por vertical.
+  - Exclusiones de dominios sensibles (quimica, farmacia, medicina, salud,
+    armamento, biotecnologia dual).
+  - Direccion estrategica: Savia Domains + SaviaVaults como capa de datos por
+    dominio soberana, local y libre (sección 6).

--- a/docs/domains/savia-domains-catalog.md
+++ b/docs/domains/savia-domains-catalog.md
@@ -1,0 +1,172 @@
+---
+entity: {type: document, id: savia-domains-catalog}
+title: Savia Domains — Catálogo abierto de dominios de conocimiento
+doc_type: catalog
+status: v0.1 (catalogacion)
+confidentiality: N1
+source: "Labs L23 — Savia Domains"
+tags: [domains, catalog, verticals, cupulas, open-source, labs]
+created_at: 2026-08-23
+---
+
+# Savia Domains — Catálogo abierto de dominios de conocimiento
+
+> Catálogo de dominios (verticales) para los que Savia construirá **cúpulas de
+> conocimiento propias, abiertas y publicadas en este repositorio** (pm-workspace).
+> Base para trabajar verticales sin reinventar ni duplicar conocimiento.
+> **Esta fase es CATALOGACIÓN**: la digestión de cada dominio (ingesta de
+> contenido en su cúpula) vendrá después, cuando el catálogo esté definido.
+
+## 1. Propósito
+
+1. Definir la taxonomía de dominios en los que Savia opera o quiere operar.
+2. Servir de **base neutra** para crear cúpulas de conocimiento por vertical
+   (SaviaVaults), reutilizando skills, reglas y agentes transversales.
+3. Evitar solapes: cada dominio tiene un ID único y una cúpula destino.
+4. Mantener la apertura: el catálogo y las cúpulas son contenido **N1
+   (público)** — conocimiento genérico de referencia, nunca datos de
+   empresa/cliente/persona (N2-N4b van aparte).
+
+## 2. Criterios de inclusión / exclusión
+
+**Inclusión** — un dominio entra cuando es: un sector o área de conocimiento
+con cuerpo propio, con demanda real de trabajo vertical, y no conflictivo.
+
+**Exclusión (dominios sensibles o polémicos)** — fuera del catálogo:
+química, farmacia, medicina y salud (biomédico clínico), armamento y defensa,
+biotecnología dual, y cualquier dominio con riesgo de uso dual alto.
+La decisión es de la operadora (Labs L23) y aplica a cúpulas públicas.
+
+## 3. Taxonomía y catálogo (v0.1)
+
+Estructura: **Categoría → Dominio (ID) → Temas objetivo** (para digestión
+posterior, NO digeridos aún). La columna *Capacidad Savia* lista lo que ya
+existe y sirve de cimiento.
+
+| ID | Categoría | Dominio | Temas objetivo (digestión posterior) | Capacidad Savia existente |
+|---|---|---|---|---|
+| PUA | Sector público | Administración pública y gobierno digital | Procesos administrativos, digitalización de servicios públicos, interoperabilidad, datos abiertos | legal-compliance (RGPD) |
+| CON | Sector público | Contratación pública | Licitaciones, LCSP, procedimientos de adjudicación, pliegos, recursos | legalize-es (parcial) |
+| LEG | Legal y normativa | Derecho general | Civil, mercantil, laboral, administrativo, redacción de documentos | legal-compliance, professional-domain/legal |
+| CMP | Legal y normativa | Compliance y regulación | RGPD, EU AI Act, normativa sectorial, matrices de riesgo | legal-compliance, regulatory-compliance |
+| BNK | Finanzas | Banca | Productos bancarios, riesgos, normativa (BASEL), pagos, crédito | banking-architecture |
+| INS | Finanzas | Seguros | Productos aseguradores, riesgos, siniestros, solvencia | — |
+| FNC | Finanzas | Finanzas corporativas | Tesorería, DCF, valoración, inversión | professional-domain/finance |
+| CTR | Finanzas | Controlling y gestión | KPIs, desviaciones, reporting mensual | professional-domain/controlling |
+| SFT | Tecnología | Ingeniería de software | Arquitectura, lenguajes, DevOps, testing, calidad | 16 language packs, architect, courts |
+| AID | Tecnología | IA y datos | ML, LLM, data engineering, RAG, MLOps | SE-027, tabular-intelligence, vaults, graph |
+| CYB | Tecnología | Ciberseguridad | OWASP, red team, hardening, normativa | security-* agents, skills de seguridad |
+| TLC | Tecnología | Telecomunicaciones | Redes, 5G, protocolos, infraestructura de red | — |
+| ELC | Electrónica | Electrónica | Analógica/digital, componentes, diseño de PCB, sensores | — |
+| SEM | Electrónica | Microelectrónica y semiconductores | Chips, fabricación, cadenas de suministro | — |
+| RBT | Robótica | Robótica | Industrial, de servicio, autónoma, ROS, percepción | robotics-roadmap, mobile-dev |
+| AUT | Robótica | Automatización industrial | PLC, SCADA, control, gemelo digital de planta | — |
+| EDU | Educación | Educación | Pedagogía, currículos, FP, universidad | savia-school |
+| EVA | Educación | E-learning y formación online | LMS, contenidos formativos, evaluación | savia-school |
+| POW | Electricidad | Electricidad y sistemas eléctricos | Redes, generación, distribución, instalaciones | — |
+| REN | Electricidad | Energías renovables | Solar, eólica, almacenamiento, balance de red | L10 (energy forecasting) |
+| EFF | Electricidad | Eficiencia energética | Auditorías, gestión de demanda, certificación | — |
+| INF | Infraestructuras | Infraestructuras y obra civil | Construcción, BIM, ciclo de vida de activos | infrastructure-agent (TI), digital twin |
+| MOV | Infraestructuras | Transporte y movilidad | Logística urbana, transporte público, movilidad | — |
+| IDS | Industria | Industria y fabricación | Procesos, calidad, lean, gemelo digital | — |
+| LOG | Industria | Logística y cadena de suministro | Warehouse, inventario, transporte, trazabilidad | — |
+| RTL | Comercio | Retail y comercio | E-commerce, retail, merchandising | professional-domain/sales |
+| SLS | Comercio | Ventas B2B | Pipeline, MEDDIC, propuestas | professional-domain/sales |
+| MKT | Comercio | Marketing y comunicación | Campañas, marca, contenidos, analítica | — |
+| HRS | Personas | Recursos humanos y trabajo | Nóminas, convenios, onboarding, conflictos laborales | professional-domain/labour |
+| AGR | Sector productivo | Agroalimentación | Agricultura, alimentación, trazabilidad | — |
+| TUR | Sector productivo | Turismo y hostelería | Hotelería, destinos, estacionalidad | — |
+| CUL | Sector productivo | Cultura y patrimonio | Patrimonio, museos, industrias culturales | — |
+| MDS | Sector productivo | Medios y comunicación | Periodismo, contenidos, audiencias | — |
+| SUS | Transversal | Sostenibilidad y medio ambiente | ESG, economía circular, huella de carbono | — |
+
+**Programas verticales:** un programa vertical integra varios dominios del
+catálogo para un fin concreto.
+
+- **Savia Farming** (Labs L24, 2026-08-23): rediseña el sector primario con
+  robótica, electrónica, informática, mecánica e IA, e integra los dominios
+  **AGR** (Agroalimentación), **RBT** (Robótica), **ELC** (Electrónica),
+  **POW/REN/EFF** (Electricidad y energía), **AID** (IA y datos) e **INF**
+  (Infraestructuras) — en clave de soberanía distribuida (datos agronómicos
+  gobernados en infraestructura propia, CRIT-001).
+- **Savia Humanity** (Labs L25, 2026-08-23): estudia el envejecimiento y la
+  transición demográfica, el cuidado de personas mayores y dependientes, y la
+  producción de alimentos — **enlazada con Savia Farming**. Integra **HRS**
+  (Recursos humanos y trabajo: cuidados), **RBT** (robótica asistencial),
+  **AID** (IA y datos) e **INF** (infraestructuras de teleasistencia). Frontera
+  ética (regla L23): el cuidado social y la autonomía sí; el contenido
+  biomédico clínico, no.
+
+## 4. Ciclo de vida de un dominio
+
+```
+PROPUESTO ──(validacion operadora)──► CATALOGADO ──► CUPULA CREADA ──► DIGERIDO
+  (candidato)                          (en este doc)  (SaviaVaults, N1)  (contenido ingerido)
+```
+
+- **Catalogado** = tiene fila en este catálogo con ID y temas objetivo.
+- **Cúpula creada** = domo abierto en SaviaVaults (N1) con su DOMAIN.md.
+- **Digerido** = contenido de referencia ingerido (skills, normas, patrones) —
+  fase posterior, alineada con la digestión de SE-342 y el puente de dominio
+  de `knowledge-graph-domain-bridge.py`.
+
+## 5. Apertura y soberanía (CRIT-001)
+
+- El catálogo y las cúpulas de dominio son **contenido N1 publicado en este
+  repositorio**: conocimiento genérico, reusable y abierto.
+- Los datos de empresa/cliente/persona (N2-N4b) jamas se mezclan con el
+  contenido de dominio: las cúpulas de Savia Domains son conocimiento, no datos.
+- CRIT-001: todo el ciclo corre en infraestructura propia; datos N3+ jamas
+  salen a proveedor cloud.
+
+## 6. Dirección estratégica — capa de datos por dominio, soberana
+
+Existe un modelo comercial de referencia de "capa de datos para agentes": un
+servicio en nube que pre-procesa el conocimiento público, lo organiza por
+**directorios de dominio** (cada vertical con sus fuentes y su esquema tipado),
+lo sirve como **hechos estructurados** (no prosa) con proveniencia, períodos de
+validez y cita de fuente, y expone **un único endpoint MCP** que cualquier
+agente del protocolo puede consultar. Se paga por consulta (créditos) y todo se
+hospeda en el perímetro del proveedor.
+
+**Savia Domains + SaviaVaults es la alternativa soberana, local y libre** de ese
+modelo:
+
+| Capacidad del modelo comercial | Equivalente soberano en Savia |
+|---|---|
+| Directorios de dominio | Este catálogo → cúpulas por dominio (SaviaVaults) |
+| Hechos tipados con lineage y validades | `knowledge-graph.py` (entidades+relaciones tipadas), catálogo L17 |
+| Ingesta de fuentes públicas | Pipeline de digestión (pdf/word/excel/reuniones) |
+| Búsqueda / consulta | Búsqueda híbrida BM25+vector (L22) sobre cúpulas |
+| Endpoint único MCP para agentes | MCP server del vault (SaviaVaults) |
+| Verificación / proveniencia | Cita de fuente + hash de contenido |
+
+Diferenciales: **soberano** (CRIT-001: datos N3+ jamás salen, ni temporal ni
+anonimizados a mano), **local** (Ollama/LocalAI, SQLite, git en el workspace),
+**libre y abierto** (sin API key, sin créditos, sin metering; cúpulas N1 en este
+repo), y **exclusiones por diseño** (los dominios sensibles del §2 quedan fuera
+del catálogo). La brecha real no es tecnológica sino de **contratos de consulta
+tipada por dominio** y **corpus estructurado** — ambos se resuelven en la fase de
+digestión.
+
+## 7. Próximos pasos
+
+1. **Validar este catálogo** con la operadora (Labs L23) — ajustar dominios,
+   IDs o exclusiones antes de abrir cúpulas.
+2. Crear cúpulas N1 por dominio (una por prioridad de vertical).
+3. Digerir dominios priorizados (skill + DOMAIN.md + corpus de referencia).
+4. Definir **contrato de consulta tipada por dominio** (operaciones + esquema)
+   sobre el MCP del vault, a imagen del modelo de referencia (§6).
+5. Alimentar el grafo de conocimiento (entity types por dominio).
+
+---
+
+## Referencias
+
+- Labs: línea **L23 — Savia Domains** (cúpula SaviaLabs).
+- Cúpulas: SaviaVaults (SE-280..SE-331); contenido N1 según
+  `docs/confidentiality-levels.md`.
+- Cimientos: `professional-domain/` (legal, finance, labour, sales,
+  controlling), `legal-compliance` (legalize-es), `savia-school`,
+  `banking-architecture`, L10 (energía), `robotics-roadmap`.
+- Deuda/evolución: `docs/savia-future-analysis-2026-08-23.md`, SE-342.

--- a/docs/specs/SE-342-data-intelligence-local.spec.md
+++ b/docs/specs/SE-342-data-intelligence-local.spec.md
@@ -1,0 +1,344 @@
+# Spec: SE-342 — Capa de Inteligencia de Datos Local
+
+**Task ID:**        SE-342
+**PBI padre:**      SE-342 — Datos + IA sobre infraestructura propia
+**Sprint:**         2026-08
+**Fecha creacion:** 2026-08-23
+**Creado por:**     Savia (benchmark de plataforma lakehouse de referencia)
+
+**Developer Type:** agent-team
+**Asignado a:**     python-developer + typescript-developer
+**Estado:**         PROPOSED
+
+**Effort Estimation (Dual Model):**
+
+| Dimension | Value |
+|---|---|
+| Agent effort | 20 h (5 slices) |
+| Human effort | 24 h |
+| Review effort | 2 h |
+| Context risk | medium |
+| Agent-capable | partial |
+| Fallback | Si agente falla: humano necesita 12h (catálogo y monitor de calidad son los delicados) |
+
+---
+
+## 1. Contexto y Objetivo
+
+La operadora pidió analizar qué hace una **plataforma lakehouse de referencia**
+(plataforma comercial unificada de datos + IA, operada en la nube de terceros),
+qué funciones de IA ofrece, cuáles de esas capacidades ya existen en Savia y
+cuáles nos interesaría desarrollar. La instrucción es explícita: **no se cita la
+marca en ningún documento o archivo de Savia** — esta spec la denomina
+genéricamente "la plataforma de referencia".
+
+El análisis completo (qué hace, stack de IA, mapeo contra Savia, gaps) está en
+el §2. La conclusión operativa:
+
+- Savia **ya cubre** el núcleo de datos + IA de la plataforma de referencia con
+  stack 100 % local: ingestión/digestión, memoria y cúpulas, grafo de
+  conocimiento, entrenamiento y despliegue de SLMs propios, embeddings, RAG
+  híbrido, agentes orquestados y tribunales de calidad.
+- Lo que la plataforma de referencia ofrece **y Savia no tiene** se reduce a
+  cinco piezas de capa de datos/IA: catálogo de activos con lineage,
+  experiment tracking, monitor de calidad de datos + feature store, gateway de
+  modelos, y predicción asistida local. Todas construibles sobre sustrato propio
+  (SQLite, git, Ollama/LocalAI, Unsloth, sentence-transformers, scikit-learn).
+
+**Por qué NO se adopta la plataforma de referencia:** es cloud-managed y gestiona
+los datos del cliente dentro de su perímetro. Eso viola **[CRIT-001]** — ante
+opciones equivalentes gana la que mantiene los datos en infraestructura propia;
+datos N3+ jamás salen a proveedor cloud, ni siquiera temporalmente o anonimizados
+a mano — y la soberanía (ART-07, ART-17 de la Constitución). No hay opción
+equivalente "autoalojada" de esa plataforma: su modelo de negocio ES la gestión
+en su perímetro. Por tanto la decisión es desarrollar los equivalentes locales.
+
+**Objetivo de esta spec:** cerrar los cinco gaps con slices incrementales,
+cada uno con criterios de aceptación y esfuerzo, priorizados por valor y
+dependencia. Cada slice mantiene la regla de cero fuga de datos (SE-093) y el
+patrón local-first ya probado en SE-027/SE-296/SE-304/SE-280.
+
+---
+
+## 2. Análisis de la plataforma de referencia y mapeo contra Savia
+
+### 2.1 Qué hace la plataforma de referencia
+
+**Núcleo de datos (arquitectura "lakehouse"):** unifica lago de datos y warehouse
+sobre formatos abiertos con transacciones ACID; computación distribuida;
+motor de consulta SQL; BI conversacional (chatbot que responde a preguntas de
+negocio sobre los datos); pipelines de datos declarativos con orquestación;
+streaming y procesamiento transaccional-analítico en una sola copia; catálogo
+unificado de datos con gobernanza, linaje y control de acceso; compartición de
+datos entre organizaciones; y monitorización de calidad/drift de datos.
+
+**Stack de IA (integrado en la misma plataforma):**
+
+| Capacidad de IA | Qué es |
+|---|---|
+| Entrenamiento de modelos | Fine-tuning y pre-training de LLMs sobre los datos del cliente |
+| Experiment tracking | Registro de runs: parámetros, métricas, artefactos, comparación |
+| Model registry | Ciclo de vida de modelos: versionado, promoción, deprecación |
+| Feature store | Ingeniería de features versionados, reutilizables en entrenamiento y en producción |
+| Model serving | Despliegue de modelos/LLMs como endpoints REST (real-time, streaming, batch) |
+| AI gateway | Capa única de acceso a modelos con gobernanza, log de uso y payload |
+| Foundation model APIs | Acceso a LLMs de terceros dentro del perímetro seguro |
+| Vector search | Búsqueda vectorial para RAG sobre documentos propios |
+| Agente de ciencia de datos | Agente autónomo que explora datos, construye y itera modelos |
+| Framework de agentes | Entorno para construir, evaluar y desplegar agentes de IA |
+| AutoML | Generación automática de modelos desde datos crudos |
+| Meta-harness de agentes | Capa de interfaz común sobre agentes CLI de distintos modelos |
+
+### 2.2 Equivalente en Savia
+
+| # | Capacidad de la referencia | Equivalente en Savia (real, local) | Estado |
+|---|---|---|---|
+| 1 | Lakehouse (lago+warehouse ACID) | Cúpulas SaviaVaults (git-backed) + knowledge-graph (SQLite) + memoria | ✅ cubierto (escala local) |
+| 2 | Computación distribuida | — | ➖ no relevante a escala Savia |
+| 3 | Motor SQL / consulta | sqlite3/polars + `tabular-profile.py` (estadística determinista) | ✅ cubierto |
+| 4 | BI conversacional / reporting | Informes (weekly/executive/KPI), `sprint-management`, `project-update`, chat savia-web | ✅ cubierto (sin dashboard en vivo) |
+| 5 | Streaming / HTAP | — | ➖ sin fuentes de streaming |
+| 6 | Pipelines declarativos | `automation-scheduler` (SE-304), pipeline de digestión (excel/pdf/word/ppt), `dag-scheduling` | 🟡 parcial: sin DAG de datos versionado |
+| 7 | Catálogo unificado + lineage | knowledge-graph + vaults dispersos; niveles N1-N4b en reglas | 🔴 **GAP → S1** |
+| 8 | Compartición de datos | Federación de cúpulas (SE-263, SE-282, SE-331) | ✅ cubierto |
+| 9 | Monitor de calidad/drift de datos | `tabular-profile.py` puntual; `savia-monitor` (infra) | 🔴 **GAP → S3** |
+| 10 | Seguridad agentic | security-* agents, `confidentiality-auditor`, `commit-guardian`, N1-N4b | ✅ cubierto |
+| 11 | Entrenamiento de modelos | `slm-train.sh` (SE-027, Unsloth local, SFT/DPO, export GGUF→Ollama, zero egress) | ✅ cubierto |
+| 12 | Experiment tracking | — (el registry guarda versiones finales, no runs) | 🔴 **GAP → S2** |
+| 13 | Model registry | `slm-registry.sh` (register/list/show/promote/deprecate por proyecto) | ✅ cubierto (extiende en S2) |
+| 14 | Feature store | — | 🔴 **GAP → S3** |
+| 15 | Model serving | LocalAI/Ollama + `savia-dual` (failover) + `slm-deploy.sh` + `embedding-server.py` | ✅ cubierto |
+| 16 | AI gateway | — (acceso directo a endpoints locales sin log unificado) | 🔴 **GAP → S4** |
+| 17 | Foundation model APIs | `savia-dual` / `emergency-mode`, contratos multi-proveedor (SE-294) | ✅ cubierto |
+| 18 | Vector search / RAG | `memory-vector.py` + `embedding-server.py` + SCL-005 (híbrido) + SE-143; vaults BM25 sin vector | 🟡 parcial → **S6 (opcional)** |
+| 19 | Agente de ciencia de datos | `tabular-analyst` (describe; no predice); orquestador SAGI | 🟡 parcial → **S5** |
+| 20 | Framework de agentes + evaluación | 83 agentes, courts/tribunals, `evaluations-framework`, `verification-lattice`, spec-judge | ✅ cubierto |
+| 21 | AutoML | Estadística determinista (SE-296), sin generación de modelos | 🟡 parcial → **S5** |
+| 22 | Meta-harness de agentes | El workspace Savia es el harness; orquestador SAGI + subagentes | ✅ cubierto |
+
+**Veredicto:** 15 de 22 capacidades ya están cubiertas con stack local. Los cinco
+gaps reales (S1-S4 + S5) son la oportunidad de desarrollo.
+
+---
+
+## 3. Objetivo — slices propuestos
+
+Orden de implementación por dependencia (S1 es la base de lineage de S2/S3):
+
+### Slice 1 — Catálogo de activos de datos local (SaviaCatalog) [ALTA, 6h]
+
+**Diseño:** extensión de `scripts/knowledge-graph.py` con un catálogo de activos
+de datos por proyecto: datasets (ficheros digeridos y su hash), features, modelos
+(registrados por `slm-registry.sh`), informes generados, y cúpulas. Cada activo
+tiene nivel de confidencialidad N1-N4b (regla `context-placement-confirmation`)
+y registra **lineage**: dataset → digestión → features → modelo → informe. Es el
+equivalente local del catálogo unificado, sobre SQLite + git, sin ningún flujo a
+cloud.
+
+**Criterios de aceptación:**
+- AC-1.1. `savia-catalog.sh register` indexa un dataset (path, hash, tamaño,
+  nivel N, fuente) y `show` devuelve su ficha.
+- AC-1.2. Lineage consultable: dado un modelo registrado, se listan los datasets
+  de entrenamiento y los informes que lo consumen (un hop, determinista).
+- AC-1.3. Nivel de confidencialidad obligatorio en `register`: un dataset sin
+  nivel N declarado se rechaza.
+- AC-1.4. Test BATS: registrar dataset→feature→modelo→informe produce un grafo
+  de 4 nodos y 3 aristas consistentes con el CSV esperado.
+- AC-1.5. No se añade ninguna dependencia de red ni proveedor externo.
+
+**Esfuerzo:** 6h
+
+### Slice 2 — Experiment tracking local + lineage de modelo [ALTA, 4h]
+
+**Diseño:** extensión de `slm-registry.sh` con registro de **runs**: cada
+entrenamiento (SFT/DPO) anota params (base model, epochs, lr, tokens), métricas
+(final_loss, eval) y artefactos (GGUF path) junto con el dataset de origen
+tomado del catálogo S1. El manifest pasa de "versión final" a "historial de
+runs + versión promovida". Equivalente local de experiment tracking + registry
+integrado con lineage.
+
+**Criterios de aceptación:**
+- AC-2.1. `slm-registry.sh run log --project X` crea un run con params/métricas
+  y lo enlaza al dataset del catálogo S1.
+- AC-2.2. `slm-registry.sh runs compare --project X` compara 2+ runs con métricas
+  en tabla plana (determinista).
+- AC-2.3. `promote` solo acepta un run con `final_loss` y dataset de origen
+  presentes; en caso contrario falla con mensaje claro.
+- AC-2.4. Test BATS: log de 3 runs + promote del mejor (por métrica explícita)
+  → manifest correcto y `show` consistente.
+- AC-2.5. Compatibilidad hacia atrás: manifests de `slm-registry.sh` existentes
+  siguen leyéndose (migración sin pérdida).
+
+**Esfuerzo:** 4h
+
+### Slice 3 — Monitor de calidad de datos local + Feature Store [ALTA, 6h]
+
+**Diseño:** dos piezas sobre la capa determinista ya probada (SE-296):
+
+1. **Monitor de calidad:** `tabular-profile.py` gana subcomando `monitor` que
+   persiste un baseline por dataset (freshness, completeness, tipos, range,
+   perfil) y detecta drift en ejecuciones posteriores (schema change, missing
+   > umbral, valores fuera de rango, anomalías IQR). Alertas a
+   `automation-scheduler` como tarea programada.
+2. **Feature store local:** registro de features versionadas (nombre, dataset
+   origen, fórmula/derivación, nivel N) reutilizables entre informes y modelos.
+   Persistencia en el catálogo S1.
+
+**Criterios de aceptación:**
+- AC-3.1. `monitor init` sobre un dataset guarda baseline; una mutación real del
+  fixture (columna nueva, 20 % missing) → `monitor check` la reporta con diff.
+- AC-3.2. Umbrales configurables por dataset (freshness días, completeness %);
+  por defecto: freshness 7d, completeness 95 %.
+- AC-3.3. `feature register` + `feature list` versionado; una feature reutilizada
+  en dos informes aparece con lineage a ambos.
+- AC-3.4. Sin fuga: los datos nunca salen del proceso local (mismo aislamiento
+  que SE-093).
+- AC-3.5. Test BATS: baseline→mutación→detección, y registro/reuso de feature.
+
+**Esfuerzo:** 6h
+
+### Slice 4 — Gateway de modelos local [MEDIA, 3h]
+
+**Diseño:** capa única de acceso a modelos locales (Ollama/LocalAI +
+`embedding-server.py` + SLMs desplegados) con: registro de uso (modelo, llamante,
+tokens/tiempo), **redacción de payloads** (campos N3+ nunca se loguean — se
+sustituyen por hash), límites por llamante (rate-limit local), y un endpoint
+único tipo API proxy para que skills/agentes no hablen con el runtime directo.
+Equivalente local del AI gateway.
+
+**Criterios de aceptación:**
+- AC-4.1. Un cliente que llama a `/v1/chat` vía el gateway recibe la respuesta del
+  runtime local y el uso queda registrado en JSONL.
+- AC-4.2. Payload con campo marcado N3+ se loguea redactado (hash), nunca en
+  claro (verificación con grep sobre el log).
+- AC-4.3. Límite por llamante configurable: excedido → 429 con cabecera
+  de reintento.
+- AC-4.4. Test BATS: uso registrado, redacción verificada, rate-limit respeta.
+
+**Esfuerzo:** 3h
+
+### Slice 5 — Predicción asistida local (tabular-analyst predict) [MEDIA, 5h]
+
+**Diseño:** `tabular-analyst` extiende su modo "describe" con un modo "predict"
+opcional: dado un dataset y una columna objetivo, entrena un modelo local
+(scikit-learn, árbol/bosque/regresión según tipo), reporta métricas de
+validación y guarda el artefacto en el catálogo S1 con lineage. **Nunca**
+instala TFMs (se reafirma la decisión de SE-296), nunca envía datos fuera. El
+resultado es un informe de viabilidad predictiva (¿hay señal?, ¿qué columnas
+importan?), no un servicio en producción.
+
+**Criterios de aceptación:**
+- AC-5.1. Dataset fixture con target numérico → informe con RMSE/R² de
+  validación cruzada y top-5 features por importancia.
+- AC-5.2. Target categórico → precisión macro + matriz de confusión en el
+  informe.
+- AC-5.3. El modelo y su informe quedan registrados en el catálogo S1 con
+  lineage al dataset (sin esto, el slice falla).
+- AC-5.4. Columna objetivo ausente o dataset con <50 filas → respuesta
+  explícita de no-viabilidad, sin entrenar.
+- AC-5.5. Determinista en semilla fija: mismo dataset → mismo informe.
+
+**Esfuerzo:** 5h
+
+### Slice 6 — Vector store unificado en cúpulas (RAG sobre documentos) [BAJA, opcional, 4h]
+
+**Diseño:** extiende SaviaVaults con índice vectorial local (por defecto el mismo
+`embedding-server.py`) en modo híbrido BM25+vector sobre las notas de cúpula,
+para RAG sobre documentos completos (no solo memoria del sistema). No es nuevo
+motor: es la consolidación de SCL-005/SE-143 dentro del vault.
+
+**Criterios de aceptación:**
+- AC-6.1. `vault search --hybrid "consulta"` devuelve resultados fusionados
+  BM25+vector con puntuación combinada determinista.
+- AC-6.2. Índice vectorial versionado y reconstruible (`vault index --rebuild`).
+- AC-6.3. Las notas de nivel N3+ no se embeben fuera de la cúpula local.
+
+**Esfuerzo:** 4h (opcional, se decide en aprobación)
+
+---
+
+## 4. Fuera de alcance
+
+- **NO** se adopta la plataforma de referencia ni ningún servicio cloud-managed
+  de datos/IA (CRIT-001).
+- **NO** streaming ni procesamiento transaccional-analítico: Savia no tiene
+  fuentes de streaming hoy; cuando existan se revisa.
+- **NO** computación distribuida tipo Spark: escala innecesaria para el volumen
+  de Savia (SQLite + git cubren).
+- **NO** dashboard BI en vivo multi-usuario: se cubre con informes y chat
+  savia-web.
+- **NO** instalación de TFMs (TabPFN/TabICL/Kumo) ni AutoML de terceros:
+  reafirma la decisión de SE-296 (describir y, ahora, predecir con estadística
+  y modelos clásicos locales, nunca datos fuera).
+
+---
+
+## 5. Priorización y dependencias
+
+```
+S1 Catálogo (lineage base) ──► S2 Experiment tracking
+                          └──► S3 Monitor de calidad + features
+S4 Gateway de modelos      (independiente, paralelizable)
+S5 Predicción asistida     (depende de S1 para lineage de artefactos)
+S6 Vector en cúpulas       (opcional, independiente)
+```
+
+Orden sugerido: **S1 → S3 → S2 → S4 → S5**, con S6 a decisión de la operadora.
+Racional: S1 da el sustrato de lineage; S3 cierra el riesgo de datos podridos
+(coste más alto de no hacerlo); S2 da el ciclo de vida de modelos; S4 y S5
+añaden valor de uso sin dependencias fuertes.
+
+---
+
+## 6. Cumplimiento CRIT-001 y reglas
+
+- **[CRIT-001]:** todos los slices corren en infraestructura propia — SQLite,
+  git, Ollama/LocalAI, Unsloth, sentence-transformers, scikit-learn. Ningún dato
+  (incluido N1-N2) sale del workspace; los N3+ nunca, ni temporalmente ni
+  anonimizados a mano (SE-093 zero-leak, ART-17).
+- **Sin nombres comerciales:** la plataforma de referencia se denomina en toda
+  esta spec "la plataforma lakehouse de referencia". No se cita su marca en
+  ningún fichero de Savia (decisión de confidencialidad de la operadora).
+- **Rule #8 (SDD):** ningún slice se implementa sin esta spec APPROVED.
+- **Soberanía (ART-07):** todo lo nuevo es auditable localmente; el derecho al
+  olvido se ejecuta sin dependencia de proveedores cloud.
+
+---
+
+## OpenCode Implementation Plan
+
+### Bindings touched
+
+| Componente | Claude Code | OpenCode v1.14 |
+|---|---|---|
+| `savia-catalog.sh` (S1) | `scripts/savia-catalog.sh` | Script bash idéntico (PURE_BASH) |
+| `slm-registry.sh` (S2) | extensión de script existente | Script bash idéntico |
+| `tabular-profile.py monitor` (S3) | extensión de script existente | Script python idéntico |
+| Gateway de modelos (S4) | `scripts/model-gateway.py` | Script python idéntico |
+| `tabular-analyst predict` (S5) | agente `.opencode/agents/` | Lee desde AGENTS.md generado |
+| Vector en cúpulas (S6) | `savia-vaults` skill + MCP | MCP server existente |
+
+### Verification protocol
+
+- [ ] Funciona en runtime OpenCode (no solo Claude Code)
+- [ ] Tests BATS por slice cubren ambos paths (S1-S4, S6) o marcan SKIP justificado (S5 agente)
+- [ ] Si añade hooks: registrados en plugin `savia-gates`
+
+### Portability classification
+
+- [x] **PURE_BASH** para S1-S4 y S6: lógica en scripts bash/python sin bindings
+  de frontend; corren idéntico en cualquier motor. S5 es DUAL_BINDING (agente
+  registrado en AGENTS.md, ya cubierto por SE-078). Justificado: el núcleo de
+  datos es tooling local, no frontend.
+
+---
+
+## Referencias
+
+- SE-027 (entrenamiento SLM local), SE-296/SE-324 (tabular intelligence),
+  SE-304 (automation scheduler), SE-280..SE-331 (savia-vaults),
+  SE-093 (zero-leak), SE-263/SE-282/SE-331 (federación), SCL-005 (embeddings
+  híbridos), SE-143 (vector search), SE-294 (multi-proveedor).
+- Análisis de estado 2026-08-23: `docs/savia-future-analysis-2026-08-23.md`.
+- Criterios humanos: CRIT-001 (infraestructura propia), regla
+  `context-placement-confirmation` (N1-N4b), `spec-opencode-implementation-plan`.


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este cambio añade la hoja de ruta para que Savia tenga su propia capa de datos e
inteligencia artificial funcionando en casa, sin depender de servicios de datos
en la nube. Se estudió una plataforma comercial de referencia (sin nombrarla en
los ficheros) y se comparó con lo que Savia ya tiene: de 22 capacidades, Savia
cubre 15 con su propio software libre y local. El PR deja escrito el plan de las
4 cosas que faltan y 1 opcional — un catálogo de datos con trazabilidad,
registro de experimentos de modelos, control de calidad de datos, una puerta
única para usar los modelos locales, y predicción asistida sin enviar datos a
ningún proveedor.

Además añade el catálogo de dominios (verticales) en los que Savia quiere operar
— desde banca y sector público hasta robótica, electrónica, educación o
electricidad — como base para crear cúpulas de conocimiento propias y abiertas.
Se excluyen deliberadamente los dominios sensibles (salud, química, farmacia,
armamento, biotecnología).

Por qué importa: sin esta base, cada proyecto reinventa la gestión de sus datos
y Savia depende de servicios en la nube que exigen enviar los datos fuera. Con
esto, los datos sensibles (nivel N3 y superior) jamás salen de la
infraestructura propia, ni siquiera anonimizados a mano.

Lo que queda abierto: es planificación y catálogo (documentos), no código en
producción; los slices se implementan en fases posteriores. No hay cambios de
comportamiento ni nada que desactivar, porque no se toca código existente.
## Summary
docs(domains): catalogo Savia Domains + spec SE-342 capa de datos local
### Changes
- 727fd5be docs(domains): catalogo Savia Domains + spec SE-342 capa de datos local
### Stats
4 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed
