### PR TITLE
feat(experiments): L18 experiment tracking local — SE-342 S2

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=22bb36c4f5832dd6fbd2982a9983a5b6bbcfd16a6d48031aca0fae1291b923e4
-timestamp=2026-08-24T10:04:54Z
-branch=agent/overnight-20260824-l21-prediction
-head_commit=e06e6f0c
+timestamp=2026-08-24T10:39:07Z
+branch=agent/overnight-20260824-l18-experiment-tracking
+head_commit=140e77bc
 signature=023ccda04cef55dff0ee15a7d4130e0f19232207bf50bc5d951531b3a85d4890

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=22bb36c4f5832dd6fbd2982a9983a5b6bbcfd16a6d48031aca0fae1291b923e4
-timestamp=2026-08-24T10:39:07Z
+diff_hash=6e247e1935d911f7acd302e017bbd6ff8f5d68ae5f53c205bf2bb9af3c263169
+timestamp=2026-08-24T10:41:40Z
 branch=agent/overnight-20260824-l18-experiment-tracking
-head_commit=140e77bc
-signature=023ccda04cef55dff0ee15a7d4130e0f19232207bf50bc5d951531b3a85d4890
+head_commit=f76e1078
+signature=c365cfcebd7e57e8ae09355ed7caa93aeeff5f1b8df7c402f65eeab1950970c3

--- a/CHANGELOG.d/l18-experiment-tracking.md
+++ b/CHANGELOG.d/l18-experiment-tracking.md
@@ -1,0 +1,15 @@
+---
+version_bump: patch
+section: Added
+---
+
+### Added
+
+- **L18 Experiment tracking local (SE-342 S2)** — `slm-registry.sh run`:
+  - Subcomando `run --run-id ID [--base-model M] [--metrics JSON] [--params JSON]
+    [--artifact PATH] [--dataset NAME] [--catalog-db DB]`: registra experimentos
+    en el manifest del registry con params, métricas y artefacto.
+  - Lineage opcional al catálogo L17: registra `run:<id>` como `model` con
+    `trained_on` al dataset origen (`--dataset` + `--catalog-db`).
+  - Determinista y local (manifest JSON + catálogo SQLite local, CRIT-001).
+  - 6 tests BATS (manifest, validación, duplicados, lineage).

--- a/scripts/slm-registry.sh
+++ b/scripts/slm-registry.sh
@@ -56,11 +56,19 @@ TRAINING_TOKENS=""
 EPOCHS=""
 FINAL_LOSS=""
 OLLAMA_NAME=""
+# L18 / SE-342 S2: experiment tracking — run metadata
+RUN_ID=""
+RUN_METRICS=""
+RUN_PARAMS=""
+RUN_ARTIFACT=""
+DATASET=""
+CATALOG_DB=""
 
 usage() {
   cat <<EOF
 Usage:
   $0 register --project PATH --id VERSION --base-model MODEL --method METHOD [options]
+  $0 run --project PATH --run-id ID [--metrics JSON] [--params JSON] [--artifact PATH] [--dataset NAME] [--catalog-db DB]
   $0 list --project PATH
   $0 show --project PATH --id VERSION
   $0 promote --project PATH --id VERSION
@@ -104,6 +112,12 @@ while [[ $# -gt 0 ]]; do
     --epochs) EPOCHS="$2"; shift 2 ;;
     --final-loss) FINAL_LOSS="$2"; shift 2 ;;
     --ollama-name) OLLAMA_NAME="$2"; shift 2 ;;
+    --run-id) RUN_ID="$2"; shift 2 ;;
+    --metrics) RUN_METRICS="$2"; shift 2 ;;
+    --params) RUN_PARAMS="$2"; shift 2 ;;
+    --artifact) RUN_ARTIFACT="$2"; shift 2 ;;
+    --dataset) DATASET="$2"; shift 2 ;;
+    --catalog-db) CATALOG_DB="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "ERROR: unknown arg '$1'" >&2; exit 2 ;;
   esac
@@ -178,6 +192,56 @@ d["versions"].append(entry)
 with open("$MANIFEST", "w") as f: json.dump(d, f, indent=2)
 PY
     echo "slm-registry register: $VERSION_ID added to $MANIFEST"
+    ;;
+
+  run)
+    # L18 / SE-342 S2: experiment tracking — append a run (params/metrics/artifact)
+    # with optional lineage to a catalog dataset (L17). Deterministic, local.
+    [[ -z "$RUN_ID" ]] && { echo "ERROR: --run-id required for run" >&2; exit 2; }
+    if ! [[ "$RUN_ID" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+      echo "ERROR: --run-id must be slug" >&2; exit 2
+    fi
+
+    ensure_manifest
+
+    if python3 -c "import json; d=json.load(open('$MANIFEST')); exit(0 if any(r.get('kind')=='run' and r['id']=='$RUN_ID' for r in d.get('runs',[])) else 1)" 2>/dev/null; then
+      echo "ERROR: run '$RUN_ID' already logged (use different id)" >&2
+      exit 1
+    fi
+
+    CREATED=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    python3 - "$RUN_PARAMS" "$RUN_METRICS" "$RUN_ARTIFACT" "$DATASET" "$RUN_ID" "$BASE_MODEL" "$MANIFEST" "$CREATED" <<'PY'
+import json, sys
+params_raw, metrics_raw, artifact, dataset, run_id, base_model, manifest, created = sys.argv[1:]
+d = json.load(open(manifest))
+runs = d.setdefault("runs", [])
+entry = {"kind": "run", "id": run_id, "created_at": created}
+if base_model:
+    entry["base_model"] = base_model
+for field, raw in (("params", params_raw), ("metrics", metrics_raw)):
+    if not raw:
+        continue
+    try:
+        entry[field] = json.loads(raw)
+    except ValueError:
+        entry[field] = {"values": raw}
+if artifact:
+    entry["artifact"] = artifact
+if dataset:
+    entry["dataset"] = dataset
+runs.append(entry)
+with open(manifest, "w") as f:
+    json.dump(d, f, indent=2)
+PY
+
+    # Best-effort lineage to L17 catalog (only when explicitly provided).
+    if [[ -n "$DATASET" && -n "$CATALOG_DB" ]]; then
+      python3 scripts/savia-catalog.py --db "$CATALOG_DB" register --type model \
+        --name "run:$RUN_ID" --level N2 --source "$RUN_ARTIFACT" \
+        --relation trained_on --from-name "$DATASET" --from-type dataset \
+        >/dev/null 2>&1 || true
+    fi
+    echo "slm-registry run: $RUN_ID logged (${RUN_METRICS:+metrics + }${RUN_PARAMS:+params})"
     ;;
 
   list)

--- a/tests/test-slm-registry-run.bats
+++ b/tests/test-slm-registry-run.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+# BATS tests for slm-registry.sh run (SE-342 S2 / Labs L18)
+# Ref: SE-342 S2, hypothesis l18-experiment-tracking.md, CRIT-001
+
+SCRIPT="scripts/slm-registry.sh"
+CATALOG="scripts/savia-catalog.py"
+
+setup() {
+  cd "$BATS_TEST_DIRNAME/.."
+  TMP_PROJ="$(mktemp -d -t reg.XXXXXX)"
+  export SAVIA_CATALOG_DB="$(mktemp -t cat.XXXXXX.db)"
+  rm -f "$SAVIA_CATALOG_DB"
+  python3 "$CATALOG" register --type dataset --name agent_data --level N2 >/dev/null
+}
+
+teardown() {
+  rm -rf "$TMP_PROJ"
+  [[ -n "${SAVIA_CATALOG_DB:-}" ]] && rm -f "$SAVIA_CATALOG_DB"
+  cd /
+}
+
+@test "script exists and executable" {
+  [[ -x "$SCRIPT" ]]
+}
+
+@test "passes bash -n" {
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "run logs metrics+params to manifest" {
+  run bash "$SCRIPT" run --project "$TMP_PROJ" --run-id exp-001 \
+    --base-model llama3.2-1b \
+    --metrics '{"final_loss": 0.82}' --params '{"epochs": 3}'
+  [ "$status" -eq 0 ]
+  json="$(cat "$TMP_PROJ/registry/manifest.json")"
+  [[ "$json" == *"\"id\": \"exp-001\""* ]]
+  [[ "$json" == *"\"final_loss\": 0.82"* ]]
+  [[ "$json" == *"\"epochs\": 3"* ]]
+}
+
+@test "run without run-id rejected (exit 2)" {
+  run bash "$SCRIPT" run --project "$TMP_PROJ"
+  [ "$status" -eq 2 ]
+}
+
+@test "duplicate run rejected (exit 1)" {
+  bash "$SCRIPT" run --project "$TMP_PROJ" --run-id exp-001 >/dev/null
+  run bash "$SCRIPT" run --project "$TMP_PROJ" --run-id exp-001
+  [ "$status" -eq 1 ]
+}
+
+@test "run with dataset writes lineage to L17 catalog" {
+  run bash "$SCRIPT" run --project "$TMP_PROJ" --run-id exp-002 \
+    --artifact adapters/sft-v1 --dataset agent_data --catalog-db "$SAVIA_CATALOG_DB"
+  [ "$status" -eq 0 ]
+  run python3 "$CATALOG" --db "$SAVIA_CATALOG_DB" lineage --name "run:exp-002"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"agent_data"* ]]
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este cambio añade un cuaderno de laboratorio para los experimentos de modelos de Savia: cada vez que se entrena o prueba un modelo, se puede apuntar aquí qué valores se usaron (parámetros), qué resultados dio (métricas) y dónde quedó el resultado. A cada experimento se le puede vincular el conjunto de datos con el que se hizo, y entonces queda registrado su origen en el catálogo de datos: de qué datos salió ese experimento.

Por qué importa: sin este registro, un modelo bueno o malo se queda sin contexto — nadie sabe con qué ajustes y con qué datos se obtuvo. Con él, se puede comparar experimentos, reproducir los buenos y ver de dónde vino cada resultado. Todo queda guardado en esta máquina, en el mismo sitio donde ya está el registro de modelos.

Qué se pierde / riesgos: es un cuaderno básico en modo texto: sirve para apuntar y consultar, sin gráficas ni comparativas visuales todavía. Las métricas se guardan tal cual se indican. No sustituye aún a la herramienta más completa que se podría adoptar más adelante.

Cómo activar: se apunta un experimento con "slm-registry run --run-id <id> --metrics ... --params ...". Se desactiva simplemente no usándolo.
## Summary
feat(experiments): L18 experiment tracking local — SE-342 S2
### Changes
- f76e1078 Merge remote-tracking branch 'origin/main' into agent/overnight-20260824-l18-experiment-tracking
- 4376ed22 feat(experiments): L18 experiment tracking local (slm-registry run) — SE-342 S2
### Stats
4 files changed across 2 commits.
## Test plan
- [x] CI passed  - [x] Signed
