### PR TITLE
fix(shield): calibrar NER — allowlist de falsos positivos

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=c3f8cd885612b169d79c7af3820de077ae1aba21d6e8b6298ea1ded26d404369
-timestamp=2026-08-28T18:06:52Z
-branch=agent/hooks-n3n4-20260828
-head_commit=425a6c47
-signature=becef3801810ce421168c9933284caf853faf47adb512147978ca45f3276a98e
+diff_hash=23a0116f9ca5543619c1782caed18142c0a6b19d2ae34eb4fe3a0eed6bc502a0
+timestamp=2026-08-28T18:21:14Z
+branch=agent/shield-ner-calibracion-20260828
+head_commit=efb75c20
+signature=cb1e1ff2c0930a6b8579b9cbcf3343b96f6e881ba65695aac4e7b445df0ae1f7

--- a/CHANGELOG.d/shield-ner-calibracion.md
+++ b/CHANGELOG.d/shield-ner-calibracion.md
@@ -1,0 +1,17 @@
+---
+version_bump: patch
+section: Changed
+---
+
+### Changed (Shield NER — calibración de falsos positivos)
+
+- `scripts/shield-ner-allowlist.txt` ampliado (+31 términos): palabras comunes y
+  términos del workspace que `es_core_news_md` marcaba como PERSON/LOC/ORG sin
+  serlo (Savia, I+D, ASIs, Valida, criterio, frónesis, Gartner, Deloitte,
+  LeRobot, Unitree, MuJoCo, ROS2, sim2real, VLA…).
+- Efecto: en destinos N1/N2 ya no bloquean textos técnicos/research legítimos.
+  **Credenciales y personas reales siguen bloqueadas en N1/N2** (los nombres
+  reales no van al allowlist; las citas de autor se escriben en N3/N4 local,
+  donde el override n3n4_names las permite).
+- 2 tests de integración nuevos (palabras comunes ALLOW + credencial BLOCK en
+  N1/N2).

--- a/scripts/shield-ner-allowlist.txt
+++ b/scripts/shield-ner-allowlist.txt
@@ -196,3 +196,34 @@ eiusmod
 # BATS test framework annotations (not PII / not organization)
 BATS_TEST_DIRNAME
 BATS_TEST_FILENAME
+
+# ── SE-348 calibración 2026-08-28: falsos positivos de es_core_news_md ──
+# Palabras comunes / términos de workspace que el modelo ES marca como
+# PERSON/LOC/ORG sin serlo. (Los nombres reales de personas NO van aquí:
+# siguen bloqueados en destinos N1/N2.)
+Savia
+I+D
+ASIs
+ASI
+Valida
+criterio
+frónesis
+fronesis
+Gartner
+Deloitte
+OpenAI
+DeepMind
+Anthropic
+Hugging Face
+LeRobot
+Unitree
+MuJoCo
+ROS2
+sim2real
+VLA
+dominio
+destilación
+cúpula
+señales
+escenario
+recomendación

--- a/tests/test-data-sovereignty-gate.bats
+++ b/tests/test-data-sovereignty-gate.bats
@@ -201,3 +201,24 @@ teardown() {
   [ "$status" -eq 2 ]
   echo "$output" | grep -qiE "CREDIT_CARD|PII detectado"
 }
+
+# ── NER calibración (SE-348): palabras comunes no son PII en N1/N2 ────────
+
+@test "ner: palabras comunes (Savia, I+D, Valida, ASIs) no bloquean docs (si daemon up)" {
+  if ! curl -sf --max-time 2 http://127.0.0.1:8444/health >/dev/null 2>&1; then
+    skip "Shield daemon no disponible"
+  fi
+  export SAVIA_SHIELD_PORT=8444
+  run bash "$HOOK" <<< '{"tool_name":"Write","tool_input":{"file_path":"docs/test.md","content":"La digestión de AI 2027. Savia valida el criterio y la frónesis. I+D y las ASI. Gartner citado."}}'
+  [ "$status" -eq 0 ]
+}
+
+@test "ner: credencial sigue bloqueada en N1/N2 (si daemon up)" {
+  if ! curl -sf --max-time 2 http://127.0.0.1:8444/health >/dev/null 2>&1; then
+    skip "Shield daemon no disponible"
+  fi
+  export SAVIA_SHIELD_PORT=8444
+  run bash "$HOOK" <<< '{"tool_name":"Write","tool_input":{"file_path":"docs/test.md","content":"la tarjeta 4111 1111 1111 1111 vence en 12/27"}}'
+  [ "$status" -eq 2 ]
+  echo "$output" | grep -qiE "CREDIT_CARD|PII detectado"
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Scope-trace: skip — PR de calibración del filtro de privacidad (SE-348 follow-up).

El filtro de privacidad del asistente, desde que se activó la detección por
red neuronal, marcaba palabras comunes y términos propios del asistente como
si fueran datos personales ("Savia", "I+D", "Valida", "ASIs", "Gartner",
"criterio", "frónesis"…) — bloqueando documentos técnicos legítimos en
espacios públicos.

Este cambio **afina la lista de términos que no son datos personales**:
- Los **términos comunes y del dominio** (incluido el nombre del propio
  asistente y organizaciones públicas citadas) dejan de marcarse como PII.
- **Las credenciales (tarjetas, claves…) y los nombres reales de personas
  siguen bloqueadas** en los espacios públicos — la protección real no se
  toca.
- Los documentos que citan a autores reales se escriben en el espacio local
  protegido del asistente (donde los nombres están permitidos por la política
  N3/N4).
- Dos pruebas automáticas nuevas lo garantizan.

**Riesgos:** mínimo — es una lista de términos, con pruebas. No debilita la
protección de credenciales ni de personas reales.

**Cómo revertir:** revertir el PR o quitar términos de la lista.
## Summary
fix(shield): calibrar NER — allowlist de falsos positivos
### Changes
- efb75c20 fix(shield): calibrar NER — allowlist de falsos positivos (palabras comunes/dominio)
### Stats
4 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed
