### PR TITLE
docs(se220): cerrar drift — SE-220-spec IMPLEMENTED (PR #874)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=fe17631816a96a09357491166541a9f4e9ad73694cbb85b3f25efa8c5764bd19
-timestamp=2026-08-30T21:40:03Z
-branch=agent/se351-poc-verify-20260830
-head_commit=702524c2
-signature=91edc9f75fd02de815e01b6b43c63cdd5054fd5d22c2f1ae93ed03c147c3191d
+diff_hash=d447e07d148d389549368acfc37eef8ddeeb32c0f87125df4ee30d0b24386bd9
+timestamp=2026-08-31T17:57:05Z
+branch=agent/se220-close-doc-20260831
+head_commit=f492dcd9
+signature=c73c667c50a981e5088bf65fcb015c843ac51bafe8514e4d852308c505709e4c

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -441,7 +441,7 @@ Post-auditoria de alineacion OpenCode (inicio de sesion 2026-05-02). 4 gaps dete
 >
 > **Progreso 2026-08-27**: Batches 1-6 del plan unificado en marcha/completos —
 > L14 ✅ (SE-338/339), SE-344 FxC ✅, L23 cúpulas ✅, backlog 4 ✅ (SE-265/258/182/106
-> cerrados; SE-220-spec pendiente), L26 ✅, L27 E3/E5/E13/E14 ✅ (Piloto 1
+> cerrados; SE-220-spec ✅ IMPLEMENTED (PR #874, 2026-06-26)), L26 ✅, L27 E3/E5/E13/E14 ✅ (Piloto 1
 > pendiente), SE-347 evaluado (RE-EVALUAR), activaciones SE-348 ✅ (salvo sandbox
 > y modelo ≥8B). Detalle por batch y PRs: `ROADMAP-UNIFIED-20260827.md`.
 >
@@ -716,7 +716,7 @@ Google Sheets · ServiceNow/SAP · Tableau · Kafka · VS Code ext · Cloud voic
 |---|---|---|---|
 | **SE-266** | Agent Git Governance — reglas disciplina git para agentes concurrentes (Pi-inspired) | 3h | — |
 | **SE-264** | Memory auto-consolidation — dedup, strip test entries, flag stale (exxperts-inspired) | 3h | — |
-| **SE-220-spec** | Speculative Tool Execution — draft+verify (S0 BLOQUEANTE >=60%) | ~18h | feasibility probe |
+| **SE-220-spec** | Speculative Tool Execution — draft+verify (S0 BLOQUEANTE >=60%) | ~18h · **IMPLEMENTED PR #874** | — |
 | **SE-258** | Brechas identitarias — 5 slices (destracking, self-audit, archive) | 8h | — |
 
 #### Tier P1
@@ -911,11 +911,11 @@ Origen: https://github.com/graykode/abtop (2.7k stars, MIT). Patrones: JSON snap
 
 | # | ID | Título | Esfuerzo | Prioridad |
 |---|---|---|---|---|
-| 0 | SE-220 S0 | **Feasibility probe BLOQUEANTE** — acceptance rate ≥60% sobre `/sprint-status` o ABORT | S (~3h) | P2 |
-| 1 | SE-220 S1 | Tool call predictor + read-only whitelist (haiku/qwen2.5:3b) | M (~4h) | P2 |
-| 2 | SE-220 S2 | Async pre-execution wrapper con flock + cache TTL 30s | M (~5h) | P2 |
-| 3 | SE-220 S3 | Speculative skill pre-loading via pre-resolve hook | S (~3h) | P2 |
-| 4 | SE-220 S4 | Telemetry dashboard + GO/CONTINUE/KILL semanal | S (~3h) | P2 |
+| 0 | SE-220 S0 | **Feasibility probe BLOQUEANTE** — acceptance rate ≥60% sobre `/sprint-status` o ABORT | S (~3h) | ✅ PROCEED 20/20 (#856) |
+| 1 | SE-220 S1 | Tool call predictor + read-only whitelist (haiku/qwen2.5:3b) | M (~4h) | ✅ IMPLEMENTED (#874) |
+| 2 | SE-220 S2 | Async pre-execution wrapper con flock + cache TTL 30s | M (~5h) | ✅ IMPLEMENTED (#874) |
+| 3 | SE-220 S3 | Speculative skill pre-loading via pre-resolve hook | S (~3h) | ✅ IMPLEMENTED (#874) |
+| 4 | SE-220 S4 | Telemetry dashboard + GO/CONTINUE/KILL semanal | S (~3h) | ✅ IMPLEMENTED (#874) |
 
 Origen: investigación speculative decoding 2026-06-20 (papers Leviathan 2022, EAGLE-3 NeurIPS'25, Medusa, Lookahead). El decoder de Claude API es opaco — speculative decoding clásico NO aplica. El **principio** draft+verify SÍ aplica a la capa de orquestación: predictor barato (haiku) pre-ejecuta tool calls idempotentes en background mientras el orquestador (sonnet/opus) piensa. Spec: `docs/propuestas/SE-220-speculative-tool-execution.md`. priority_score = 78.4 (V=75, U=65, E=22) según SPEC-154. Dep: SE-202 (agent-hook-runner)  + SE-217 (time-budget) .
 

--- a/docs/propuestas/LOG.md
+++ b/docs/propuestas/LOG.md
@@ -6,6 +6,13 @@
 > Each entry: date, spec ID, status transition, optional rationale.
 > Ref: SE-222 S1 OKF Adoptable Patterns (log.md convention).
 
+## 2026-08-31 SE-220 IMPLEMENTED
+Speculative Tool Execution — S0 feasibility (PROCEED, acceptance_rate=1.00) + Slices 1-4.
+Implementado en PR #874 (2026-06-26): predictor heurístico (`speculative-tool-predictor.py`),
+orquestador (`speculative-tool-execution.py`), cache con flock+TTL 30s (`speculative-cache-manager.py`),
+telemetría JSONL + dashboard (`speculative-telemetry-report.sh`), hooks pre-execute (S2) y
+skill-preload (S3) registrados. 39 pytest + 35 bats verdes.
+
 ## 2026-06-24 SPEC-182 IMPLEMENTED
 Bi-temporal timeline frontmatter on specs and decisions
 SPEC-182 implementado: spec-timeline-append.py + spec-timeline-query.py + lifecycle --no-timeline + 10 back-fills + 21 tests

--- a/docs/propuestas/ROADMAP-UNIFIED-20260827.md
+++ b/docs/propuestas/ROADMAP-UNIFIED-20260827.md
@@ -63,7 +63,7 @@ empezar ya.
 | Batch 1 — L14 | ✅ SE-338 rule-manifest + SE-339 coverage ratchet · SE-264 ya implementado (#905) | #1025 |
 | Batch 2 — SE-344 FxC | ✅ CLI fronema + cúpula Fronesia + 6 seed + 13 bats | #1028 |
 | Batch 3 — L23 cúpulas N1 | ✅ dome SaviaDomains + 34 cúpulas + generador | #1026 |
-| Batch 4 — backlog | ✅ SPEC-182/SE-106/SE-265/SE-258 cerrados + dep-audit CI · **SE-220-spec pendiente (18h)** | #1032 |
+| Batch 4 — backlog | ✅ SPEC-182/SE-106/SE-265/SE-258 cerrados + dep-audit CI · **SE-220-spec IMPLEMENTED (PR #874, 2026-06-26)** | #1032 |
 | Batch 5 — L26 | ✅ evidencia + FxC + política soberanía/resiliencia | #1029 |
 | Batch 6 — L27 | 🔶 E3/E5 gate PASS + E13 auditor + E14 matriz · **E12 Piloto 1 pendiente (VASS obviado)** | #1033 #1034 |
 | Batch 7 — verticales | ⏳ L24/L25/L12/L9 | — |
@@ -86,7 +86,7 @@ empezar ya.
 - 3h. Apertura de cúpulas sobre el catálogo validado. Precede a dominios de SE-344.
 
 ### Batch 4 — Backlog general P0/P2
-- SE-220-spec (18h, probe listo) · SE-258 (8h) · SPEC-182→SPEC-183 · SE-106 · SE-265.
+- SE-220-spec **IMPLEMENTED** (PR #874, 2026-06-26) · SE-258 (8h) · SPEC-182→SPEC-183 · SE-106 · SE-265.
 
 ### Batch 5 — L26 Savia Evolution (P3 Labs)
 - 14-18h. Evidencia → L27 + discurso inversor.


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este PR no introduce código nuevo: cierra el drift documental de SE-220 (Speculative Tool Execution). La spec ya estaba implementada y mergeada en main desde el PR #874 (2026-06-26): predictor heurístico, orquestador de pre-ejecución, caché con flock y TTL 30s, telemetría JSONL con dashboard, y los dos hooks (pre-execute y skill-preload), todos registrados. Los 39 tests pytest y los 35 tests bats pasan en verde, y la spec ya tenía status IMPLEMENTED. Sin embargo, el roadmap general, el plan unificado de batches y el LOG de specs seguían listando SE-220 como "pendiente (18h)". Este PR corrige esas tres fuentes para reflejar la realidad: SE-220 está implementado, no pendiente. No hay cambio de comportamiento ni de código.

## Summary

Scope-trace: skip — Cierre documental: los 3 ficheros son roadmaps/LOG que reflejan el estado IMPLEMENTED de SE-220 (PR #874), no código con ACs.

docs(se220): cerrar drift — SE-220-spec IMPLEMENTED (PR #874)

### Changes

- docs/ROADMAP.md: marca S0-S4 como implementados y actualiza referencia de progreso
- ROADMAP-UNIFIED-20260827.md: Batch 4 SE-220-spec IMPLEMENTED
- LOG.md: entrada de cierre IMPLEMENTED con PR de referencia

## Test plan

- [x] CI passed
- [x] Signed
## Summary
docs(se220): cerrar drift — SE-220-spec IMPLEMENTED (PR #874)
### Changes
- f492dcd9 docs(se220): cerrar drift — SE-220-spec IMPLEMENTED (PR #874) en roadmap, unified plan y LOG
### Stats
4 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed
