### PR TITLE
feat(robotica): skill robotica-diseno + digestión MHS en cúpula RBT/AUT

### DIFF
--- a/.claude/skills/robotica-diseno/DOMAIN.md
+++ b/.claude/skills/robotica-diseno/DOMAIN.md
@@ -1,0 +1,49 @@
+# DOMAIN — Robótica y Diseño de Sistemas Físicos
+
+> Companion de `SKILL.md`. NO se carga en runtime.
+
+## Por que existe esta skill
+
+La cúpula RBT (plan savia-domains-robotica-plan) declara que el dominio más
+crítico de Savia es la **puerta al mundo físico**: construir y operar robots
+no catalogarlos. Esta skill convierte ese plan en capacidad de diseño
+accionable — hardware (sensores, servos, PLCs, actuadores), software de
+control, visión artificial, y la capa de interfaz agente↔hardware (estándar
+MHS). Sin ella, Savia carece de procedimiento de diseño y el conocimiento de
+la cúpula queda decorativo.
+
+## Conceptos de dominio
+
+- **MHS (Model Hardware Standard)**: estándar de drivers para que agentes
+  operen hardware físico (read/write, descubrimiento, tags, state dictionary,
+  MCP/CLI/code files).
+- **Sim2real**: entrenar en simulación (MuJoCo/Isaac) y desplegar en hardware;
+  la fidelidad del actuador (modelo BAM) es el mayor gap.
+- **VLA / imitación / RL**: familias de aprendizaje para control robótico
+  (Pi0, GR00T, ACT, Diffusion Policy, PPO).
+- **PLC/SCADA**: automatización industrial; PLC = controlador lógico
+  programable (automatización de celdas, ISO 10218/15066).
+- **Visión artificial**: cámara + CV como sensor de control de calidad y de
+  bucle (detección de errores físicos, Tetsuwan).
+
+## Limites y no-objetivos
+
+- No fabrica hardware ni ejecuta soldadura/mecanizado (diseña y especifica).
+- No ejecuta terraform/cloud para el stack (CRIT-001: local).
+- No reemplaza la supervisión humana en despliegues físicos
+  (autonomous-safety): todo artefacto físico se propone, no se auto-aplica.
+- No promete integración MHS con hardware no programable.
+
+## Confidencialidad
+
+- Nivel: N1 (conocimiento de referencia) por defecto; datos de hogar/empresa
+  (mapas, vídeo, telemetría) son N3+ → nunca cloud (CRIT-001).
+- Output: notas en cúpulas SaviaDomains (N1) / SaviaLabs (N2), vía MCP.
+
+## Referencias
+
+- Plan: `labs/research/savia-domains-robotica-plan-20260828.md` (SaviaLabs).
+- Criterio: `docs/domains/robotics/ROBOTICS-CRITERIO-20260828.md`.
+- MHS: vault SaviaDomains `robotica/RBT/mhs-model-hardware-standard-20260829.md`.
+- Hipótesis: `labs/hypotheses/robotica-puerta-al-mundo-fisico.md` (SaviaLabs).
+- Seguridad: ISO 10218 · ISO/TS 15066 · `docs/rules/domain/autonomous-safety.md`.

--- a/.claude/skills/robotica-diseno/SKILL.md
+++ b/.claude/skills/robotica-diseno/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: robotica-diseno
+description: "Diseño profundo de robótica, automatización y hardware/software para el mundo físico. Usar cuando se diseña un robot, una celda de automatización, integración de sensores, servos, PLCs, visión artificial, o cuando se conecta un agente a hardware físico."
+metadata:
+  savia.maturity: "stable"
+  savia.context: "standalone"
+  savia.context_cost: "medium"
+  savia.category: "domain"
+  savia.tags: "robotica, automation, hardware, software, sensores, servos, plc, vision, diseño, mundo-fisico, mhs"
+  savia.priority: "high"
+  savia.loop_level: "L0"
+  savia.trigger_keywords: "robótica, robot, automatización, PLC, servos, sensores, visión artificial, hardware, mundo físico, brazo robótico, liquid handler, MHS"
+---
+
+# Skill: Robótica y Diseño de Sistemas Físicos
+
+Habilita a Savia para **diseñar, integrar y operar soluciones en el mundo
+físico**: robots, celdas de automatización, electrónica de control,
+actuación, sensórica, visión artificial y la capa de interfaz agente↔hardware
+(estándares tipo MHS). Accionable (construir/operar), no catálogo.
+
+## Authoritative Paths
+
+> **Lee estos paths antes de actuar. NUNCA asumas firmas, NUNCA inventes paths.**
+
+| Para | Lee este path |
+|---|---|
+| Plan RBT (verticales V1-V6, fases F1-F4, ejes A-H) | `labs/research/savia-domains-robotica-plan-20260828.md` (vault SaviaLabs) |
+| Criterio de evaluación/recomendación (9 dimensiones + CRIT-001) | `docs/domains/robotics/ROBOTICS-CRITERIO-20260828.md` |
+| Estándar MHS (drivers agente↔hardware, evidencia de campo) | vault SaviaDomains `robotica/RBT/mhs-model-hardware-standard-20260829.md` |
+| Índice cúpula RBT (notas + cross-dominio) | vault SaviaDomains `robotica/RBT/INDEX.md` |
+| Cúpula automatización industrial (PLC/SCADA) | vault SaviaDomains `robotica/AUT/INDEX.md` |
+| Hipótesis Labs (puerta al mundo físico) | vault SaviaLabs `labs/hypotheses/robotica-puerta-al-mundo-fisico.md` |
+| Seguridad humana-robot (estándares) | ISO 10218 · ISO/TS 15066 (industria/cobots); fall-safe cuidado de personas |
+
+**Reglas duras**:
+- Cúpulas SaviaLabs/SaviaDomains se leen/escriben SOLO por MCP (`savia-vaults_*`),
+  nunca por filesystem.
+- CRIT-001: jamás enviar datos del mundo físico (vídeo, mapas, telemetría N3+)
+  a proveedor cloud; todo el stack corre local.
+- Soberanía: el robot es una tool local de Savia; sin telemetría externa no
+  consentida.
+
+## Cuándo usar
+
+- Diseñar un robot/brazo/AMR/humanoide o su control (sim2real, RL, VLA).
+- Diseñar una celda de automatización o integrar PLC/SCADA/sensores/servos.
+- Conectar un agente a hardware físico (drivers, MCP, state dictionary).
+- Visión artificial como sensor de control (cámara→CV→decisión).
+- Evaluar/recomendar hardware con criterio (9 dimensiones).
+
+## Cuándo NO usar
+
+- Solo documentación de catálogo (sin diseño/operación) → `tech-writer`.
+- Arquitectura de software pura sin hardware → `architecture-intelligence`.
+- Preguntas puntuales de electrónica sin diseño → responder directamente.
+
+## Decision Checklist
+
+1. ¿Es N1 (conocimiento genérico) o N2-N4b (datos reales de hogar/empresa)? Si
+   es N3+/datos del mundo físico → encriptar/local; nunca cloud (CRIT-001).
+2. ¿Se necesita diseño o solo recomendación? Si recomendación de compra →
+   aplicar ROBOTICS-CRITERIO (9 dimensiones, filtro soberanía).
+3. ¿Hay estándar aplicable? Seguridad: ISO 10218/ISO/TS 15066; interfaz
+   agente↔hardware: MHS. Si el hardware no es programable, MHS no aplica aún.
+
+### Abort Conditions
+
+- Hardware sin interfaz programable y sin driver disponible → no prometer
+  integración vía MHS; reportar como bloqueante.
+- Datos N3+ del mundo físico que no pueden quedarse locales → abortar y
+  rediseñar (CRIT-001).
+
+## Workflow
+
+```
+Requisito físico (tarea, entorno, presupuesto, soberanía)
+    ↓
+Seleccionar vertical (V1-V6) y fase (F1-F4) del plan RBT
+    ↓
+Diseñar: actuación (servos/motores) + sensórica + control (PLC/MCU) + SW
+    ↓
+Definir capa agente↔hardware (MHS: read/write, state dictionary, MCP)
+    ↓
+Seguridad (ISO, fall-safe, límites por dispositivo)
+    ↓
+Validar en sim (MuJoCo/ROS2) → deploy → operar local
+```
+
+### Detalle de cada paso
+
+1. **Requisito**: tarea concreta, entorno (casa/lab/fábrica/exterior), coste,
+   privacidad. Si es hogar/empresa real → aplicar ROBOTICS-CRITERIO primero.
+2. **Vertical/fase**: V1 cocina · V2 limpieza · V3 cuidado · V4 huerta · V5
+   atención · V6 industrial; F1 sim → F2 plataforma → F3 vertical → F4 Savia.
+3. **Diseño físico**: elegir actuadores (Dynamixel/BLDC+FOC/harmonic/belt),
+   sensores (encoders/IMU/F-T/RGB-D), controlador (RP2040/ESP32/STM32/Jetson),
+   potencia (BMS, DC-DC, presupuesto).
+4. **Capa agente↔hardware**: driver MHS con primitivas read/write, tags con
+   características no discernibles de código (peso, límites), fichero de
+   referencia, state dictionary en shared memory; control por MCP/CLI/code
+   files. Ejecutar comando→medir→ajustar en bucle; empaquetar lo aprendido en
+   code files deterministas.
+5. **Seguridad**: límites de fuerza/velocidad, detección de personas, fall-safe;
+   en laboratorio, límites por dispositivo (como MHS).
+6. **Validar/operar**: sim2real local (MuJoCo/mjlab + PPO + BAM + ONNX), luego
+   física; operación local con supervisión humana (autonomous-safety).
+
+## Outputs esperados
+
+- Diseño/spec ejecutable de la solución (HW+SW+interfaz agente).
+- Nota en cúpula RBT/AUT (MCP `vault_write`) con la decisión de diseño.
+- Código/skills reutilizables (drivers, recipes de control, skills de manejo).
+
+## Memory hooks
+
+- Decisión de diseño física → `bash scripts/memory-store.sh save --type decision --title "diseno fisico: <tema>" --content "<resumen>" --source skill:robotica-diseno`
+- Recall de stack local → `bash scripts/memory-store.sh recall "robotica hardware"`
+
+## Related
+
+- Skill: `savia-vaults` (acceso a cúpulas) · `spec-driven-development` · `tdd-vertical-slices`
+- Rule: `docs/rules/domain/autonomous-safety.md` · CRIT-001 (datos N3+ locales)
+- Docs: `docs/domains/robotics/ROBOTICS-CRITERIO-20260828.md` · plan RBT

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=3512492cbe7ee1ed46e95eeb52dde4c267c67b21eae53a4c6be55e885aa450f9
-timestamp=2026-08-29T17:20:08Z
+diff_hash=b6c4ef61c257274e2e1c11d9b739251ae55e816cce9951fcee16b1afad742502
+timestamp=2026-08-29T17:23:55Z
 branch=agent/robotica-mhs-20260829
-head_commit=82bcbc57
-signature=14331c394f13e89e3e74b1ca4873c2bc22e9346f7908b91866f9a85ce728b59c
+head_commit=eb41d5b5
+signature=6decc74242e64b146fdcb50b171a90b811a761585503680fda394010f7d06a05

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=60edfa66ef48481cf8076f4ff497173c8b0b27cf954aead5c75d77238cacba14
-timestamp=2026-08-29T12:07:28Z
-branch=agent/SE-349-agent-runs-ledger
-head_commit=0a7b45bf
-signature=e31f1be33ab4dc9dc6d6e2fb03b415faffa95aacf6dd3cb475e18e6ffc5f6171
+diff_hash=3512492cbe7ee1ed46e95eeb52dde4c267c67b21eae53a4c6be55e885aa450f9
+timestamp=2026-08-29T17:20:08Z
+branch=agent/robotica-mhs-20260829
+head_commit=82bcbc57
+signature=14331c394f13e89e3e74b1ca4873c2bc22e9346f7908b91866f9a85ce728b59c

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: bf608e3e1a42 | resources: 1409
-> 294 commands · 131 skills · 83 agents · 901 scripts
+> hash: 27b44509e4f7 | resources: 1410
+> 294 commands · 132 skills · 83 agents · 901 scripts
 
 [analysis] Trace Optimize — across,distributed,optimize,rates,sampling — cmd:.claude/commands/trace-optimize.md
 [analysis] agent-activity — activity,agent,executions,recent,show — cmd:.claude/commands/agent-activity.md
@@ -972,6 +972,7 @@
 [planning] resource-references — necesitan,plantillas,recursos,referencias,workspace — skill:.claude/skills/resource-references/SKILL.md
 [planning] restore-checkpoint — checkpoint,high,operations,radius,restore — script:scripts/restore-checkpoint.sh
 [planning] restore-drill — drill,restore,slice — script:scripts/restore-drill.sh
+[planning] robotica-diseno — agente,artificial,automatización,celda,conecta — skill:.claude/skills/robotica-diseno/SKILL.md
 [planning] rpi-start —  — cmd:.claude/commands/rpi-start.md
 [planning] ruby-developer —  — agent:.opencode/agents/ruby-developer.md
 [planning] rule-manifest-generate — determinista,generador,generate,manifest,rule — script:scripts/rule-manifest-generate.sh

--- a/.scm/categories/planning.scm
+++ b/.scm/categories/planning.scm
@@ -1,5 +1,5 @@
 # planning — Savia Capability Map (L1)
-> 604 resources
+> 605 resources
 
 - **/decide-architecture** (cmd): Clasifica una tarea como WORKFLOW (deterministica) o AGENT (loop). Bias hacia workflow per Anthropic. Sugiere plantilla inicial. Mide accuracy contra corpus curado de 20 tareas.
 - **_template** (skill): TEMPLATE — copia este directorio para crear una skill nueva. NO se carga en runtime.
@@ -427,6 +427,7 @@
 - **resource-references** (skill): Usar cuando se necesitan referencias a recursos y plantillas del workspace.
 - **restore-checkpoint** (script): restore-checkpoint.sh — Git stash checkpoint for high-radius operations
 - **restore-drill** (script): restore-drill.sh — SE-258 Slice 2
+- **robotica-diseno** (skill): Diseño profundo de robótica, automatización y hardware/software para el mundo físico. Usar cuando se diseña un robot, una celda de automatización, integración de sensores, servos, PLCs, visión artificial, o cuando se conecta un agente a har
 - **rpi-start** (cmd): >
 - **ruby-developer** (agent): >
 - **rule-manifest-generate** (script): rule-manifest-generate.sh — Generador determinista de rule-manifest (SE-338)

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "a4296509fb4a",
-  "total": 1409,
+  "hash": "309e644f7610",
+  "total": 1410,
   "resources": [
     {
       "category": "analysis",
@@ -12797,6 +12797,20 @@
       "kind": "script",
       "path": "scripts/restore-drill.sh",
       "description": "restore-drill.sh — SE-258 Slice 2"
+    },
+    {
+      "category": "planning",
+      "name": "robotica-diseno",
+      "intents": [
+        "agente",
+        "artificial",
+        "automatización",
+        "celda",
+        "conecta"
+      ],
+      "kind": "skill",
+      "path": ".claude/skills/robotica-diseno/SKILL.md",
+      "description": "Diseño profundo de robótica, automatización y hardware/software para el mundo físico. Usar cuando se diseña un robot, una celda de automatización, integración de sensores, servos, PLCs, visión artificial, o cuando se conecta un agente a har"
     },
     {
       "category": "planning",

--- a/CHANGELOG.d/agent-robotica-mhs-20260829.md
+++ b/CHANGELOG.d/agent-robotica-mhs-20260829.md
@@ -1,0 +1,15 @@
+---
+version_bump: minor
+section: Added
+---
+
+### Added
+
+- Skill `robotica-diseno`: diseño profundo de robótica, automatización y
+  hardware/software para el mundo físico (sensores, servos, PLC, visión
+  artificial, estándares agente↔hardware tipo MHS). Habilita la cúpula RBT
+  como capacidad accionable (construir/operar robots), CRIT-001 (stack local).
+- Cúpula SaviaDomains RBT/AUT: digestión del Model Hardware Standard (MHS) —
+  estándar de drivers para que agentes operen hardware físico; evidencia de
+  campo (Genentech, UW, CMU, Janelia, QuEra, Tetsuwan) y plan de integración
+  local-first en F1-F4.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Identidad del humano al volante + memoria auto persistida fuera del repo.
 
 ## Estructura
 
-`.claude/{agents(83), commands(570), profiles, hooks(116/119reg), rules/{domain,languages}, skills(130), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
+`.claude/{agents(83), commands(570), profiles, hooks(116/119reg), rules/{domain,languages}, skills(131), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
 
 ## Reglas Críticas (Rules 1-8, inline)
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -126,6 +126,7 @@ To use a skill: read `<path>` and follow its instructions.
 | reranker | `.opencode/skills/reranker/SKILL.md` | Usar cuando se recibe un top-K ruidoso de búsqueda en memoria y se necesita reordenar por releva... |
 | resource-references | `.opencode/skills/resource-references/SKILL.md` | Usar cuando se necesitan referencias a recursos y plantillas del workspace. |
 | risk-scoring | `.opencode/skills/risk-scoring/SKILL.md` | Usar cuando se calcula el riesgo de una tarea para decidir el nivel de revisión requerido. |
+| robotica-diseno | `.opencode/skills/robotica-diseno/SKILL.md` | Diseño profundo de robótica, automatización y hardware/software para el mundo físico. Usar cu... |
 | rules-traceability | `.opencode/skills/rules-traceability/SKILL.md` | Usar cuando se mapean reglas de negocio a PBIs para trazabilidad completa. |
 | savia-dual | `.opencode/skills/savia-dual/SKILL.md` | Usar cuando la inferencia cloud falla, es lenta o está rate-limited y se necesita failover local. |
 | savia-flow-practice | `.opencode/skills/savia-flow-practice/SKILL.md` | Usar cuando se implementa Savia Flow con dual-track y métricas de flujo en un proyecto. |


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este cambio le da a Savia la capacidad de diseñar robots y sistemas de automatización, y guarda en su biblioteca de conocimiento (cúpula de robótica) el estándar MHS de Anthropic — la especificación para que una IA pueda operar aparatos físicos reales (brazos robóticos, microscopios, máquinas de laboratorio).

Ahora, cuando preguntes "¿cómo montamos un robot que cocine?", Savia no tendrá que improvisar: existe un procedimiento de diseño (skill `robotica-diseno`) que cubre sensores, servos, PLC, visión artificial, electrónica y seguridad, y que consulta la cúpula de robótica donde se guardó, de forma estructurada y utilizable sin internet, el estándar MHS con toda su evidencia de campo (Genentech, UW, CMU, Janelia, QuEra, Tetsuwan): tiempos de integración reales, tasas de éxito, y las lecciones sobre dónde fallan los modelos.

Importa porque la robótica es la puerta de Savia al mundo físico — el plan de investigación ya existía, pero faltaba la capacidad de diseño ejecutable y el conocimiento del estándar de interfaz agente↔hardware. CRIT-001: todo queda en infraestructura propia (el estándar es local-first, sin telemetría a la nube).

Riesgos: es conocimiento de referencia N1 (no hay hardware físico aún); la skill es nueva y se calibrará con uso. Reversible: el skill se puede desactivar o editar; las notas de la cúpula se pueden archivar.
## Summary
feat(robotica): skill robotica-diseno + digestión MHS en cúpula RBT/AUT
### Changes
- 82bcbc57 chore(scm): regenerar capability map (skill robotica-diseno)
- c926a194 feat(robotica): skill robotica-diseno + digestión MHS en cúpula RBT/AUT
### Stats
8 files changed across 2 commits.
## Test plan
- [x] CI passed  - [x] Signed
