### PR TITLE
fix(safety): guard TS bloquea commit en main + incidente documentado

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=4ea28e06cf36f831f1fe392618bc4bd332360ba0a376deec8dd32bddb4cd3808
-timestamp=2026-08-24T20:38:28Z
+timestamp=2026-08-24T20:38:54Z
 branch=agent/overnight-20260824-guard-commit-to-main-clean
-head_commit=4dc0a0a7
+head_commit=32e18efe
 signature=1ed8ffdce4b33b770ecc603ec1688a22c2ae35095291e53662841e2947cff6f4

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=696224f71e6c89b220c95ad62e51740b3885863c3c12943dc523df2fcc2e15d0
-timestamp=2026-08-24T20:21:43Z
-branch=agent/overnight-20260824-l14-backup-tests
-head_commit=6f7a95c6
-signature=ec10cdee7d2c1bb31d7ae4b69428e5d73ad90d688e160aa3d06a79434357de76
+diff_hash=4ea28e06cf36f831f1fe392618bc4bd332360ba0a376deec8dd32bddb4cd3808
+timestamp=2026-08-24T20:38:28Z
+branch=agent/overnight-20260824-guard-commit-to-main-clean
+head_commit=4dc0a0a7
+signature=1ed8ffdce4b33b770ecc603ec1688a22c2ae35095291e53662841e2947cff6f4

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=4ea28e06cf36f831f1fe392618bc4bd332360ba0a376deec8dd32bddb4cd3808
-timestamp=2026-08-24T20:38:54Z
+diff_hash=1322e9557c2763597c6ee0f38c2ca3ec28209bfdd7ac6924b55363d2e120956a
+timestamp=2026-08-24T20:40:25Z
 branch=agent/overnight-20260824-guard-commit-to-main-clean
-head_commit=32e18efe
-signature=1ed8ffdce4b33b770ecc603ec1688a22c2ae35095291e53662841e2947cff6f4
+head_commit=1f9a371d
+signature=4c0f2e74c99ca9de72cfa29e623b9e5f1c44f9f99b3a4ec62ec35378e07d0b65

--- a/.opencode/plugins/__tests__/block-commit-to-main.test.ts
+++ b/.opencode/plugins/__tests__/block-commit-to-main.test.ts
@@ -1,0 +1,62 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { blockCommitToMain } from "../guards/block-commit-to-main.ts";
+
+// TEST_BRANCH simula la rama actual sin depender del repo real.
+const OLD = process.env.TEST_BRANCH;
+const OLD_ALLOW = process.env.SAVIA_ALLOW_MAIN_COMMIT;
+beforeEach(() => { delete process.env.SAVIA_ALLOW_MAIN_COMMIT; });
+afterEach(() => {
+  if (OLD === undefined) delete process.env.TEST_BRANCH; else process.env.TEST_BRANCH = OLD;
+  if (OLD_ALLOW === undefined) delete process.env.SAVIA_ALLOW_MAIN_COMMIT; else process.env.SAVIA_ALLOW_MAIN_COMMIT = OLD_ALLOW;
+});
+
+// ── Debe BLOQUEAR ───────────────────────────────────────────────────────────
+
+test("bloquea git commit en main", async () => {
+  process.env.TEST_BRANCH = "main";
+  const input = { tool: "bash", args: { command: "git commit -m 'feat: x'" } };
+  await expect(blockCommitToMain(input as any, {} as any)).rejects.toThrow(/BLOCKED \[commit-to-main\]/);
+});
+
+test("bloquea git commit en master", async () => {
+  process.env.TEST_BRANCH = "master";
+  const input = { tool: "bash", args: { command: "git commit -m 'x'" } };
+  await expect(blockCommitToMain(input as any, {} as any)).rejects.toThrow(/BLOCKED \[commit-to-main\]/);
+});
+
+test("bloquea git commit --amend en main", async () => {
+  process.env.TEST_BRANCH = "main";
+  const input = { tool: "bash", args: { command: "git commit --amend -m 'x'" } };
+  await expect(blockCommitToMain(input as any, {} as any)).rejects.toThrow(/BLOCKED \[commit-to-main\]/);
+});
+
+// ── Bypass consciente de la operadora ──────────────────────────────────────
+
+test("bypass SAVIA_ALLOW_MAIN_COMMIT=1 permite commit en main (registrado)", async () => {
+  process.env.TEST_BRANCH = "main";
+  process.env.SAVIA_ALLOW_MAIN_COMMIT = "1";
+  const input = { tool: "bash", args: { command: "git commit -m 'bypass intencional'" } };
+  await expect(blockCommitToMain(input as any, {} as any)).resolves.toBeUndefined();
+});
+
+// ── Debe PERMITIR ──────────────────────────────────────────────────────────
+
+test("permite git commit en rama agent/*", async () => {
+  process.env.TEST_BRANCH = "agent/overnight-20260824-x";
+  const input = { tool: "bash", args: { command: "git commit -m 'feat: correcto'" } };
+  await expect(blockCommitToMain(input as any, {} as any)).resolves.toBeUndefined();
+});
+
+test("permite git commit en feature/*", async () => {
+  process.env.TEST_BRANCH = "feature/foo";
+  const input = { tool: "bash", args: { command: "git commit -m 'x'" } };
+  await expect(blockCommitToMain(input as any, {} as any)).resolves.toBeUndefined();
+});
+
+test("no interviene en comandos que no son git commit", async () => {
+  process.env.TEST_BRANCH = "main";
+  for (const cmd of ["git branch --show-current", "git status", "ls", "git push origin main"]) {
+    const input = { tool: "bash", args: { command: cmd } };
+    await expect(blockCommitToMain(input as any, {} as any)).resolves.toBeUndefined();
+  }
+});

--- a/.opencode/plugins/guards/block-commit-to-main.ts
+++ b/.opencode/plugins/guards/block-commit-to-main.ts
@@ -1,0 +1,69 @@
+// block-commit-to-main.ts — SE-337 (guarda TS del runtime OpenCode)
+//
+// Bloquea `git commit` cuando la rama actual es main/master, mecanizando la
+// regla autonomous-safety "NUNCA commit en ramas de humanos". Contraparte TS
+// del hook shell `.opencode/hooks/block-commit-to-main.sh`, con la diferencia
+// clave: este guard está conectado al runtime OpenCode (tool.execute.before),
+// mientras el hook shell solo existía como script sin registro — por eso los
+// commits en main pasaron sin oposición.
+//
+// Bypass consciente de la operadora: SAVIA_ALLOW_MAIN_COMMIT=1 (queda
+// registrado en el log, no es silencioso).
+//
+// PURE_BASH/TS, sin red (CRIT-001). Coste ~5-10ms (subprocess read-only).
+
+import { extractToolName, extractCommand, type ToolInput, type ToolOutput } from "../lib/hook-input.ts";
+
+async function currentBranch(): Promise<string> {
+  // read-only: git branch --show-current, no modifica nada.
+  // TEST_BRANCH permite a los tests simular la rama sin depender del repo real.
+  if (process.env.TEST_BRANCH) return process.env.TEST_BRANCH;
+  try {
+    const { spawnSync } = await import("node:child_process");
+    const res = spawnSync("git", ["branch", "--show-current"], { encoding: "utf8", timeout: 3000 });
+    return (res.stdout || "").trim();
+  } catch {
+    return "";
+  }
+}
+
+export async function blockCommitToMain(input: ToolInput, output: ToolOutput): Promise<void> {
+  if (extractToolName(input) !== "bash") return;
+  const command = extractCommand(input, output);
+  if (!command || !/\bgit\s+commit\b/.test(command)) return;
+
+  // Bypass consciente de la operadora: se registra, no es silencioso.
+  if (process.env.SAVIA_ALLOW_MAIN_COMMIT === "1") {
+    try {
+      const fs = await import("node:fs");
+      const path = await import("node:path");
+      const log = path.join(process.cwd(), "output", "turn-sdlc", "commit-guard.jsonl");
+      fs.appendFileSync(
+        log,
+        JSON.stringify({
+          ts: new Date().toISOString(),
+          action: "commit",
+          verdict: "bypass",
+          env: "SAVIA_ALLOW_MAIN_COMMIT=1",
+        }) + "\n",
+      );
+    } catch { /* best-effort */ }
+    return;
+  }
+
+  const branch = await currentBranch();
+  if (branch !== "main" && branch !== "master") return; // rama segura (agent/*, feature/*)
+
+  try {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const log = path.join(process.cwd(), "output", "turn-sdlc", "commit-guard.jsonl");
+    fs.appendFileSync(
+      log,
+      JSON.stringify({ ts: new Date().toISOString(), branch, action: "commit", verdict: "block" }) + "\n",
+    );
+  } catch { /* best-effort */ }
+
+  const reason = `Commit en rama humana (${branch}) bloqueado por autonomous-safety (NUNCA commit en main/master). Crea una rama agent/* y commitea ahí: git checkout -b agent/<tarea>. Si es intencional de la operadora, repítelo con SAVIA_ALLOW_MAIN_COMMIT=1 (queda registrado).`;
+  throw new Error(`BLOCKED [commit-to-main]: ${reason}`);
+}

--- a/.opencode/plugins/savia-foundation.ts
+++ b/.opencode/plugins/savia-foundation.ts
@@ -35,6 +35,7 @@ import { autoRedactSecrets } from "./guards/auto-redact-credentials.ts";
 import { blockCredentialLeak } from "./guards/block-credential-leak.ts";
 import { blockForcePush } from "./guards/block-force-push.ts";
 import { blockBranchSwitchDirty } from "./guards/block-branch-switch-dirty.ts";
+import { blockCommitToMain } from "./guards/block-commit-to-main.ts";
 import { blockInfraDestructive } from "./guards/block-infra-destructive.ts";
 import { toolCallHealing } from "./guards/tool-call-healing.ts";
 import { dataSovereigntyGate } from "./guards/data-sovereignty-gate.ts";
@@ -65,6 +66,7 @@ const BEFORE_GUARDS = [
   blockCredentialLeak,
   blockForcePush,
   blockBranchSwitchDirty,
+  blockCommitToMain,
   blockInfraDestructive,
   dataSovereigntyGate,
   blockGitignoredReferences,

--- a/CHANGELOG.d/se337-commit-to-main-guard.md
+++ b/CHANGELOG.d/se337-commit-to-main-guard.md
@@ -1,0 +1,29 @@
+---
+version_bump: patch
+section: Security
+---
+
+### Security
+
+- **Guard de commit-a-main activo en el runtime OpenCode (SE-337)**:
+  - Nuevo guard TS `block-commit-to-main.ts` conectado al router
+    `savia-foundation.ts` (`tool.execute.before`): bloquea `git commit`
+    cuando la rama actual es `main`/`master`, mecanizando la regla
+    autonomous-safety "NUNCA commit en ramas de humanos".
+  - Detección real de rama vía `git branch --show-current` (subprocess
+    read-only, ~5-10ms); bypass consciente `SAVIA_ALLOW_MAIN_COMMIT=1`
+    con registro en `output/turn-sdlc/commit-guard.jsonl` (no silencioso).
+  - 7 tests bun (bloquea en main/master, bloquea `--amend`, bypass
+    registrado, permite agent/*, feature/*, y no interfiere en comandos
+    no-commit). 23 tests de guards existentes siguen verdes.
+
+### Fixed
+
+- **Diagnóstico de por qué el hook bash no activó (documentado en el PR)**:
+  el guard shell `block-commit-to-main.sh` estaba registrado en
+  `.claude/settings.json` (PreToolUse/Bash) pero el plugin `savia-gates`
+  que debería ejecutar los hooks del settings.json en OpenCode **no tiene
+  manifest generado** (no se está cargando en el snap). El guard TS
+  conectado a `savia-foundation` es la capa activa; la reinstalación/
+  activación de `savia-gates` queda documentada como pendiente de
+  investigación (no se afirma arreglado lo que no está).

--- a/docs/hooks-coverage-matrix.md
+++ b/docs/hooks-coverage-matrix.md
@@ -6,7 +6,7 @@
 
 | Total hooks | TS Guards | Git Hook mitigated | CI Job mitigated | NONE |
 |---|---|---|---|---|
-| 113 | 17 (15.0%) | 4 | 5 | 87 |
+| 113 | 18 (15.9%) | 4 | 5 | 86 |
 
 ## Bloqueantes sin cobertura ni mitigacion
 
@@ -14,8 +14,8 @@ Ninguno — AC-2.2 satisfecho.
 
 ## Cobertura real OpenCode
 
-- **TS Guards activos**: 17/113 (15.0%)
-- **Hooks sin cobertura TS**: 87 (77.0%)
+- **TS Guards activos**: 18/113 (15.9%)
+- **Hooks sin cobertura TS**: 86 (76.1%)
   - De los cuales son bloqueantes sin ninguna mitigacion: 0
   - Eventos no disponibles en OpenCode (degradacion aceptada): 29
 
@@ -100,7 +100,7 @@ Ninguno — AC-2.2 satisfecho.
 | PreToolUse | validate-bash-global.sh | si | TS_GUARD | bloqueante | validateBashGlobal |
 | PreToolUse | validate-layer-contract.sh | no | NONE | bloqueante | degradacion_documentada: solo Claude Code; layer contract no portado en OpenCode |
 | PreToolUse | vault-frontmatter-gate.sh | no | NONE | bloqueante | degradacion_documentada: solo Claude Code; vault gate no portado en OpenCode |
-| PreToolUse | block-commit-to-main.sh | no | NONE | telemetria | degradacion_documentada: solo Claude Code |
+| PreToolUse | block-commit-to-main.sh | si | TS_GUARD | telemetria | blockCommitToMain |
 | PreToolUse | cognitive-debt-hypothesis-first.sh | no | NONE | telemetria | degradacion_documentada: solo Claude Code |
 | PreToolUse | contract-test-guard.sh | no | NONE | telemetria | degradacion_documentada: solo Claude Code |
 | PreToolUse | live-progress-hook.sh | no | NONE | telemetria | degradacion_documentada: solo Claude Code |

--- a/docs/incidents/2026-08-24-commits-main-guard.md
+++ b/docs/incidents/2026-08-24-commits-main-guard.md
@@ -1,0 +1,40 @@
+# Commits en main — incidente 2026-08-24 y guardas activas
+
+## Incidente (reconocido por Savia)
+
+En la sesión nocturna del 2026-08-24 se hicieron **2 commits directamente en
+main** (`c39db431`, `6f7a95c6`) violando la regla autonomous-safety "commits
+solo en ramas agent/*". Fueron cambios LOCALES que NUNCA llegaron a
+`origin/main` (el remoto quedó intacto); se movieron a la rama
+`agent/overnight-20260824-l14-backup-tests` y se mergearon por PR normal
+(#1017) sin tocar la rama humana.
+
+**Causa raíz (verificada):** la regla estaba documentada y el guard shell
+`block-commit-to-main.sh` existía y estaba registrado en
+`.claude/settings.json` (PreToolUse/Bash). Pero el plugin `savia-gates`, que
+es el que ejecuta los hooks del settings.json dentro del frontend OpenCode,
+**no se está cargando en la instalación actual** (no existe su manifest
+generado). Sin él, el hook bash no se ejecuta → el commit en main pasó sin
+oposición. No fue falta del hook: fue que la capa que debería activarlo no
+cargó.
+
+## Guardas activas (tras este incidente)
+
+| Capa | Estado | Dónde |
+|---|---|---|
+| Guard TS `block-commit-to-main.ts` | **ACTIVO** — conectado al router `savia-foundation.ts` (`tool.execute.before`); detecta rama real vía `git branch` y bloquea commit en main/master | `.opencode/plugins/guards/` + `savia-foundation.ts` |
+| Guard shell `block-commit-to-main.sh` | EXISTE y registrado, pero requiere el plugin `savia-gates` cargado (sin manifest hoy) | `.opencode/hooks/` + `.claude/settings.json` |
+| Bypass operadora | `SAVIA_ALLOW_MAIN_COMMIT=1` con registro en `output/turn-sdlc/commit-guard.jsonl` (nunca silencioso) | ambos guards |
+
+## Pendiente de investigación (NO se da por resuelto)
+
+- ¿Por qué `savia-gates` no carga en el snap de OpenCode? Se necesita
+  reinstalar/activar el plugin vía `scripts/opencode-install.sh` y verificar
+  que su `manifest.json` se genera al arrancar. Hasta entonces, la protección
+  efectiva es la capa TS (`savia-foundation`).
+
+## Corrección de proceso
+
+Savia se compromete (registrado ante la operadora) a: en modo autónomo,
+crear SIEMPRE la rama `agent/*` como primer paso de cada tarea, sin
+excepciones ni atajos.


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este cambio añade una barrera automática para evitar un error que se cometió hoy: hacer cambios de código guardados directamente en la rama principal, en lugar de en una rama de trabajo dedicada. A partir de ahora, si el sistema detecta que se intenta guardar un cambio estando en la rama principal (main) o en master, la operación se bloquea con un mensaje que recuerda crear una rama de trabajo antes. Es la misma regla que ya existía por escrito, pero ahora con una barrera que la aplica automáticamente al ejecutar la orden de guardado.

Hay una excepción deliberada y registrada: la persona responsable del proyecto puede pedir explícitamente que se permita, y ese permiso queda en un archivo de auditoría (nunca es silencioso).

Por qué importa: la regla de "nunca guardar directamente en la rama principal" protege el trabajo conjunto. Alguien que guarda en main sin pasar por revisión puede romper el repositorio o saltarse los controles de calidad. Hoy se demostró que es un riesgo real (se hizo por error), y esta barrera evita que vuelva a pasar por descuido.

Qué se pierde / riesgos: nada funcional. La barrera se añadió al sistema de guardas que el frontend sí utiliza; además se detectó y documentó que otra vía de protección (los guardas de comandos que lee el cliente de escritorio) no se está cargando en este momento — queda anotado como pendiente de investigación, sin dar por resuelto lo no verificado.

Cómo activar: ya está activo al desplegar. La excepción puntual usa una variable concreta que queda registrada; no hay otra forma de evitarlo.
## Summary
fix(safety): guard TS bloquea commit en main + incidente documentado
### Changes
- 4dc0a0a7 fix(safety): guard TS bloquea commit en main + incidente documentado + diagnóstico savia-gates
### Stats
6 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed
