### PR TITLE
test(backup): L14 — cobertura BATS de vaults-backup-cron.sh + SAVIA_VAULTS_DIR override

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=2d849e24d5ee7b7bfc4f85edf1ae328230f34c687cde84f4a877c75f836e9d49
-timestamp=2026-08-24T20:03:19Z
-branch=agent/overnight-20260824-se344-fxc
-head_commit=a6ccfb44
-signature=8f9d500a10d3c8cd06b0f333a78479fda0a219a1f790f8bdbaa64e8e447e812f
+diff_hash=696224f71e6c89b220c95ad62e51740b3885863c3c12943dc523df2fcc2e15d0
+timestamp=2026-08-24T20:20:50Z
+branch=main
+head_commit=c39db431
+signature=ec10cdee7d2c1bb31d7ae4b69428e5d73ad90d688e160aa3d06a79434357de76

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=696224f71e6c89b220c95ad62e51740b3885863c3c12943dc523df2fcc2e15d0
-timestamp=2026-08-24T20:20:50Z
-branch=main
-head_commit=c39db431
+timestamp=2026-08-24T20:21:43Z
+branch=agent/overnight-20260824-l14-backup-tests
+head_commit=6f7a95c6
 signature=ec10cdee7d2c1bb31d7ae4b69428e5d73ad90d688e160aa3d06a79434357de76

--- a/CHANGELOG.d/l14-vaults-backup-tests.md
+++ b/CHANGELOG.d/l14-vaults-backup-tests.md
@@ -1,0 +1,20 @@
+---
+version_bump: patch
+section: Added
+---
+
+### Added
+
+- **L14 (parcial) — cobertura de tests de `vaults-backup-cron.sh`** — 
+  `tests/test-vaults-backup.bats` (7 tests):
+  - `run` genera por cúpula `tar.gz` + `git bundle` + `sha256` (assert por
+    find, robusto ante timestamps).
+  - `--verify` valida integridad (gzip -t + sha256 -c) y `--status` reporta
+    dir/retention.
+  - `nc-push` con destino caído es **fail-safe**: no rompe el backup local
+    (best-effort, CRIT-001: destino = infra propia, cero egress).
+  - Verificación de no-egress (sin SDK de terceros).
+- **`SAVIA_VAULTS_DIR` override** en `vaults-backup-cron.sh`: permite apuntar
+  el origen de cúpulas a un directorio distinto de `$HOME/savia/vaults`
+  (necesario para tests aislados y back-ups portables; retrocompatible: el
+  default es el de siempre).

--- a/scripts/vaults-backup-cron.sh
+++ b/scripts/vaults-backup-cron.sh
@@ -23,7 +23,7 @@
 # Salida: 0 OK · 1 fallo
 set -uo pipefail
 
-VAULTS_DIR="${HOME}/savia/vaults"
+VAULTS_DIR="${SAVIA_VAULTS_DIR:-$HOME/savia/vaults}"
 BACKUP_DIR="${SAVIA_VAULTS_BACKUP_DIR:-${HOME}/.savia-vaults/backups}"
 RETENTION="${SAVIA_BACKUP_RETENTION:-30}"
 LOG_DIR="${HOME}/.savia-vaults"

--- a/tests/test-vaults-backup.bats
+++ b/tests/test-vaults-backup.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+# BATS tests for scripts/vaults-backup-cron.sh (SE-344/L14)
+# Valida: backup por cúpula (tar.gz+bundle+sha256), verify, status,
+# rotación, nc-push fail-safe y cero egress (CRIT-001).
+
+SCRIPT="scripts/vaults-backup-cron.sh"
+TESTROOT=""
+
+setup() {
+  cd "$BATS_TEST_DIRNAME/.."
+  # crear vault/senario aislado con cúpulas git falsas
+  TESTROOT="$(mktemp -d -t vb.XXXXXX)"
+  export SAVIA_VAULTS_DIR="$TESTROOT/vaults"
+  export SAVIA_VAULTS_BACKUP_DIR="$TESTROOT/backups"
+  mkdir -p "$TESTROOT/vaults/SaviaLabs" "$TESTROOT/vaults/SaviaLearning" "$TESTROOT/vaults/savia-docs"
+  echo "nota" > "$TESTROOT/vaults/SaviaLabs/a.md"
+  echo "nota" > "$TESTROOT/vaults/SaviaLearning/b.md"
+  echo "nota" > "$TESTROOT/vaults/savia-docs/c.md"
+  for d in SaviaLabs SaviaLearning savia-docs; do
+    git -C "$TESTROOT/vaults/$d" init -q 2>/dev/null || true
+    git -C "$TESTROOT/vaults/$d" config user.email "test@local"
+    git -C "$TESTROOT/vaults/$d" config user.name "test"
+    git -C "$TESTROOT/vaults/$d" add . 2>/dev/null || true
+    git -C "$TESTROOT/vaults/$d" commit -qm "seed" 2>/dev/null || true
+  done
+  # HOME aislado para que el script use TESTROOT y no el real
+  export HOME="$TESTROOT/home"; mkdir -p "$HOME/.savia-vaults"
+  LOG="$HOME/.savia-vaults/vaults-backup.log"
+}
+
+teardown() {
+  [[ -n "$TESTROOT" ]] && rm -rf "$TESTROOT"
+  unset SAVIA_VAULTS_BACKUP_DIR HOME LOG
+  cd /
+}
+
+@test "script existe y es ejecutable" { [[ -x "$SCRIPT" ]]; }
+
+@test "pasa bash -n" { run bash -n "$SCRIPT"; [ "$status" -eq 0 ]; }
+
+count_backups() { find "$1" -name "$2" | wc -l; }
+
+@test "run genera ficheros de backup por cúpula (tar.gz, bundle, sha256)" {
+  # monkeypatch VAULTS_DIR via env no existe; usamos la ruta por defecto real $HOME/savia/vaults
+  # en su lugar: ejecutar con BACKUP_DIR aislado y VAULTS_DIR real (solo asegura tar.gz)
+  export SAVIA_VAULTS_DIR="$TESTROOT/vaults"
+  export SAVIA_VAULTS_BACKUP_DIR="$TESTROOT/backups"
+  run bash "$SCRIPT" run
+  [ "$status" -eq 0 ]
+  [ "$(count_backups "$SAVIA_VAULTS_BACKUP_DIR" "SaviaLabs-*.tar.gz")" -ge 1 ]
+  [ "$(count_backups "$SAVIA_VAULTS_BACKUP_DIR" "savia-docs-*.tar.gz")" -ge 1 ]
+  [ "$(count_backups "$SAVIA_VAULTS_BACKUP_DIR" "SaviaLabs-repo-*.bundle")" -ge 1 ]
+}
+
+@test "verify OK en backups generados" {
+  export SAVIA_VAULTS_DIR="$TESTROOT/vaults"
+  export SAVIA_VAULTS_BACKUP_DIR="$TESTROOT/backups"
+  bash "$SCRIPT" run >/dev/null 2>&1
+  run bash "$SCRIPT" --verify
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK  SaviaLabs"* ]]
+}
+
+@test "--status muestra dir y retention" {
+  run bash "$SCRIPT" --status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Backup dir"* ]]
+  [[ "$output" == *"Retention"* ]]
+}
+
+@test "nc-push con URL caída no rompe el backup (fail-safe)" {
+  export SAVIA_VAULTS_DIR="$TESTROOT/vaults"
+  export SAVIA_VAULTS_BACKUP_DIR="$TESTROOT/backups"
+  export NEXTCLOUD_URL="http://127.0.0.1:1"
+  export NEXTCLOUD_USER="test"
+  export NEXTCLOUD_PASS="test"
+  # crear el env que carga el script
+  mkdir -p "$TESTROOT/home/.savia-vaults"
+  cat > "$TESTROOT/home/.savia-vaults/nextcloud.env" <<EOF
+NEXTCLOUD_URL="http://127.0.0.1:1"
+NEXTCLOUD_USER="test"
+NEXTCLOUD_PASS="test"
+EOF
+  run bash "$SCRIPT" run
+  [ "$status" -eq 0 ]  # el fallo de NC NO rompe el backup local
+  [ "$(count_backups "$SAVIA_VAULTS_BACKUP_DIR" "SaviaLabs-*.tar.gz")" -ge 1 ]
+}
+
+@test "cero egress: el script no contiene urllib/requests/curl a externos" {
+  # el script usa curl para WebDAV a NEXTCLOUD_URL (infra propia de la operadora);
+  # verifica que NO haya drivers de nube de terceros (aws/gcp/azure SDK)
+  run bash -c "! grep -E 'aws |gsutil|az ' $SCRIPT"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este cambio añade pruebas automáticas a la utilidad que respalda las cúpulas de conocimiento de Savia (el guardado local de los domos de contexto), que esta tarde se reparó tras estar roto varios días. Las pruebas comprueban que: al ejecutar el respaldo se generan los tres archivos por cada cúpula (el comprimido, la copia del historial y la huella de integridad), que la comprobación de integridad funciona, que el estado se informa bien, y que si el destino secundario de sincronización (un servidor propio) no responde, el respaldo local no se rompe ni pierde nada — simplemente sigue guardando en la máquina.

Por qué importa: esta utilidad es la red de seguridad de los domos de contexto (donde vive el conocimiento de Savia). Sin pruebas, una regresión silenciosa podría volver a dejar los domos sin copia de seguridad — exactamente lo que ocurrió esta semana cuando el programador automático apuntaba a un archivo que ya no existía. Con estas pruebas, ese tipo de fallo se detecta antes de que se note en una noche de trabajo perdida.

Qué se pierde / riesgos: nada funcional; añadimos la posibilidad de indicar de qué carpeta se respaldan las cúpulas (para poder usar una ubicación distinta en pruebas o en equipos nuevos), pero el comportamiento por defecto no cambia. Ningún dato sale del equipo: el destino externo solo se usa si ya estaba configurado, y si falla el respaldo sigue siendo completo y local.

Cómo activar: es automático (las pruebas corren en la verificación de cambios); el cambio de utilidad no requiere ninguna configuración nueva salvo si se quiere un origen distinto, que se indica con una variable de entorno.
## Summary
test(backup): L14 — cobertura BATS de vaults-backup-cron.sh + SAVIA_VAULTS_DIR override
### Changes
- c39db431 test(backup): L14 — cobertura BATS de vaults-backup-cron.sh + SAVIA_VAULTS_DIR override
### Stats
4 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed
