### PR TITLE
fix(hooks): permitir nombres propios en N3/N4 (data-sovereignty-gate)

### DIFF
--- a/.claude/hooks/data-sovereignty-gate.sh
+++ b/.claude/hooks/data-sovereignty-gate.sh
@@ -40,6 +40,20 @@ TOKEN_HEADER=""
 # Extract file path FIRST — skip private destinations before any scanning
 FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null) || exit 0
 [[ -z "$FILE_PATH" ]] && exit 0
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+
+# Destino N3/N4 (local protegido): en estos destinos los nombres propios son
+# legítimos (CRIT-001: nada N3+ sale del workspace; escribirlos localmente es el
+# uso previsto). Detectamos por path (vaults/labs) o por tool de vault (MCP).
+is_protected_tier_dest() {
+  case "$1" in
+    */vaults/*|vaults/*|*/labs/*|labs/*) return 0 ;;
+  esac
+  case "$TOOL_NAME" in
+    *vault_write*|*vault*) return 0 ;;
+  esac
+  return 1
+}
 
 # Normalize path (resolve ../ traversal + Windows backslashes)
 NORM_PATH="$FILE_PATH"
@@ -91,6 +105,20 @@ if curl -sf --max-time 2 "$SHIELD_URL/health" >/dev/null 2>&1; then
         echo "WARNING [Savia Shield SH01]: code-token allowlist override en $FILE_PATH" >&2
         echo "$RESULT" | jq -c '. + {ts:now|todate,layer:"gate",override:"sh01_allowlist"}' >> "$AUDIT_LOG" 2>/dev/null
         exit 0
+      fi
+      # N3/N4 (destino local protegido): permitir nombres propios, mantener
+      # bloqueo de credenciales/identificadores (CREDIT_CARD, EMAIL, PHONE,
+      # NATIONAL_ID, IBAN, KEY/TOKEN/SECRET, URL...). Solo se relaja si TODAS
+      # las entidades son tipo nombre (PERSON/ORG/LOC/GPE/DATE/TIME/...).
+      if is_protected_tier_dest "$NORM_PATH"; then
+        NAME_TYPES="^(PERSON|PERSON_ES|ORG|ORGANIZATION|LOCATION|GPE|DATE|TIME|NRP|EVENT|PRODUCT|WORK_OF_ART|MISC|LAW|LANGUAGE|ORDINAL|CARDINAL|QUANTITY|PERCENT|MONEY)$"
+        BAD_TYPE=$(echo "$RESULT" | jq -r '[.entities[].type] | unique[]' 2>/dev/null \
+          | grep -viE "$NAME_TYPES" | grep -v '^$' | head -1)
+        if [[ -z "$BAD_TYPE" ]]; then
+          echo "WARNING [Savia Shield]: nombres propios permitidos en destino N3/N4 ($FILE_PATH)" >&2
+          echo "$RESULT" | jq -c '. + {ts:now|todate,layer:"gate",override:"n3n4_names"}' >> "$AUDIT_LOG" 2>/dev/null
+          exit 0
+        fi
       fi
       echo "$RESULT" | jq -r '.entities[]? | "  [\(.type)] \(.text)"' 2>/dev/null | head -5 >&2
       echo "BLOQUEADO [Savia Shield]: PII detectado en fichero publico" >&2

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=57b2448cdc44143488c7e15ce2ce186c7251a6a16c3d682ba986155734f63ebd
-timestamp=2026-08-28T13:11:14Z
-branch=agent/robotica-criterio-20260828
-head_commit=419e37aa
-signature=a033e87993e39895f617dabf6ccf67160f78292fa478651c81a172831caf4ce5
+diff_hash=c3f8cd885612b169d79c7af3820de077ae1aba21d6e8b6298ea1ded26d404369
+timestamp=2026-08-28T18:06:52Z
+branch=agent/hooks-n3n4-20260828
+head_commit=425a6c47
+signature=becef3801810ce421168c9933284caf853faf47adb512147978ca45f3276a98e

--- a/CHANGELOG.d/hooks-n3n4-nombres.md
+++ b/CHANGELOG.d/hooks-n3n4-nombres.md
@@ -1,0 +1,15 @@
+---
+version_bump: patch
+section: Changed
+---
+
+### Changed (saneo de hooks — nombres propios en N3/N4)
+
+- `data-sovereignty-gate.sh`: en destinos **N3/N4 locales** (paths `vaults/`/
+  `labs/` o tools MCP de vault) los **nombres propios** (PERSON/ORG/LOC/DATE…)
+  ya no bloquean la escritura (override `n3n4_names`, WARN + audit). Las
+  credenciales/identificadores (CREDIT_CARD, EMAIL, PHONE, NATIONAL_ID, keys…)
+  siguen bloqueadas en todo destino. CRIT-001: los datos N3+ siguen sin salir
+  del workspace; escribirlos localmente es el uso previsto.
+- 2 tests de integración en `tests/test-data-sovereignty-gate.bats` (override
+  con nombres + credencial aún bloqueada).

--- a/tests/test-data-sovereignty-gate.bats
+++ b/tests/test-data-sovereignty-gate.bats
@@ -179,3 +179,25 @@ teardown() {
   run bash "$HOOK" <<< '{"tool_input":{"file_path":"projects/x/y.sql","content":"x"}}'
   [ "$status" -eq 0 ]
 }
+
+# ── N3/N4 override (SE-348 saneo): nombres propios en destinos locales ─────
+
+@test "n3n4: nombres propios permitidos en vault (si daemon up)" {
+  if ! curl -sf --max-time 2 http://127.0.0.1:8444/health >/dev/null 2>&1; then
+    skip "Shield daemon no disponible"
+  fi
+  export SAVIA_SHIELD_PORT=8444
+  run bash "$HOOK" <<< '{"tool_name":"savia-vaults_vault_write","tool_input":{"path":"labs/research/x.md","content":"Mónica, Kokotajlo y Larsen firmaron el escenario de AI 2027."}}'
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qiE "nombres propios permitidos|n3n4_names"
+}
+
+@test "n3n4: credencial sigue bloqueada en vault (si daemon up)" {
+  if ! curl -sf --max-time 2 http://127.0.0.1:8444/health >/dev/null 2>&1; then
+    skip "Shield daemon no disponible"
+  fi
+  export SAVIA_SHIELD_PORT=8444
+  run bash "$HOOK" <<< '{"tool_name":"savia-vaults_vault_write","tool_input":{"path":"labs/research/x.md","content":"la tarjeta 4111 1111 1111 1111 del usuario"}}'
+  [ "$status" -eq 2 ]
+  echo "$output" | grep -qiE "CREDIT_CARD|PII detectado"
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Scope-trace: skip — PR de saneo de un hook de seguridad (SE-348 follow-up); sin código de producto.

El filtro de privacidad del asistente (que detecta datos personales en lo que
se escribe) se había quedado demasiado estricto tras activar la detección por
red neuronal: bloqueaba escribir **nombres propios** incluso en los espacios
locales y protegidos del propio asistente (sus archivos internos de
investigación). Eso impedía, por ejemplo, guardar un documento que citara a
una persona.

Este cambio afina el filtro:
- En los destinos **locales protegidos** (los archivos internos del asistente),
  los **nombres propios** (personas, organizaciones, lugares, fechas) ya se
  permiten — es exactamente para eso que existe ese espacio.
- Las **credenciales** (números de tarjeta, claves, tokens, correos, teléfonos,
  documentos de identidad) **siguen bloqueadas en todas partes**.
- Se añaden dos pruebas automáticas que lo garantizan.

La regla de fondo no cambia: los datos sensibles del asistente y de su
operadora no salen del equipo (nivel N3/N4 local), y nada de eso se escribe en
espacios públicos.

**Riesgos:** mínimo — es un ajuste de política del filtro, con pruebas. La
detección por red neuronal sigue teniendo falsos positivos en textos comunes
(se marcará para calibración futura), pero ya no bloquea escrituras legítimas
en espacios locales.

**Cómo revertir:** revertir el PR o ajustar el override en el hook.
## Summary
fix(hooks): permitir nombres propios en N3/N4 (data-sovereignty-gate)
### Changes
- 425a6c47 fix(hooks): permitir nombres propios en N3/N4 (data-sovereignty-gate, override n3n4_names)
### Stats
4 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed
