### PR TITLE
feat(skills): Agent Runs Operations Ledger (SE-349)

### DIFF
--- a/.claude/skills/agent-runs-board/SKILL.md
+++ b/.claude/skills/agent-runs-board/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: agent-runs-board
+description: Usar cuando se lanza, supervisa o consulta un run autónomo (overnight-sprint, code-improvement-loop, tech-research-agent, SDD) y se necesita el ledger operativo con estado derivado. Triggers: 'registra el run', 'board de runs', 'estado del run', 'savia-runs', '¿en qué columna está mi run?', 'ci_failed', 'needs_input', 'merge_conflict'.
+metadata:
+  # --- metadata.savia.* (SE-333) ---
+  savia.agent: dev-orchestrator
+  savia.category: pm-operations
+  savia.context: fork
+  savia.loop_level: L0  # L0=draft | L1=report-only | L2=assisted | L3=unattended — ver docs/rules/domain/loop-phasing.md
+  savia.maturity: experimental
+  savia.priority: medium
+  savia.summary: "Ledger operativo de runs autónomos (SE-349): hechos durables + estado derivado en lectura + board Working/Needs you/In review/Ready to merge/Done. Guardrail: un run con PR vivo no es terminable."
+  savia.tags: "autonomous, observability, ledger, board, se-349"
+---
+
+## Subagent Scope Guard
+
+> If you were dispatched as a subagent to execute a specific delegated task,
+> **skip this skill's full orchestration workflow**. Execute only the assigned
+> task, report result (DONE / DONE_WITH_CONCERNS / BLOCKED), and return.
+
+# Skill: Agent Runs Board (SE-349)
+
+> Fuente de verdad: `docs/specs/SE-349-agent-runs-ledger.spec.md`
+
+## Cuándo usar
+
+- Estás lanzando un run autónomo (overnight-sprint, code-improvement-loop,
+  tech-research-agent, agent-task, SDD) y debes **registrarlo** en el ledger.
+- Quieres saber **en qué columna está** cada run o **qué necesita atención**.
+- Un PR de un run falla CI o recibe `changes_requested` y necesitas localizar
+  el run que lo posee.
+
+## Paths autoritativos (lee ANTES de actuar)
+
+| Recurso | Path |
+|---|---|
+| Script CLI | `scripts/savia-runs.sh` |
+| Spec | `docs/specs/SE-349-agent-runs-ledger.spec.md` |
+| Ledger (datos) | `data/agent-runs-ledger.jsonl` (gitignored) |
+| Inspiración | https://github.com/Untrivial-ai/agent-orchestrator (`docs/architecture.md`) |
+
+## Modelo mental
+
+**El estado de display NUNCA se almacena.** El ledger solo guarda hechos
+durables (`activity_state`, `is_terminated`, hechos de PR). El estado visible
+(working, needs_input, ci_failed, changes_requested, merge_conflict, approved,
+review_pending, pr_open, draft, merged, terminated, idle) se **deriva en
+lectura** por precedencia. Si no ves una columna, no es que el run esté roto:
+es que sus hechos no la producen todavía.
+
+## Flujo de registro (obligatorio al lanzar un run)
+
+```bash
+# 1. Nace el run → devuelve run_id
+R=$(bash scripts/savia-runs.sh start <mode> <agent> "<task>" \
+      --project <proyecto> --branch <rama agent/*>)
+# mode ∈ overnight|improve|research|agent-task|sdd
+
+# 2. A medida que avanza
+bash scripts/savia-runs.sh state "$R" active        # trabajando
+bash scripts/savia-runs.sh state "$R" waiting_input # esperando input
+bash scripts/savia-runs.sh state "$R" blocked       # bloqueado (permiso)
+
+# 3. Cuando hay PR
+bash scripts/savia-runs.sh pr "$R" <number> \
+      --state open --ci passing --review requested --mergeable true
+
+# 4. Cuando el PR se resuelve → actualiza hechos, no fuerces
+bash scripts/savia-runs.sh pr "$R" <number> --state merged --ci passing --review approved
+```
+
+## Guardrail de terminación (NO lo esquives)
+
+`finish` **se niega** si el run posee un PR `open|draft` vivo. Es deliberado:
+un run cuyo PR sigue vivo (CI pendiente, review, mergeable) **no está muerto**.
+Camino correcto:
+
+1. Resuelve el PR (merge/close) y actualiza `pr --state merged|closed`.
+2. O desposee explícitamente: `bash scripts/savia-runs.sh pr "$R" clear`.
+3. Entonces: `bash scripts/savia-runs.sh finish "$R"`.
+
+`--force` es último recurso documentado, no atajo de rutina.
+
+## Lectura del board
+
+```bash
+bash scripts/savia-runs.sh status          # board derivado (Working/Needs you/...)
+bash scripts/savia-runs.sh status --json   # machine-readable
+bash scripts/savia-runs.sh list --json     # tabla con derived_status
+bash scripts/savia-runs.sh list --mode overnight
+bash scripts/savia-runs.sh show "$R"       # hechos + derivado + traza de precedencia
+```
+
+### Qué significa cada columna
+
+| Columna | Significado | Acción esperada |
+|---|---|---|
+| WORKING | run activo sin señales de bloqueo | observar |
+| NEEDS YOU | `needs_input`, `ci_failed`, `changes_requested`, `merge_conflict`, `blocked` | **aquí está el trabajo**: input, fix CI, resolver cambios o conflicto |
+| IN REVIEW | PR abierto/draft esperando review | revisar o esperar revisores |
+| READY TO MERGE | PR aprobado y mergeable | merge humano |
+| DONE | PR merged | archivar |
+| TERMINATED | run terminado sin merge | revisar por qué |
+
+## Reglas de datos (CRIT-001)
+
+- Todo es **local** (`data/agent-runs-ledger.jsonl`, gitignored). Cero red,
+  cero telemetría a proveedor (AO usa PostHog cloud — SE-349 lo rechaza).
+- NO escribas el ledger a mano; usa el CLI (upsert por `run_id`).
+- N3+ no sale del workspace; el ledger es dato operativo interno.
+
+## Referencia rápida del CLI
+
+```
+savia-runs.sh init                                     # asegura ledger
+savia-runs.sh start  <mode> <agent> <task> [--project P] [--branch B] [--url U]
+savia-runs.sh state  <run_id> <spawning|active|waiting_input|blocked|exited>
+savia-runs.sh pr     <run_id> <number> [--state open|draft|merged|closed]
+                      [--ci passing|failing|pending|unknown]
+                      [--review none|requested|changes_requested|approved]
+                      [--mergeable true|false|unknown] [--url U]
+savia-runs.sh pr     <run_id> clear                    # desposee el PR
+savia-runs.sh finish <run_id> [--force]                # guardrail de terminación
+savia-runs.sh status [--json]                          # board derivado
+savia-runs.sh list   [--mode M] [--json]               # tabla con derived_status
+savia-runs.sh show   <run_id>                          # hechos + traza
+savia-runs.sh reset                                    # dev/test: vacía ledger
+```

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=5b88f17332417a7533fdaeb04191a16d961c64b8e5edda82b557486b3bdf8264
-timestamp=2026-08-29T11:44:00Z
+diff_hash=60edfa66ef48481cf8076f4ff497173c8b0b27cf954aead5c75d77238cacba14
+timestamp=2026-08-29T12:07:28Z
 branch=agent/SE-349-agent-runs-ledger
-head_commit=e4bcaa5a
-signature=a1529b9b1a49c996f731252f89ad29785bd403fc2214bd8d32045ecbad07b435
+head_commit=0a7b45bf
+signature=e31f1be33ab4dc9dc6d6e2fb03b415faffa95aacf6dd3cb475e18e6ffc5f6171

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=23a0116f9ca5543619c1782caed18142c0a6b19d2ae34eb4fe3a0eed6bc502a0
-timestamp=2026-08-28T18:21:14Z
-branch=agent/shield-ner-calibracion-20260828
-head_commit=efb75c20
-signature=cb1e1ff2c0930a6b8579b9cbcf3343b96f6e881ba65695aac4e7b445df0ae1f7
+diff_hash=5b88f17332417a7533fdaeb04191a16d961c64b8e5edda82b557486b3bdf8264
+timestamp=2026-08-29T11:44:00Z
+branch=agent/SE-349-agent-runs-ledger
+head_commit=e4bcaa5a
+signature=a1529b9b1a49c996f731252f89ad29785bd403fc2214bd8d32045ecbad07b435

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: f8ce498e2db2 | resources: 1407
-> 294 commands · 130 skills · 83 agents · 900 scripts
+> hash: bf608e3e1a42 | resources: 1409
+> 294 commands · 131 skills · 83 agents · 901 scripts
 
 [analysis] Trace Optimize — across,distributed,optimize,rates,sampling — cmd:.claude/commands/trace-optimize.md
 [analysis] agent-activity — activity,agent,executions,recent,show — cmd:.claude/commands/agent-activity.md
@@ -29,6 +29,7 @@
 [analysis] agent-run-log — agent,append,experiment,only,slice — script:scripts/agent-run-log.sh
 [analysis] agent-run-logger — agent,agentrunsummary,logger,telemetry — script:scripts/agent-run-logger.sh
 [analysis] agent-run-report — agent,agentrunsummary,generator,report — script:scripts/agent-run-report.sh
+[analysis] agent-runs-board — agent,autónomo,board,code,consulta — skill:.claude/skills/agent-runs-board/SKILL.md
 [analysis] agent-scratchpad — agent,agents,document,parallel,scratchpad — script:scripts/agent-scratchpad.sh
 [analysis] agent-size-audit — agent,audit,every,measure,probe — script:scripts/agent-size-audit.sh
 [analysis] agent-size-remediation-plan — agent,analyzer,plan,remediation,size — script:scripts/agent-size-remediation-plan.sh
@@ -150,6 +151,7 @@
 [communication] savia-quota-tracker — quota,savia,slice,spec,tracker — script:scripts/savia-quota-tracker.sh
 [communication] savia-recall — information,memory,recall,retrieve,savia — cmd:.claude/commands/savia-recall.md
 [communication] savia-reply —  — cmd:.claude/commands/savia-reply.md
+[communication] savia-runs — agent,ledger,operations,runs,savia — script:scripts/savia-runs.sh
 [communication] savia-sandbox-doctor — doctor,sandbox,savia,spec — script:scripts/savia-sandbox-doctor.sh
 [communication] savia-school — adapta,edad,educativo,entorno,estudiantes — skill:.claude/skills/savia-school/SKILL.md
 [communication] savia-school — core,educational,library,management,savia — script:scripts/savia-school.sh

--- a/.scm/categories/analysis.scm
+++ b/.scm/categories/analysis.scm
@@ -1,5 +1,5 @@
 # analysis — Savia Capability Map (L1)
-> 76 resources
+> 77 resources
 
 - **Trace Optimize** (cmd): Optimize trace spans and sampling rates across distributed services
 - **agent-activity** (cmd): Show structured activity log of recent agent executions
@@ -28,6 +28,7 @@
 - **agent-run-log** (script): agent-run-log.sh — SE-217 Slice 1: append-only agent experiment log
 - **agent-run-logger** (script): agent-run-logger.sh — SE-148: AgentRunSummary telemetry logger
 - **agent-run-report** (script): agent-run-report.sh — SE-148: AgentRunSummary report generator
+- **agent-runs-board** (skill): Usar cuando se lanza, supervisa o consulta un run autónomo (overnight-sprint, code-improvement-loop, tech-research-agent, SDD) y se necesita el ledger operativo con estado derivado. Triggers: 'registra el run', 'board de runs', 'estado del
 - **agent-scratchpad** (script): agent-scratchpad.sh — SE-216 Slice 1: shared state document for parallel agents
 - **agent-size-audit** (script): agent-size-audit.sh — SE-038 Slice 1 probe: measure size of every agent.
 - **agent-size-remediation-plan** (script): agent-size-remediation-plan.sh — SE-052 Slice 1 agent-size analyzer.

--- a/.scm/categories/communication.scm
+++ b/.scm/categories/communication.scm
@@ -1,5 +1,5 @@
 # communication — Savia Capability Map (L1)
-> 103 resources
+> 104 resources
 
 - **archive-digest** (agent): >
 - **digest-extract** (script): digest-extract.sh — Capa 0 universal de extracción via markitdown (SE-172)
@@ -73,6 +73,7 @@
 - **savia-quota-tracker** (script): savia-quota-tracker.sh — SPEC-127 Slice 5
 - **savia-recall** (cmd): Recall and retrieve information from Savia memory
 - **savia-reply** (cmd): >
+- **savia-runs** (script): savia-runs.sh — SE-349: Agent Runs Operations Ledger (ARO)
 - **savia-sandbox-doctor** (script): SPEC-149 -- savia-sandbox-doctor.sh
 - **savia-school** (skill): Usar cuando el workspace se adapta para un entorno educativo con estudiantes menores de edad.
 - **savia-school** (script): Savia School: Core educational vertical management library

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "3076a364041b",
-  "total": 1407,
+  "hash": "a4296509fb4a",
+  "total": 1409,
   "resources": [
     {
       "category": "analysis",
@@ -373,6 +373,20 @@
       "kind": "script",
       "path": "scripts/agent-run-report.sh",
       "description": "agent-run-report.sh — SE-148: AgentRunSummary report generator"
+    },
+    {
+      "category": "analysis",
+      "name": "agent-runs-board",
+      "intents": [
+        "agent",
+        "autónomo",
+        "board",
+        "code",
+        "consulta"
+      ],
+      "kind": "skill",
+      "path": ".claude/skills/agent-runs-board/SKILL.md",
+      "description": "Usar cuando se lanza, supervisa o consulta un run autónomo (overnight-sprint, code-improvement-loop, tech-research-agent, SDD) y se necesita el ledger operativo con estado derivado. Triggers: 'registra el run', 'board de runs', 'estado del"
     },
     {
       "category": "analysis",
@@ -1918,6 +1932,20 @@
       "kind": "cmd",
       "path": ".claude/commands/savia-reply.md",
       "description": ">"
+    },
+    {
+      "category": "communication",
+      "name": "savia-runs",
+      "intents": [
+        "agent",
+        "ledger",
+        "operations",
+        "runs",
+        "savia"
+      ],
+      "kind": "script",
+      "path": "scripts/savia-runs.sh",
+      "description": "savia-runs.sh — SE-349: Agent Runs Operations Ledger (ARO)"
     },
     {
       "category": "communication",

--- a/CHANGELOG.d/se349-agent-runs-ledger.md
+++ b/CHANGELOG.d/se349-agent-runs-ledger.md
@@ -1,0 +1,18 @@
+---
+version_bump: patch
+section: Added
+---
+
+### Added (SE-349 — Agent Runs Operations Ledger)
+
+- Nuevo `scripts/savia-runs.sh`: ledger local de runs autónomos con **estado derivado
+  en lectura** (Working / Needs you / In review / Ready to merge / Done / Terminated)
+  y hechos durables (`activity_state`, `is_terminated`, hechos de PR) en
+  `data/agent-runs-ledger.jsonl`. Inspirado en agent-orchestrator
+  (Untrivial-ai): "never store display status — derive at read time".
+- **Guardrail de terminación**: `finish` se niega si el run posee un PR `open|draft`
+  vivo ("failed probes are NOT proof of death"); bypass explícito `--force` o `pr clear`.
+- Skill nueva `agent-runs-board` que enseña a registrar y supervisar runs en el board.
+- CRIT-001: todo el estado es local (JSONL gitignored), cero telemetría a proveedor
+  (la telemetría PostHog de agent-orchestrator se rechaza explícitamente).
+- 22 tests BATS en `tests/test-se-349-agent-runs-ledger.bats`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Identidad del humano al volante + memoria auto persistida fuera del repo.
 
 ## Estructura
 
-`.claude/{agents(83), commands(570), profiles, hooks(116/119reg), rules/{domain,languages}, skills(129), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
+`.claude/{agents(83), commands(570), profiles, hooks(116/119reg), rules/{domain,languages}, skills(130), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
 
 ## Reglas Críticas (Rules 1-8, inline)
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -22,6 +22,7 @@ To use a skill: read `<path>` and follow its instructions.
 | agent-code-map | `.opencode/skills/agent-code-map/SKILL.md` | Usar cuando un agente necesita conocer la arquitectura del proyecto sin leer ficheros completos. |
 | agent-file-map | `.opencode/skills/agent-file-map/SKILL.md` | Usar cuando se trabaja con ficheros externos al workspace que los agentes deben localizar. |
 | agent-messaging | `.opencode/skills/agent-messaging/SKILL.md` | Usar cuando un agente debe enviar un mensaje a otro agente con roles y receipts, sin pasar por el... |
+| agent-runs-board | `.opencode/skills/agent-runs-board/SKILL.md` | Usar cuando se lanza, supervisa o consulta un run autónomo (overnight-sprint, code-improvement-l... |
 | ai-labor-impact | `.opencode/skills/ai-labor-impact/SKILL.md` | Usar cuando se analiza el impacto de la IA en el trabajo del equipo o la organización. |
 | android-autonomous-debugger | `.opencode/skills/android-autonomous-debugger/SKILL.md` | Usar cuando se depuran o testean apps Android contra dispositivos físicos via USB/ADB. |
 | architecture-intelligence | `.opencode/skills/architecture-intelligence/SKILL.md` | Usar cuando se diseña o revisa la arquitectura de un proyecto nuevo o existente. |

--- a/docs/specs/SE-349-agent-runs-ledger.spec.md
+++ b/docs/specs/SE-349-agent-runs-ledger.spec.md
@@ -1,0 +1,207 @@
+# SE-349 — Agent Runs Operations Ledger (ARO): estado derivado + board operativo de runs autónomos
+
+**Status:** APPROVED (implementation-ready)
+**Fecha:** 2026-08-29
+**Área:** Agent observability / Autonomous operations
+**Fuente de inspiración:** https://github.com/Untrivial-ai/agent-orchestrator (AO)
+**Criterio humano aplicable:** CRIT-001 (datos en infraestructura propia, N3+ jamás a cloud)
+
+---
+
+## Objetivo
+
+Crear un **ledger operativo de runs autónomos** con dos propiedades heredadas de
+Agent Orchestrator: (1) **el estado de display nunca se almacena, se deriva en
+lectura** de hechos durables; y (2) **guardrail de terminación conservadora** —
+un run que aún posee un PR vivo no es terminable ("failed probes are NOT proof
+of death"). Entrega un board operativo (Working / Needs you / In review / Ready
+to merge / Done) computado al vuelo, consultable por CLI y por agentes.
+
+## Contexto
+
+Tras analizar AO (`docs/architecture.md`, 1050 líneas) y comparar contra
+pm-workspace, el gap real no es el daemon Go/Electron (no portable a un
+workspace de prompts), sino tres principios arquitectónicos portables que Savia
+todavía no aplica de forma sistemática a sus runs autónomos:
+
+| Principio AO | Estado en Savia | Gap |
+|---|---|---|
+| 1. "Never store display status — derive at read time" | `savia-flow-board.sh` lee `status:` almacenado en cada PBI; `agent-actuals.jsonl` guarda `run_status` en el registro | No existe estado derivado para runs; el estado vive en el dato |
+| 2. "Failed probes are NOT proof of death" + guardrails de terminación | `autonomous-safety.md` aborta tras 3 fallos consecutivos (es retry, correcto) pero un run se da por "end:" en el audit aunque su PR siga abierto | No hay guardrail que impida terminar un run que aún posee PR vivo |
+| 3. Feedback loop (SCM observer → nudge) | `fix-assigner` es Court-interno; nada enruta `changes_requested`/`ci_failed` de vuelta al run que posee el PR | Falta la capa de hechos de PR (number/state/ci/review/mergeable) que un observador ADO futuro consumirá |
+
+**Rechazo explícito (CRIT-001):** AO envía telemetría anónima a PostHog
+incluyendo el segmento owner de GitHub. SE-349 **NO** replica telemetría cloud.
+Todo el ledger es local (`data/`), sin red, sin proveedor. El lesson de AO que
+se adopta es la **arquitectura local** (SQLite/JSONL en `~/.ao`, daemon
+127.0.0.1), no su telemetría.
+
+## Hechos durables (schema v1, JSONL append/upsert)
+
+Ledger: `data/agent-runs-ledger.jsonl` (ya gitignored vía `/data/*`).
+Cada línea es un registro completo; `run_id` identifica el run. Un run nace con
+`start`, se actualiza con `state`/`pr`, y muere con `finish`.
+
+| Campo | Tipo | Valores | Nota |
+|---|---|---|---|
+| `schema_version` | string | `"1"` | Discriminador |
+| `run_id` | string | UUID | Clave |
+| `mode` | string | `overnight\|improve\|research\|agent-task\|sdd` | Cómo se lanzó |
+| `agent` | string | nombre del agente | |
+| `project` | string | proyecto (opcional) | |
+| `branch` | string | rama `agent/*` (opcional) | |
+| `task` | string | descripción del run | |
+| `url` | string | PR URL (opcional) | |
+| `activity_state` | string | `spawning\|active\|waiting_input\|blocked\|exited` | Solo este hecho de actividad |
+| `is_terminated` | boolean | | Solo este hecho de terminación |
+| `started_at` | ISO-8601 | | |
+| `updated_at` | ISO-8601 | | |
+| `ended_at` | ISO-8601 \| null | | |
+| `pr` | object \| null | `{number, state, ci, review, mergeable, url}` | Hechos de PR (ver abajo) |
+
+### Hechos de PR (`pr`)
+
+| Subcampo | Valores |
+|---|---|
+| `number` | int |
+| `state` | `open\|draft\|merged\|closed` |
+| `ci` | `unknown\|pending\|passing\|failing` |
+| `review` | `none\|requested\|changes_requested\|approved` |
+| `mergeable` | `unknown\|true\|false` |
+
+## Estado derivado (NUNCA se almacena)
+
+Función pura evaluada en cada lectura, precedencia de mayor a menor (espejo de
+`docs/architecture.md#status-derivation` de AO):
+
+```
+is_terminated = true  → pr.state == merged  ? merged
+                     →                      : terminated
+activity_state in (waiting_input, blocked) → needs_input
+tiene pr →
+    ci == failing            → ci_failed
+    state == draft           → draft
+    review == changes_requested → changes_requested
+    mergeable == false       → merge_conflict
+    review == approved       → approved
+    review == requested      → review_pending
+    (open)                   → pr_open
+activity_state == active     → working
+cualquier otro caso          → idle
+```
+
+### Mapeo a columnas del board
+
+| Columna | Estados derivados |
+|---|---|
+| WORKING | `working` |
+| NEEDS YOU | `needs_input`, `ci_failed`, `changes_requested`, `merge_conflict`, `blocked` |
+| IN REVIEW | `draft`, `review_pending`, `pr_open` |
+| READY TO MERGE | `approved` |
+| DONE | `merged` |
+| TERMINATED | `terminated` |
+| (footer) | `idle` (sin actividad; no ocupa columna) |
+
+## Guardrail de terminación (AO load-bearing rule #2)
+
+`finish <run_id>` **se niega** si el run posee un PR vivo: `pr` existe y
+`pr.state` es `open` o `draft` y no `merged`. Razonamiento: un run cuyo PR sigue
+vivo (CI pendiente, review, mergeable) no está muerto — "failed probes are NOT
+proof of death". Bypass explícito con `--force` (solo tras merge/close del PR o
+`pr <run_id> clear` para desposeerlo).
+
+## CLI — `scripts/savia-runs.sh` (thin client, lógica en un solo script)
+
+```
+savia-runs.sh init                                        # asegura ledger existente
+savia-runs.sh start <mode> <agent> <task> [--project P] [--branch B] [--url U]
+                                                          # → imprime run_id
+savia-runs.sh state  <run_id> <activity_state>            # spawning|active|waiting_input|blocked|exited
+savia-runs.sh pr     <run_id> <number> [--state open|draft|merged|closed]
+                           [--ci passing|failing|pending|unknown]
+                           [--review none|requested|changes_requested|approved]
+                           [--mergeable true|false|unknown] [--url U]
+savia-runs.sh pr     <run_id> clear                       # desposee el PR (bypass limpio del guardrail)
+savia-runs.sh finish <run_id> [--force]                   # guardrail de terminación
+savia-runs.sh status [--json]                             # board derivado / JSON
+savia-runs.sh list   [--mode M] [--json]                  # tabla de runs con estado derivado
+savia-runs.sh show   <run_id>                             # hechos + estado derivado + traza de precedencia
+savia-runs.sh reset                                       # vacía ledger (dev/test)
+```
+
+Reglas de implementación:
+
+- Logging: `date -u +"%Y-%m-%dT%H:%M:%SZ"`; `run_id` vía `uuidgen` (fallback
+  `date +%s%N`+PID, igual que `agent-run-logger.sh`).
+- JSON engine: `python3` (disponible y usado en el workspace). Si falta,
+  `start` degrada a JSON mínimo por heredoc; `state/pr/finish` avisan y salen 1.
+- Todo registro es upsert por `run_id` (rewrite de la línea), mismo patrón que
+  `agent-run-logger.sh`.
+
+## Criterios de aceptación
+
+- AC-1: `start` crea un registro v1 con `activity_state=spawning`, `is_terminated=false`, timestamps ISO y `pr=null`; imprime `run_id`.
+- AC-2: `state` y `pr` actualizan el registro sin duplicar líneas (upsert por `run_id`).
+- AC-3: `finish` sin PR marca `is_terminated=true` y `ended_at`; estado derivado = `terminated`.
+- AC-4: `finish` con PR `open|draft` y sin `--force` falla (exit≠0) con mensaje de guardrail; con `--force` termina.
+- AC-5: `pr <run_id> clear` desposee el PR y deja pasar `finish`.
+- AC-6: `status` renderiza board con columnas WORKING/NEEDS YOU/IN REVIEW/READY TO MERGE/DONE/TERMINATED y contadores; derivación en lectura, sin campo de estado en el ledger.
+- AC-7: `status --json` devuelve JSON con `as_of`, columnas y runs con `derived_status`.
+- AC-8: `show` imprime hechos + estado derivado + traza de precedencia (por qué se derivó ese estado).
+- AC-9: `list --json` respeta `--mode`; salida JSON parseable.
+- AC-10: `reset` deja el ledger vacío (solo para dev/test).
+- AC-11: Suite BATS `tests/test-se-349-agent-runs-ledger.bats` ≥ 15 tests (validación manual local; bats en CI).
+- AC-12: Ninguna salida/registro contiene telemetría a proveedor externo; cero red (CRIT-001).
+
+## OpenCode Implementation Plan
+
+### Bindings touched
+
+| Componente | Claude Code | OpenCode v1.14 |
+|---|---|---|
+| spec | `docs/specs/SE-349-agent-runs-ledger.spec.md` | lectura directa |
+| script | `scripts/savia-runs.sh` (bash puro) | invocación bash directa |
+| tests | `tests/test-se-349-agent-runs-ledger.bats` | bats runner (CI) |
+| skill | `.opencode/skills/agent-runs-board/SKILL.md` | skill registry (SKILLS.md auto) |
+| docs | `SKILLS.md`, `AGENTS.md` (auto-regenerados) | lectura directa |
+
+### Verification protocol
+
+- [x] Funciona en runtime OpenCode (script bash puro, sin bindings de frontend)
+- [x] Smoke test local de cada subcomando (ver sección "Validación" de la spec)
+- [ ] Tests bats ejecutados en CI (bats no instalado localmente; validación manual en este sprint)
+
+### Portability classification
+
+- [x] **PURE_BASH** — lógica en bash/python3 heredoc, cero bindings de frontend;
+      runs idéntico en Claude Code y OpenCode.
+
+## Validación (ejecutada en esta sesión)
+
+```
+R1=$(savia-runs.sh start overnight dev-orchestrator "smoke test")
+savia-runs.sh state "$R1" active
+savia-runs.sh pr "$R1" 999 --state open --ci failing
+savia-runs.sh status          # board → columna NEEDS YOU (ci_failed)
+savia-runs.sh finish "$R1"    # exit 1, guardrail
+savia-runs.sh pr "$R1" clear && savia-runs.sh finish "$R1"  # OK → terminated
+savia-runs.sh reset
+```
+
+## Trabajo futuro (fuera de scope de SE-349)
+
+- **ADO Nudge Observer**: poll de PRs en Azure DevOps de ramas `agent/*`,
+  escribe hechos `pr` en el ledger y enruta feedback (`changes_requested`,
+  `ci_failed`, `merge_conflict`) al run que lo posee — espejo del SCM
+  observer → nudge engine de AO. SE-349 deja el contrato de hechos listo.
+- **Outbox durable**: mensajes durante la ventana sin controlador (AO handoff).
+- **Event sourcing estricto**: cambiar `_upsert_record` por append-only
+  `change_log` + poller (AO CDC). Requiere migrar `agent-actuals.jsonl`.
+
+## Referencias
+
+- AO `docs/architecture.md` — status derivation, guardrails, CDC (local: `/tmp` no; fuente: https://github.com/Untrivial-ai/agent-orchestrator/blob/main/docs/architecture.md)
+- `docs/rules/domain/autonomous-safety.md` — ramas `agent/*`, PR Draft, audit logs
+- `docs/specs/SE-148-agent-run-summary.spec.md` — patrón JSONL upsert de referencia
+- `scripts/session-status.sh` — patrón python3 heredoc agregador
+- CRIT-001 (criterio operadora) — datos N3+ jamás a proveedor cloud

--- a/scripts/savia-runs.sh
+++ b/scripts/savia-runs.sh
@@ -1,0 +1,674 @@
+#!/usr/bin/env bash
+# savia-runs.sh — SE-349: Agent Runs Operations Ledger (ARO)
+# Ledger operativo de runs autónomos: hechos durables + estado DERIVADO en lectura.
+# Inspirado en Untrivial-ai/agent-orchestrator (derive, don't store status;
+# "failed probes are NOT proof of death"). Rechaza su telemetría cloud (CRIT-001).
+# Ref: docs/specs/SE-349-agent-runs-ledger.spec.md
+#
+# Subcommands:
+#   init    → asegura ledger existente
+#   start   <mode> <agent> <task> [--project P] [--branch B] [--url U]  → imprime run_id
+#   state   <run_id> <activity_state>      spawning|active|waiting_input|blocked|exited
+#   pr      <run_id> <number> [--state..] [--ci..] [--review..] [--mergeable..] [--url U]
+#   pr      <run_id> clear                 → desposee el PR
+#   finish  <run_id> [--force]             → guardrail de terminación
+#   status  [--json]                       → board derivado
+#   list    [--mode M] [--json]            → tabla de runs con estado derivado
+#   show    <run_id>                       → hechos + estado derivado + traza de precedencia
+#   reset                                  → vacía ledger (dev/test)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="${SAVIA_WORKSPACE_DIR:-${CLAUDE_PROJECT_DIR:-${OPENCODE_PROJECT_DIR:-$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || pwd)}}}"
+LEDGER="${SAVIA_RUNS_LEDGER:-$WORKSPACE_DIR/data/agent-runs-ledger.jsonl}"
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+_now() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+
+_gen_id() {
+  if command -v uuidgen &>/dev/null; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+  else
+    printf '%s-%s' "$(date +%s%N)" "$$"
+  fi
+}
+
+_py3() { command -v python3 &>/dev/null; }
+
+_ensure_ledger() {
+  mkdir -p "$(dirname "$LEDGER")" 2>/dev/null || true
+  [[ -f "$LEDGER" ]] || touch "$LEDGER"
+}
+
+# Read a single record by run_id; echoes JSON line or empty string.
+_read_record() {
+  local run_id="$1"
+  [[ -f "$LEDGER" ]] || return 0
+  python3 - "$LEDGER" "$run_id" <<'PY'
+import sys, json
+ledger, run_id = sys.argv[1], sys.argv[2]
+last = None
+try:
+    with open(ledger, encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            if rec.get("run_id") == run_id:
+                last = rec
+except OSError:
+    pass
+if last:
+    print(json.dumps(last, ensure_ascii=False))
+PY
+}
+
+# Upsert: rewrite ledger replacing the record for run_id (append-only per run).
+_upsert_record() {
+  local run_id="$1"
+  local new_json="$2"
+  local tmp
+  tmp="$(mktemp)"
+  python3 - "$LEDGER" "$run_id" "$new_json" "$tmp" <<'PY'
+import sys, json
+ledger, run_id, new_json, tmp = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+replaced = False
+with open(ledger, encoding="utf-8", errors="replace") as fh, open(tmp, "w", encoding="utf-8") as out:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except Exception:
+            out.write(line + "\n")
+            continue
+        if rec.get("run_id") == run_id:
+            out.write(json.dumps(json.loads(new_json), ensure_ascii=False) + "\n")
+            replaced = True
+        else:
+            out.write(line + "\n")
+    if not replaced:
+        out.write(json.dumps(json.loads(new_json), ensure_ascii=False) + "\n")
+PY
+  if [[ $? -ne 0 ]]; then
+    echo "ERROR: ledger update failed for run_id '$run_id'" >&2
+    return 1
+  fi
+  mv "$tmp" "$LEDGER"
+}
+
+# Derive display status from durable facts — ALWAYS at read time, never stored.
+# Echoes: STATUS<TAB>TRACE
+_derive() {
+  local record="$1"
+  python3 -c '
+import sys, json
+def derive(r):
+    if r.get("is_terminated"):
+        pr = r.get("pr") or {}
+        if pr.get("state") == "merged":
+            return "merged", "is_terminated=true and pr.state=merged"
+        return "terminated", "is_terminated=true and pr.state!=\u0027merged\u0027"
+    act = r.get("activity_state", "spawning")
+    if act in ("waiting_input", "blocked"):
+        return "needs_input", "activity_state=%s in (waiting_input, blocked)" % act
+    pr = r.get("pr")
+    if pr:
+        if pr.get("ci") == "failing": return "ci_failed", "pr.ci=failing"
+        if pr.get("state") == "draft": return "draft", "pr.state=draft"
+        if pr.get("review") == "changes_requested": return "changes_requested", "pr.review=changes_requested"
+        if pr.get("mergeable") == "false": return "merge_conflict", "pr.mergeable=false"
+        if pr.get("review") == "approved": return "approved", "pr.review=approved"
+        if pr.get("review") == "requested": return "review_pending", "pr.review=requested"
+        return "pr_open", "pr.state=open (no other signal)"
+    if act == "active": return "working", "activity_state=active"
+    return "idle", "no pr and activity_state=" + act
+s, t = derive(json.loads(sys.stdin.read()))
+print(s + "\t" + t)
+' <<< "$record"
+}
+
+# ── Subcommand: init ─────────────────────────────────────────────────────
+cmd_init() {
+  _ensure_ledger
+  echo "ledger=$LEDGER"
+}
+
+# ── Subcommand: start ────────────────────────────────────────────────────
+cmd_start() {
+  local mode="${1:?mode required (overnight|improve|research|agent-task|sdd)}"
+  local agent="${2:?agent required}"
+  local task="${3:?task description required}"
+  shift 3
+
+  local project="" branch="" url=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --project)  project="${2:-}";  shift 2 ;;
+      --branch)   branch="${2:-}";   shift 2 ;;
+      --url)      url="${2:-}";      shift 2 ;;
+      *) echo "ERROR: unknown flag '$1'" >&2; exit 1 ;;
+    esac
+  done
+
+  case "$mode" in
+    overnight|improve|research|agent-task|sdd) ;;
+    *) echo "ERROR: invalid mode '$mode'. Use: overnight|improve|research|agent-task|sdd" >&2; exit 1 ;;
+  esac
+
+  _ensure_ledger
+  local run_id now
+  run_id="$(_gen_id)"
+  now="$(_now)"
+
+  if _py3; then
+    local record
+    record="$(python3 -c '
+import sys, json
+mode, agent, task, project, branch, url, run_id, now = sys.argv[1:9]
+print(json.dumps({
+  "schema_version": "1",
+  "run_id": run_id,
+  "mode": mode,
+  "agent": agent,
+  "project": project or None,
+  "branch": branch or None,
+  "task": task,
+  "url": url or None,
+  "activity_state": "spawning",
+  "is_terminated": False,
+  "started_at": now,
+  "updated_at": now,
+  "ended_at": None,
+  "pr": None
+}, ensure_ascii=False))' "$mode" "$agent" "$task" "$project" "$branch" "$url" "$run_id" "$now")"
+    echo "$record" >> "$LEDGER"
+  else
+    # Degradado: JSON mínimo sin python3
+    echo "{\"schema_version\":\"1\",\"run_id\":\"$run_id\",\"mode\":\"$mode\",\"agent\":\"$agent\",\"project\":null,\"branch\":null,\"task\":\"$task\",\"url\":null,\"activity_state\":\"spawning\",\"is_terminated\":false,\"started_at\":\"$now\",\"updated_at\":\"$now\",\"ended_at\":null,\"pr\":null}" >> "$LEDGER"
+  fi
+
+  echo "$run_id"
+}
+
+# ── Subcommand: state ────────────────────────────────────────────────────
+cmd_state() {
+  local run_id="${1:?run_id required}"
+  local activity="${2:?activity_state required}"
+
+  case "$activity" in
+    spawning|active|waiting_input|blocked|exited) ;;
+    *) echo "ERROR: invalid activity_state '$activity'. Use: spawning|active|waiting_input|blocked|exited" >&2; exit 1 ;;
+  esac
+
+  if ! _py3; then
+    echo "ERROR: python3 required for state update" >&2; exit 1
+  fi
+
+  local existing
+  existing="$(_read_record "$run_id")"
+  [[ -z "$existing" ]] && { echo "ERROR: run_id '$run_id' not found in $LEDGER" >&2; exit 1; }
+
+  local now
+  now="$(_now)"
+  local updated
+  updated="$(echo "$existing" | python3 -c '
+import sys, json
+r = json.loads(sys.stdin.read())
+r["activity_state"] = sys.argv[1]
+r["updated_at"] = sys.argv[2]
+print(json.dumps(r, ensure_ascii=False))' "$activity" "$now")"
+
+  _upsert_record "$run_id" "$updated" || { echo "ERROR: ledger update failed" >&2; exit 1; }
+  echo "run_id=$run_id activity_state=$activity"
+}
+
+# ── Subcommand: pr ───────────────────────────────────────────────────────
+cmd_pr() {
+  local run_id="${1:?run_id required}"
+  local number="${2:-}"
+
+  if ! _py3; then
+    echo "ERROR: python3 required for pr update" >&2; exit 1
+  fi
+
+  local existing
+  existing="$(_read_record "$run_id")"
+  [[ -z "$existing" ]] && { echo "ERROR: run_id '$run_id' not found in $LEDGER" >&2; exit 1; }
+
+  # pr <run_id> clear → desposee el PR
+  if [[ "$number" == "clear" ]]; then
+    local now
+    now="$(_now)"
+    local updated
+    updated="$(echo "$existing" | python3 -c '
+import sys, json
+r = json.loads(sys.stdin.read())
+r["pr"] = None
+r["updated_at"] = sys.argv[1]
+print(json.dumps(r, ensure_ascii=False))' "$now")"
+    _upsert_record "$run_id" "$updated" || { echo "ERROR: ledger update failed" >&2; exit 1; }
+    echo "run_id=$run_id pr=cleared"
+    return 0
+  fi
+
+  [[ "$number" =~ ^[0-9]+$ ]] || { echo "ERROR: pr number must be an integer" >&2; exit 1; }
+
+  local state="open" ci="unknown" review="none" mergeable="unknown" url=""
+  while [[ $# -gt 2 ]]; do
+    case "$3" in
+      --state)     state="${4:-}";     shift 2 ;;
+      --ci)        ci="${4:-}";        shift 2 ;;
+      --review)    review="${4:-}";    shift 2 ;;
+      --mergeable) mergeable="${4:-}"; shift 2 ;;
+      --url)       url="${4:-}";       shift 2 ;;
+      *) echo "ERROR: unknown flag '$3'" >&2; exit 1 ;;
+    esac
+  done
+
+  case "$state" in
+    open|draft|merged|closed) ;;
+    *) echo "ERROR: invalid pr state '$state'. Use: open|draft|merged|closed" >&2; exit 1 ;;
+  esac
+  case "$ci" in
+    unknown|pending|passing|failing) ;;
+    *) echo "ERROR: invalid ci '$ci'. Use: unknown|pending|passing|failing" >&2; exit 1 ;;
+  esac
+  case "$review" in
+    none|requested|changes_requested|approved) ;;
+    *) echo "ERROR: invalid review '$review'. Use: none|requested|changes_requested|approved" >&2; exit 1 ;;
+  esac
+  case "$mergeable" in
+    unknown|true|false) ;;
+    *) echo "ERROR: invalid mergeable '$mergeable'. Use: unknown|true|false" >&2; exit 1 ;;
+  esac
+
+  local now
+  now="$(_now)"
+  local updated
+  updated="$(echo "$existing" | python3 -c '
+import sys, json
+r = json.loads(sys.stdin.read())
+r["pr"] = {
+  "number": int(sys.argv[1]),
+  "state": sys.argv[2],
+  "ci": sys.argv[3],
+  "review": sys.argv[4],
+  "mergeable": sys.argv[5],
+  "url": sys.argv[6] or None
+}
+r["updated_at"] = sys.argv[7]
+print(json.dumps(r, ensure_ascii=False))' "$number" "$state" "$ci" "$review" "$mergeable" "$url" "$now")"
+
+  _upsert_record "$run_id" "$updated" || { echo "ERROR: ledger update failed" >&2; exit 1; }
+  echo "run_id=$run_id pr=#$number state=$state ci=$ci review=$review mergeable=$mergeable"
+}
+
+# ── Subcommand: finish (guardrail) ───────────────────────────────────────
+cmd_finish() {
+  local run_id="${1:?run_id required}"
+  local force=""
+  shift || true
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --force) force="1"; shift ;;
+      *) echo "ERROR: unknown flag '$1'" >&2; exit 1 ;;
+    esac
+  done
+
+  if ! _py3; then
+    echo "ERROR: python3 required for finish" >&2; exit 1
+  fi
+
+  local existing
+  existing="$(_read_record "$run_id")"
+  [[ -z "$existing" ]] && { echo "ERROR: run_id '$run_id' not found in $LEDGER" >&2; exit 1; }
+
+  # Idempotente: ya terminado → no-op con éxito
+  if echo "$existing" | python3 -c 'import sys,json; sys.exit(0 if json.load(sys.stdin).get("is_terminated") else 1)'; then
+    echo "run_id=$run_id already terminated"
+    return 0
+  fi
+
+  # Guardrail AO #2: failed probes are NOT proof of death.
+  # Un run que posee un PR vivo (open/draft, no merged) NO es terminable.
+  if [[ -z "$force" ]]; then
+    local pr_line
+    pr_line="$(echo "$existing" | python3 -c '
+import sys, json
+r = json.loads(sys.stdin.read())
+pr = r.get("pr")
+if not pr:
+    sys.exit(0)
+if pr.get("state") in ("open", "draft"):
+    print("%s\t%s\t%s\t%s" % (pr.get("number"), pr.get("state"), pr.get("ci"), pr.get("review")))
+    sys.exit(1)
+sys.exit(0)')"
+    if [[ $? -eq 1 ]]; then
+      local num st ci rv
+      num="${pr_line%%$'\t'*}"
+      st="$(echo "$pr_line" | cut -f2)"
+      ci="$(echo "$pr_line" | cut -f3)"
+      rv="$(echo "$pr_line" | cut -f4)"
+      echo "BLOCKED: run $run_id owns PR #$num (state=$st, ci=$ci, review=$rv) — still live." >&2
+      echo "Termination would orphan its PR. AO guardrail: failed probes are not proof of death; an owned PR keeps the run alive." >&2
+      echo "Finish it with --force only after the PR is merged/closed, or run 'savia-runs.sh pr $run_id clear' to disown it." >&2
+      exit 1
+    fi
+  fi
+
+  local now
+  now="$(_now)"
+  local updated
+  updated="$(echo "$existing" | python3 -c '
+import sys, json
+r = json.loads(sys.stdin.read())
+r["is_terminated"] = True
+r["ended_at"] = sys.argv[1]
+r["updated_at"] = sys.argv[1]
+print(json.dumps(r, ensure_ascii=False))' "$now")"
+
+  _upsert_record "$run_id" "$updated" || { echo "ERROR: ledger update failed" >&2; exit 1; }
+  echo "run_id=$run_id terminated"
+}
+
+# ── Subcommand: status (board derivado) ──────────────────────────────────
+cmd_status() {
+  local json_mode=""
+  [[ "${1:-}" == "--json" ]] && json_mode="1"
+  [[ -f "$LEDGER" ]] || { echo "ledger=$LEDGER (empty)"; return 0; }
+
+  if ! _py3; then
+    echo "ERROR: python3 required for status" >&2; exit 1
+  fi
+
+  if [[ -n "$json_mode" ]]; then
+    python3 - "$LEDGER" <<'PY'
+import sys, json, datetime
+
+def derive(r):
+    if r.get("is_terminated"):
+        pr = r.get("pr") or {}
+        return "merged" if pr.get("state") == "merged" else "terminated"
+    act = r.get("activity_state", "spawning")
+    if act in ("waiting_input", "blocked"):
+        return "needs_input"
+    pr = r.get("pr")
+    if pr:
+        if pr.get("ci") == "failing": return "ci_failed"
+        if pr.get("state") == "draft": return "draft"
+        if pr.get("review") == "changes_requested": return "changes_requested"
+        if pr.get("mergeable") == "false": return "merge_conflict"
+        if pr.get("review") == "approved": return "approved"
+        if pr.get("review") == "requested": return "review_pending"
+        return "pr_open"
+    if act == "active": return "working"
+    return "idle"
+
+cols = ["working", "needs_input", "ci_failed", "changes_requested", "merge_conflict",
+        "draft", "review_pending", "pr_open", "approved", "merged", "terminated", "idle"]
+runs = []
+with open(sys.argv[1], encoding="utf-8", errors="replace") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line: continue
+        try:
+            r = json.loads(line)
+        except Exception:
+            continue
+        r["derived_status"] = derive(r)
+        runs.append(r)
+
+out = {"as_of": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+       "columns": {c: [x["run_id"] for x in runs if x["derived_status"] == c] for c in cols},
+       "runs": sorted(runs, key=lambda x: x.get("started_at", ""))}
+print(json.dumps(out, ensure_ascii=False))
+PY
+    return 0
+  fi
+
+  python3 - "$LEDGER" <<'PY'
+import sys, json, datetime
+
+COLUMN_ORDER = [
+    ("WORKING",         "working"),
+    ("NEEDS YOU",       "needs_input"),
+    ("NEEDS YOU",       "ci_failed"),
+    ("NEEDS YOU",       "changes_requested"),
+    ("NEEDS YOU",       "merge_conflict"),
+    ("IN REVIEW",       "draft"),
+    ("IN REVIEW",       "review_pending"),
+    ("IN REVIEW",       "pr_open"),
+    ("READY TO MERGE",  "approved"),
+    ("DONE",            "merged"),
+    ("TERMINATED",      "terminated"),
+]
+
+def derive(r):
+    if r.get("is_terminated"):
+        pr = r.get("pr") or {}
+        return "merged" if pr.get("state") == "merged" else "terminated"
+    act = r.get("activity_state", "spawning")
+    if act in ("waiting_input", "blocked"):
+        return "needs_input"
+    pr = r.get("pr")
+    if pr:
+        if pr.get("ci") == "failing": return "ci_failed"
+        if pr.get("state") == "draft": return "draft"
+        if pr.get("review") == "changes_requested": return "changes_requested"
+        if pr.get("mergeable") == "false": return "merge_conflict"
+        if pr.get("review") == "approved": return "approved"
+        if pr.get("review") == "requested": return "review_pending"
+        return "pr_open"
+    if act == "active": return "working"
+    return "idle"
+
+def short_task(t, n=26):
+    t = t or ""
+    return t if len(t) <= n else t[:n-1] + "…"
+
+def card(r):
+    parts = [r.get("run_id", "?")]
+    mode = r.get("mode") or ""
+    agent = r.get("agent") or ""
+    parts.append("%s@%s" % (mode, agent))
+    if r.get("branch"): parts.append(r["branch"])
+    parts.append(short_task(r.get("task")))
+    return " · ".join(parts)
+
+runs = []
+with open(sys.argv[1], encoding="utf-8", errors="replace") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line: continue
+        try:
+            r = json.loads(line)
+        except Exception:
+            continue
+        r["derived_status"] = derive(r)
+        runs.append(r)
+runs.sort(key=lambda x: x.get("started_at", ""))
+
+columns = {}
+for label, st in COLUMN_ORDER:
+    columns.setdefault(label, [])
+    columns[label] += [r for r in runs if r["derived_status"] == st]
+idle = [r for r in runs if r["derived_status"] == "idle"]
+
+header = ["WORKING", "NEEDS YOU", "IN REVIEW", "READY TO MERGE", "DONE", "TERMINATED"]
+widths = {h: max(len(h), 4) for h in header}
+as_of = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+print("=== Agent Runs Board (derived) — as of %s ===" % as_of)
+print("ledger: %s" % sys.argv[1])
+print("")
+for h in header:
+    print("%-*s| " % (widths[h], "%s (%d)" % (h, len(columns.get(h, [])))), end="")
+print()
+print("-" * (sum(widths[h] + 2 for h in header)))
+nrows = max((len(columns.get(h, [])) for h in header), default=0)
+for i in range(nrows):
+    for h in header:
+        c = columns.get(h, [])
+        cell = card(c[i]) if i < len(c) else ""
+        print("%-*s| " % (widths[h], cell[:widths[h]]), end="")
+    print()
+if not runs:
+    print("(no runs)")
+if idle:
+    print("")
+    print("idle (sin actividad): %d" % len(idle))
+    for r in idle:
+        print("  " + card(r))
+PY
+}
+
+# ── Subcommand: list ─────────────────────────────────────────────────────
+cmd_list() {
+  local mode_filter="" json_mode=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --mode) mode_filter="${2:-}"; shift 2 ;;
+      --json) json_mode="1"; shift ;;
+      *) echo "ERROR: unknown flag '$1'" >&2; exit 1 ;;
+    esac
+  done
+
+  [[ -f "$LEDGER" ]] || { echo "(no ledger)"; return 0; }
+  if ! _py3; then
+    echo "ERROR: python3 required for list" >&2; exit 1
+  fi
+
+  python3 - "$LEDGER" "$mode_filter" "$json_mode" <<'PY'
+import sys, json
+
+def derive(r):
+    if r.get("is_terminated"):
+        pr = r.get("pr") or {}
+        return "merged" if pr.get("state") == "merged" else "terminated"
+    act = r.get("activity_state", "spawning")
+    if act in ("waiting_input", "blocked"):
+        return "needs_input"
+    pr = r.get("pr")
+    if pr:
+        if pr.get("ci") == "failing": return "ci_failed"
+        if pr.get("state") == "draft": return "draft"
+        if pr.get("review") == "changes_requested": return "changes_requested"
+        if pr.get("mergeable") == "false": return "merge_conflict"
+        if pr.get("review") == "approved": return "approved"
+        if pr.get("review") == "requested": return "review_pending"
+        return "pr_open"
+    if act == "active": return "working"
+    return "idle"
+
+ledger, mode_filter, json_mode = sys.argv[1], sys.argv[2], sys.argv[3]
+rows = []
+with open(ledger, encoding="utf-8", errors="replace") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line: continue
+        try:
+            r = json.loads(line)
+        except Exception:
+            continue
+        if mode_filter and r.get("mode") != mode_filter:
+            continue
+        r["derived_status"] = derive(r)
+        rows.append(r)
+rows.sort(key=lambda x: x.get("started_at", ""))
+
+if json_mode:
+    print(json.dumps(rows, ensure_ascii=False))
+    sys.exit(0)
+
+if not rows:
+    print("(no runs)%s" % (" for mode=" + mode_filter if mode_filter else ""))
+    sys.exit(0)
+
+print("%-38s %-10s %-18s %-12s %-28s %s" % ("RUN_ID", "MODE", "AGENT", "STATUS", "BRANCH", "STARTED"))
+for r in rows:
+    rid = r.get("run_id", "?")
+    print("%-38s %-10s %-18s %-12s %-28s %s" % (
+        rid[:38], (r.get("mode") or "")[:10], (r.get("agent") or "")[:18],
+        r["derived_status"], (r.get("branch") or "")[:28], (r.get("started_at") or "")[:19]))
+PY
+}
+
+# ── Subcommand: show ─────────────────────────────────────────────────────
+cmd_show() {
+  local run_id="${1:?run_id required}"
+  [[ -f "$LEDGER" ]] || { echo "ERROR: no ledger at $LEDGER" >&2; exit 1; }
+  if ! _py3; then
+    echo "ERROR: python3 required for show" >&2; exit 1
+  fi
+
+  local existing
+  existing="$(_read_record "$run_id")"
+  [[ -z "$existing" ]] && { echo "ERROR: run_id '$run_id' not found in $LEDGER" >&2; exit 1; }
+
+  local derived trace
+  derived="$(_derive "$existing")"
+  trace="${derived#*$'\t'}"
+  derived="${derived%%$'\t'*}"
+
+  echo "run_id      : $run_id"
+  echo "mode        : $(echo "$existing" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("mode") or "")')"
+  echo "agent       : $(echo "$existing" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("agent") or "")')"
+  echo "project     : $(echo "$existing" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("project") or "")')"
+  echo "branch      : $(echo "$existing" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("branch") or "")')"
+  echo "task        : $(echo "$existing" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("task") or "")')"
+  echo "started_at  : $(echo "$existing" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("started_at") or "")')"
+  echo "ended_at    : $(echo "$existing" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("ended_at") or "")')"
+  echo "activity    : $(echo "$existing" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("activity_state") or "")')"
+  echo "terminated  : $(echo "$existing" | python3 -c 'import sys,json;print("true" if json.load(sys.stdin).get("is_terminated") else "false")')"
+  echo "pr          : $(echo "$existing" | python3 -c '
+import sys, json
+pr = json.load(sys.stdin).get("pr")
+if not pr: print("(none)")
+else: print("#%(number)s state=%(state)s ci=%(ci)s review=%(review)s mergeable=%(mergeable)s" % pr)')"
+  echo ""
+  echo "derived_status : $derived"
+  echo "trace          : $trace"
+}
+
+# ── Subcommand: reset ────────────────────────────────────────────────────
+cmd_reset() {
+  : > "$LEDGER"
+  echo "ledger=$LEDGER reset"
+}
+
+# ── Dispatcher ───────────────────────────────────────────────────────────
+SUBCOMMAND="${1:-}"
+shift || true
+
+case "$SUBCOMMAND" in
+  init)   cmd_init   "$@" ;;
+  start)  cmd_start  "$@" ;;
+  state)  cmd_state  "$@" ;;
+  pr)     cmd_pr     "$@" ;;
+  finish) cmd_finish "$@" ;;
+  status) cmd_status "$@" ;;
+  list)   cmd_list   "$@" ;;
+  show)   cmd_show   "$@" ;;
+  reset)  cmd_reset  "$@" ;;
+  *)
+    echo "Usage: savia-runs.sh <init|start|state|pr|finish|status|list|show|reset> [args...]" >&2
+    echo "" >&2
+    echo "  init" >&2
+    echo "  start   <mode> <agent> <task> [--project P] [--branch B] [--url U]   → imprime run_id" >&2
+    echo "  state   <run_id> <spawning|active|waiting_input|blocked|exited>" >&2
+    echo "  pr      <run_id> <number> [--state open|draft|merged|closed] [--ci passing|failing|pending|unknown]" >&2
+    echo "          [--review none|requested|changes_requested|approved] [--mergeable true|false|unknown] [--url U]" >&2
+    echo "  pr      <run_id> clear" >&2
+    echo "  finish  <run_id> [--force]" >&2
+    echo "  status  [--json]" >&2
+    echo "  list    [--mode M] [--json]" >&2
+    echo "  show    <run_id>" >&2
+    echo "  reset" >&2
+    exit 1 ;;
+esac

--- a/tests/test-se-349-agent-runs-ledger.bats
+++ b/tests/test-se-349-agent-runs-ledger.bats
@@ -1,0 +1,251 @@
+#!/usr/bin/env bats
+# tests/test-se-349-agent-runs-ledger.bats — SE-349: Agent Runs Operations Ledger (ARO)
+# Ref: docs/specs/SE-349-agent-runs-ledger.spec.md
+# Safety: set -uo pipefail applied per-test in setup().
+#
+# Coverage notes:
+#   Exercises the public command surface of scripts/savia-runs.sh:
+#     init, start, state, pr, finish, status, list, show, reset
+#   Verifies the core AO lesson: display status is DERIVED at read time,
+#   never stored (assertions on derived_status vs absence of a stored status
+#   field), and the termination guardrail ("owned PR keeps the run alive").
+
+ARO="${BATS_TEST_DIRNAME}/../scripts/savia-runs.sh"
+
+setup() {
+  set -uo pipefail
+  TMP_DIR="$(mktemp -d)"
+  export TMP_DIR
+  export SAVIA_WORKSPACE_DIR="$TMP_DIR"
+  export SAVIA_RUNS_LEDGER="$TMP_DIR/data/agent-runs-ledger.jsonl"
+  mkdir -p "$TMP_DIR/data"
+  touch "$SAVIA_RUNS_LEDGER"
+}
+
+teardown() {
+  [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]] && rm -rf "$TMP_DIR"
+}
+
+# helper: run_id of the first (and only) ledger record
+first_run_id() {
+  python3 -c 'import sys,json;print(json.loads(open(sys.argv[1]).readline())["run_id"])' "$SAVIA_RUNS_LEDGER"
+}
+
+# helper: parse a JSON field from a record line (by run_id)
+field() {
+  local run_id="$1" key="$2"
+  python3 - "$SAVIA_RUNS_LEDGER" "$run_id" "$key" <<'PY'
+import sys, json
+for line in open(sys.argv[1]):
+    line = line.strip()
+    if not line: continue
+    try: r = json.loads(line)
+    except Exception: continue
+    if r.get("run_id") == sys.argv[2]:
+        print(r.get(sys.argv[3]))
+        break
+PY
+}
+
+# ── init ─────────────────────────────────────────────────────────────────
+@test "init: creates the ledger file and echoes its path" {
+  run bash "$ARO" init
+  [ "$status" -eq 0 ]
+  [[ "$output" == "ledger=$SAVIA_RUNS_LEDGER" ]]
+  [ -f "$SAVIA_RUNS_LEDGER" ]
+}
+
+# ── start ────────────────────────────────────────────────────────────────
+@test "start: prints a run_id and writes a JSONL entry" {
+  run bash "$ARO" start overnight dev-orchestrator "smoke task"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+  RUN_ID="$output"
+  [ "$(field "$RUN_ID" run_id)" = "$RUN_ID" ]
+}
+
+@test "start: record is schema v1, spawning, not terminated, pr null" {
+  RUN_ID="$(bash "$ARO" start improve test-engineer "add tests")"
+  [ "$(field "$RUN_ID" schema_version)" = "1" ]
+  [ "$(field "$RUN_ID" activity_state)" = "spawning" ]
+  [ "$(field "$RUN_ID" is_terminated)" = "False" ]
+  [ "$(field "$RUN_ID" pr)" = "None" ]
+  [ "$(field "$RUN_ID" mode)" = "improve" ]
+  [ "$(field "$RUN_ID" agent)" = "test-engineer" ]
+}
+
+@test "start: --project and --branch are persisted" {
+  RUN_ID="$(bash "$ARO" start overnight dev-orchestrator "task" --project proyecto-alpha --branch agent/overnight-20260829-lint)"
+  [ "$(field "$RUN_ID" project)" = "proyecto-alpha" ]
+  [ "$(field "$RUN_ID" branch)" = "agent/overnight-20260829-lint" ]
+}
+
+@test "start: rejects an invalid mode" {
+  run bash "$ARO" start bogus-mode dev-orchestrator "task"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"invalid mode"* ]]
+}
+
+# ── state ────────────────────────────────────────────────────────────────
+@test "state: updates activity_state on existing run" {
+  RUN_ID="$(bash "$ARO" start overnight dev-orchestrator "task")"
+  run bash "$ARO" state "$RUN_ID" active
+  [ "$status" -eq 0 ]
+  [ "$(field "$RUN_ID" activity_state)" = "active" ]
+}
+
+@test "state: rejects an invalid activity_state" {
+  RUN_ID="$(bash "$ARO" start overnight dev-orchestrator "task")"
+  run bash "$ARO" state "$RUN_ID" bogus
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"invalid activity_state"* ]]
+}
+
+@test "state: fails on unknown run_id" {
+  run bash "$ARO" state deadbeef-0000-0000-0000-000000000000 active
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+# ── pr ───────────────────────────────────────────────────────────────────
+@test "pr: attaches PR facts (state/ci/review/mergeable)" {
+  RUN_ID="$(bash "$ARO" start overnight dev-orchestrator "task")"
+  run bash "$ARO" pr "$RUN_ID" 1009 --state open --ci failing --review requested --mergeable true
+  [ "$status" -eq 0 ]
+  [ "$(field "$RUN_ID" pr)" = "{'number': 1009, 'state': 'open', 'ci': 'failing', 'review': 'requested', 'mergeable': 'true', 'url': None}" ]
+}
+
+@test "pr: clear disowns the PR" {
+  RUN_ID="$(bash "$ARO" start overnight dev-orchestrator "task")"
+  bash "$ARO" pr "$RUN_ID" 1009 --state open >/dev/null
+  [ -n "$(field "$RUN_ID" pr)" ]
+  run bash "$ARO" pr "$RUN_ID" clear
+  [ "$status" -eq 0 ]
+  [ "$(field "$RUN_ID" pr)" = "None" ]
+}
+
+@test "pr: rejects an invalid ci value" {
+  RUN_ID="$(bash "$ARO" start overnight dev-orchestrator "task")"
+  run bash "$ARO" pr "$RUN_ID" 1009 --ci orange
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"invalid ci"* ]]
+}
+
+# ── finish (guardrail) ───────────────────────────────────────────────────
+@test "finish: terminates a run without PR (is_terminated, ended_at)" {
+  RUN_ID="$(bash "$ARO" start improve security-guardian "scan")"
+  run bash "$ARO" finish "$RUN_ID"
+  [ "$status" -eq 0 ]
+  [ "$(field "$RUN_ID" is_terminated)" = "True" ]
+  [ -n "$(field "$RUN_ID" ended_at)" ]
+}
+
+@test "finish: BLOCKS a run that owns a live PR (AO guardrail)" {
+  RUN_ID="$(bash "$ARO" start overnight dev-orchestrator "task")"
+  bash "$ARO" pr "$RUN_ID" 1009 --state open --ci failing >/dev/null
+  run bash "$ARO" finish "$RUN_ID"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"BLOCKED"* ]]
+  # guardrail holds: record is NOT terminated
+  [ "$(field "$RUN_ID" is_terminated)" = "False" ]
+}
+
+@test "finish: --force bypasses the guardrail" {
+  RUN_ID="$(bash "$ARO" start overnight dev-orchestrator "task")"
+  bash "$ARO" pr "$RUN_ID" 1009 --state open >/dev/null
+  run bash "$ARO" finish "$RUN_ID" --force
+  [ "$status" -eq 0 ]
+  [ "$(field "$RUN_ID" is_terminated)" = "True" ]
+}
+
+@test "finish: is idempotent on an already-terminated run" {
+  RUN_ID="$(bash "$ARO" start improve test-engineer "x")"
+  bash "$ARO" finish "$RUN_ID" >/dev/null
+  run bash "$ARO" finish "$RUN_ID"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already terminated"* ]]
+}
+
+# ── derived status (read-time, never stored) ─────────────────────────────
+@test "derivation: merged run derives to merged even when terminated" {
+  RUN_ID="$(bash "$ARO" start improve test-engineer "x")"
+  bash "$ARO" pr "$RUN_ID" 1001 --state merged >/dev/null
+  bash "$ARO" finish "$RUN_ID" >/dev/null
+  bash "$ARO" status --json > "$TMP_DIR/status.json"
+  python3 - "$TMP_DIR/status.json" "$RUN_ID" "$SAVIA_RUNS_LEDGER" <<'PY'
+import sys, json
+d = json.load(open(sys.argv[1]))
+r = [x for x in d["runs"] if x["run_id"] == sys.argv[2]][0]
+assert r["derived_status"] == "merged", r["derived_status"]
+raw = open(sys.argv[3]).read()
+assert "derived_status" not in raw, "display status must never be stored"
+PY
+}
+
+@test "derivation: needs_input for waiting_input, ci_failed for failing ci" {
+  R1="$(bash "$ARO" start overnight dev-orchestrator "a")"
+  bash "$ARO" state "$R1" waiting_input >/dev/null
+  R2="$(bash "$ARO" start overnight dev-orchestrator "b")"
+  bash "$ARO" pr "$R2" 1002 --state open --ci failing >/dev/null
+  bash "$ARO" status --json > "$TMP_DIR/status.json"
+  python3 - "$TMP_DIR/status.json" "$R1" "$R2" <<'PY'
+import sys, json
+d = json.load(open(sys.argv[1]))
+m = {x["run_id"]: x["derived_status"] for x in d["runs"]}
+assert m[sys.argv[2]] == "needs_input", m
+assert m[sys.argv[3]] == "ci_failed", m
+PY
+}
+
+# ── status / list / show / reset ─────────────────────────────────────────
+@test "status: board renders columns with counts" {
+  RUN_ID="$(bash "$ARO" start overnight dev-orchestrator "task")"
+  bash "$ARO" pr "$RUN_ID" 1003 --state draft >/dev/null
+  run bash "$ARO" status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"IN REVIEW"* ]]
+  [[ "$output" == *"IN REVIEW (1)"* ]]
+}
+
+@test "list: shows derived status and --mode filters" {
+  R1="$(bash "$ARO" start overnight dev-orchestrator "a")"
+  R2="$(bash "$ARO" start improve test-engineer "b")"
+  bash "$ARO" pr "$R2" 1004 --state open --ci passing --review approved >/dev/null
+  run bash "$ARO" list --json
+  [ "$status" -eq 0 ]
+  python3 - "$output" "$R1" "$R2" <<'PY'
+import sys, json
+rows = json.loads(sys.argv[1])
+assert len(rows) == 2
+m = {r["run_id"]: r["derived_status"] for r in rows}
+assert m[sys.argv[2]] == "idle", m   # no pr, spawning → idle
+assert m[sys.argv[3]] == "approved", m
+assert all("derived_status" in r for r in rows)
+PY
+  run bash "$ARO" list --mode overnight --json
+  [ "$status" -eq 0 ]
+  python3 -c 'import sys,json; assert len(json.loads(sys.argv[1]))==1' "$output"
+}
+
+@test "show: prints durable facts, derived status and precedence trace" {
+  RUN_ID="$(bash "$ARO" start overnight dev-orchestrator "task")"
+  bash "$ARO" pr "$RUN_ID" 1005 --state open --ci failing >/dev/null
+  run bash "$ARO" show "$RUN_ID"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"derived_status : ci_failed"* ]]
+  [[ "$output" == *"trace"* ]]
+  [[ "$output" == *"pr.ci=failing"* ]]
+}
+
+@test "reset: empties the ledger" {
+  RUN_ID="$(bash "$ARO" start overnight dev-orchestrator "task")"
+  run bash "$ARO" reset
+  [ "$status" -eq 0 ]
+  [ ! -s "$SAVIA_RUNS_LEDGER" ]
+}
+
+@test "usage: no subcommand exits non-zero with usage" {
+  run bash "$ARO"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage: savia-runs.sh"* ]]
+}


### PR DESCRIPTION
## Resumen

- Nuevo ledger operativo de runs autónomos (`scripts/savia-runs.sh`, SE-349): hechos durables + estado derivado en lectura, sin estado de display almacenado.
- Board derivado (Working / Needs you / In review / Ready to merge / Done / Terminated) con guardrail de terminación: un run que posee un PR vivo no es terminable.
- Inspirado en agent-orchestrator (Untrivial-ai) pero 100% local: sin telemetría cloud (CRIT-001), JSONL gitignored en `data/`.
- Skill nueva `agent-runs-board` + spec + 22 tests BATS.

## What does this PR add or fix?

Adds an operational ledger and derived-status board for autonomous agent runs. Every run registers durable facts (activity_state, is_terminated, PR facts) in a local JSONL; display status is computed at read time (never stored) and the CLI renders an AO-style board plus a conservative termination guardrail that refuses to finish a run while it still owns a live PR.

## Type of contribution

- [ ] New slash command
- [ ] New agent
- [x] New skill
- [ ] New hook
- [ ] New domain rule
- [ ] Bug fix
- [ ] Documentation improvement
- [x] Test suite addition
- [ ] Refactor (no behaviour change)
- [ ] Other: ___

## Context impact

- [x] This PR does NOT modify CLAUDE.md or files loaded at startup
- [ ] This PR modifies context files — estimated impact: 1 line added (CLAUDE.md skills count 129→130)
- [ ] CLAUDE.md stays within 120 lines limit

## Hook safety (if modifying hooks)

- [x] This PR does NOT modify hooks

## Files added / modified

- `scripts/savia-runs.sh` — CLI: init/start/state/pr/finish/status/list/show/reset + estado derivado en lectura
- `docs/specs/SE-349-agent-runs-ledger.spec.md` — spec (schema v1, precedencia de derivación, guardrail, OpenCode impl plan)
- `tests/test-se-349-agent-runs-ledger.bats` — 22 tests (guardrail, derivación, upsert, board)
- `.claude/skills/agent-runs-board/SKILL.md` — skill para registrar y supervisar runs
- `SKILLS.md` — catálogo regenerado (auto)
- `CHANGELOG.d/se349-agent-runs-ledger.md` — fragmento changelog
- `CLAUDE.md` — skills count 129→130 (drift gate)
- `.scm/` — índice de capacidades regenerado (auto)

## How to test / Test plan

- [x] Local: `bash scripts/savia-runs.sh start|state|pr|finish|status` smoke (guardrail bloquea `finish` con PR vivo; `--force` y `pr clear` funcionan)
- [x] Local: `bats tests/test-se-349-agent-runs-ledger.bats` → 22/22 passing
- [x] CI: BATS Hook Tests (dynamic selection), PR Guardian, Standards Compliance Gate

## Qué hace este PR (en lenguaje no técnico)

Este PR añade un cuadro operativo para los trabajos automáticos de agentes. Hasta ahora, cuando un agente trabajaba de noche o en segundo plano solo dejaba un log de texto plano; para saber qué agente estaba haciendo qué, qué PR estaba abierto, si la comprobación automática había fallado o si hacía falta que una persona interviniera, había que mirar ficheros sueltos. Con este cambio, cada trabajo automático queda registrado en un registro local con datos sencillos (qué agente, qué rama, qué PR, si está esperando algo), y al consultar se dibuja una tabla que agrupa los trabajos en columnas: en marcha, necesita atención, en revisión, listos para fusionar y terminados. El estado mostrado no se guarda, se calcula en el momento de consultar a partir de los datos, de forma que nunca se queda desactualizado. Además, se protege contra un error común: si un trabajo todavía tiene un PR abierto, no se permite marcarlo como terminado, porque cerrarlo a medias dejaría ese PR huérfano. Todo se guarda en la propia máquina, sin enviar nada a ningún servidor externo.
