### PR TITLE
feat(se365): company as code

### DIFF
--- a/.claude/skills/org-registrar/SKILL.md
+++ b/.claude/skills/org-registrar/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: org-registrar
+description: "Gestiona el grafo de entidades organizacionales (Company as Code, SE-365): valida entidades, indexa el grafo, consulta dependencias y prepara propuestas de escritura mediada. Usar cuando se consultan roles/unidades/personas/políticas/proyectos/recursos, o se propone una entidad nueva."
+metadata:
+  savia.category: governance
+  savia.context: fork
+  savia.context_cost: low
+  savia.maturity: stable
+  savia.priority: high
+  savia.summary: "Company as Code (SE-365): valida/consulta el grafo organizacional (company/projects/resources) con vocabulario de relaciones controlado y escritura mediada por humano."
+layer: peripheral
+---
+
+# org-registrar — Grafo organizacional (SE-365)
+
+> Company as Code: entidades organizacionales como código versionable, consultable
+> y gobernado por CRITERIO.md. CRIT-001: todo local.
+
+## Cuándo usar
+
+- Consultar "¿qué proyectos usan este recurso?" / "¿qué políticas aplican a esta unidad?"
+- Validar una entidad o relación nueva contra el esquema y CRITERIO.md
+- Proponer una entidad nueva (escritura mediada: prepara el diff, no lo aplica)
+
+## Comandos
+
+```bash
+# validar una entidad
+bash scripts/org-registrar.sh validate --file company/policies/policy-x.md
+
+# indexar el grafo de un directorio
+bash scripts/org-registrar.sh index --dir company --json
+
+# consultar dependencias de un recurso
+bash scripts/org-registrar.sh query --graph graph.json --what uses_resource --id resource-x
+
+# preparar propuesta (no aplica — requiere confirmación humana)
+bash scripts/org-registrar.sh propose --file entity.md --out proposals/
+```
+
+## Estructura del grafo
+
+```
+org/company/roles|units|people|policies/<slug>.md
+org/projects/<slug>.md
+org/resources/infra|tools|knowledge/<slug>.md
+```
+
+> Árbol dedicado bajo `org/`, separado de `projects/` de pm-workspace (protegido por
+> `protect-project-privacy`).
+
+## Reglas de gobernanza
+
+1. **Lectura libre** para agentes; **escritura mediada** por humano (se delega la
+   ejecución, nunca el criterio).
+2. **Vocabulario de relaciones cerrado** (sección 6 del spec SE-365): relación no
+   listada → rechazo.
+3. **Políticas solo `origin: owner`** (`source: human`); agentes pueden proponer
+   (marcan `proposed`).
+4. **Recursos**: `sensitivity` nunca `secret` — credenciales nunca viven en el vault.
+5. **CRITERIO.md valida, no almacena** — las entidades viven en su propio árbol.
+6. Cada escritura emite receipt en el audit ledger (SE-355) con `enforced`.
+
+## Referencias
+
+- Spec: `docs/specs/SE-365-company-as-code.spec.md`
+- Dependencias: SE-352 (origin), SE-355 (audit), SE-363 (records), SE-362 (risk)

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=8845e4a82d80eb68e189724642347a794834f9efc132580164f32473c51d1222
-timestamp=2026-09-01T19:11:19Z
-branch=agent/se354-readonly-permission-20260831
-head_commit=b8613364
-signature=e7cffdd3ba4cd2ccc72e1731bb755f143f32a34dffbc0b9e31eb6bc45d49f7fe
+diff_hash=637e35ac22b6fe377ca3f461d332013350e5e529cdaf73038897ee134dafdf19
+timestamp=2026-09-01T19:51:14Z
+branch=agent/se365-company-as-code-20260901
+head_commit=fbfb96b8
+signature=6eec4fe9afa12e7f26c8bd3301d80c0c038637571038a0c8a2bbddc2347a809c

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=637e35ac22b6fe377ca3f461d332013350e5e529cdaf73038897ee134dafdf19
-timestamp=2026-09-01T19:54:17Z
+diff_hash=baa0767c5a30c7c8fb6330d72a531eecc7d13c796da8a3fe3d16161ff6bcfe11
+timestamp=2026-09-01T19:55:27Z
 branch=agent/se365-company-as-code-20260901
-head_commit=9063c810
-signature=6eec4fe9afa12e7f26c8bd3301d80c0c038637571038a0c8a2bbddc2347a809c
+head_commit=83df1f25
+signature=5b2eec320d088add2839527357316b99ede6269ed3e978d59d4a0b98210f7832

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=637e35ac22b6fe377ca3f461d332013350e5e529cdaf73038897ee134dafdf19
-timestamp=2026-09-01T19:51:14Z
+timestamp=2026-09-01T19:54:17Z
 branch=agent/se365-company-as-code-20260901
-head_commit=fbfb96b8
+head_commit=9063c810
 signature=6eec4fe9afa12e7f26c8bd3301d80c0c038637571038a0c8a2bbddc2347a809c

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: 98709b67554e | resources: 1430
-> 295 commands · 132 skills · 88 agents · 915 scripts
+> hash: 627b3db8d4c3 | resources: 1432
+> 295 commands · 133 skills · 88 agents · 916 scripts
 
 [analysis] Trace Optimize — across,distributed,optimize,rates,sampling — cmd:.claude/commands/trace-optimize.md
 [analysis] agent-activity — activity,agent,executions,recent,show — cmd:.claude/commands/agent-activity.md
@@ -311,6 +311,7 @@
 [development] opencode-install — install,opencode,slice — script:scripts/opencode-install.sh
 [development] opencode-migration-smoke — final,migration,opencode,prep,slice — script:scripts/opencode-migration-smoke.sh
 [development] opencode-monthly-canary — canary,monthly,opencode,slice — script:scripts/opencode-monthly-canary.sh
+[development] org-registrar — code,company,consulta,consultan,dependencias — skill:.claude/skills/org-registrar/SKILL.md
 [development] parallel-specs-cleanup-stale — cleanup,parallel,slice,specs,stale — script:scripts/parallel-specs-cleanup-stale.sh
 [development] parallel-specs-db-sandbox — parallel,sandbox,slice,specs,worker — script:scripts/parallel-specs-db-sandbox.sh
 [development] parallel-specs-merge-queue — cascade,merge,parallel,queue,rebase — script:scripts/parallel-specs-merge-queue.sh
@@ -908,6 +909,7 @@
 [planning] opus47-calibration-scorecard — calibration,opus,scorecard,slice — script:scripts/opus47-calibration-scorecard.sh
 [planning] orchestration-protocol — agent,inter,messaging,orchestration,protocol — script:scripts/orchestration-protocol.sh
 [planning] org-political-landscape — alianzas,análisis,centros,detecta,interno — skill:.claude/skills/org-political-landscape/SKILL.md
+[planning] org-registrar — grafo,organizacional,registrar,wrapper — script:scripts/org-registrar.sh
 [planning] org-stakeholder-mapper — alianzas,decisores,extrae,formales,mapeador — skill:.claude/skills/org-stakeholder-mapper/SKILL.md
 [planning] orgchart-import —  — cmd:.claude/commands/orgchart-import.md
 [planning] orgchart-import — equipo,estructura,extraer,importa,organigrama — skill:.claude/skills/orgchart-import/SKILL.md

--- a/.scm/categories/development.scm
+++ b/.scm/categories/development.scm
@@ -1,5 +1,5 @@
 # development — Savia Capability Map (L1)
-> 224 resources
+> 225 resources
 
 - **/speckit.checklist** (cmd): Alias spec-kit compatible. Gate de calidad final con verification-lattice multi-capa. Invoca skill verification-lattice. Compatible con github/spec-kit.
 - **/speckit.clarify** (cmd): Alias spec-kit compatible. Preguntas dirigidas para cerrar ambigüedad en una spec. Invoca skill context-interview-conductor. Compatible con github/spec-kit.
@@ -128,6 +128,7 @@
 - **opencode-install** (script): opencode-install.sh — SE-077 Slice 1
 - **opencode-migration-smoke** (script): opencode-migration-smoke.sh — SPEC-127 Slice 2b-ii (final migration prep)
 - **opencode-monthly-canary** (script): opencode-monthly-canary.sh — SE-077 Slice 2
+- **org-registrar** (skill): Gestiona el grafo de entidades organizacionales (Company as Code, SE-365): valida entidades, indexa el grafo, consulta dependencias y prepara propuestas de escritura mediada. Usar cuando se consultan roles/unidades/personas/políticas/proyec
 - **parallel-specs-cleanup-stale** (script): parallel-specs-cleanup-stale.sh — SE-074 Slice 3 — stale worktree cleanup
 - **parallel-specs-db-sandbox** (script): parallel-specs-db-sandbox.sh — SE-074 Slice 3 — DB sandbox per worker
 - **parallel-specs-merge-queue** (script): parallel-specs-merge-queue.sh — SE-074 Slice 2 — PR queue + cascade-rebase

--- a/.scm/categories/planning.scm
+++ b/.scm/categories/planning.scm
@@ -1,5 +1,5 @@
 # planning — Savia Capability Map (L1)
-> 619 resources
+> 620 resources
 
 - **/decide-architecture** (cmd): Clasifica una tarea como WORKFLOW (deterministica) o AGENT (loop). Bias hacia workflow per Anthropic. Sugiere plantilla inicial. Mide accuracy contra corpus curado de 20 tareas.
 - **_template** (skill): TEMPLATE — copia este directorio para crear una skill nueva. NO se carga en runtime.
@@ -359,6 +359,7 @@
 - **opus47-calibration-scorecard** (script): opus47-calibration-scorecard.sh — SE-070 Slice 1
 - **orchestration-protocol** (script): scripts/orchestration-protocol.sh — SE-205: typed inter-agent messaging
 - **org-political-landscape** (skill): Análisis de Paisaje Político Interno: detecta tensiones, alianzas y centros de poder a partir de un mapa de stakeholders.
+- **org-registrar** (script): org-registrar.sh — SE-365: CLI del grafo organizacional (wrapper).
 - **org-stakeholder-mapper** (skill): Mapeador de Stakeholders y Decisores: extrae roles formales y reales, motivaciones, alianzas y tensiones de una organización.
 - **orgchart-import** (cmd): >
 - **orgchart-import** (skill): Usar cuando se importa un organigrama para extraer la estructura del equipo.

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "afbfb3a0a260",
-  "total": 1430,
+  "hash": "30b74b3bd396",
+  "total": 1432,
   "resources": [
     {
       "category": "analysis",
@@ -4071,6 +4071,20 @@
       "kind": "script",
       "path": "scripts/opencode-monthly-canary.sh",
       "description": "opencode-monthly-canary.sh — SE-077 Slice 2"
+    },
+    {
+      "category": "development",
+      "name": "org-registrar",
+      "intents": [
+        "code",
+        "company",
+        "consulta",
+        "consultan",
+        "dependencias"
+      ],
+      "kind": "skill",
+      "path": ".claude/skills/org-registrar/SKILL.md",
+      "description": "Gestiona el grafo de entidades organizacionales (Company as Code, SE-365): valida entidades, indexa el grafo, consulta dependencias y prepara propuestas de escritura mediada. Usar cuando se consultan roles/unidades/personas/políticas/proyec"
     },
     {
       "category": "development",
@@ -12001,6 +12015,19 @@
       "kind": "skill",
       "path": ".claude/skills/org-political-landscape/SKILL.md",
       "description": "Análisis de Paisaje Político Interno: detecta tensiones, alianzas y centros de poder a partir de un mapa de stakeholders."
+    },
+    {
+      "category": "planning",
+      "name": "org-registrar",
+      "intents": [
+        "grafo",
+        "organizacional",
+        "registrar",
+        "wrapper"
+      ],
+      "kind": "script",
+      "path": "scripts/org-registrar.sh",
+      "description": "org-registrar.sh — SE-365: CLI del grafo organizacional (wrapper)."
     },
     {
       "category": "planning",

--- a/CHANGELOG.d/se365-company-as-code.md
+++ b/CHANGELOG.d/se365-company-as-code.md
@@ -1,0 +1,8 @@
+---
+version_bump: patch
+section: Added
+---
+
+### Added
+
+- SE-365 Company as Code: estándar de entidades organizacionales como código (renumerado de SE-265). `org-registrar.py` valida entidades (frontmatter común, vocabulario de relaciones cerrado, consistencia referencial, origin/source SE-352), indexa el grafo (company/projects/resources) y prepara propuestas de escritura mediada. Skill `org-registrar` + grafo piloto (5 entidades). 6 pytest + 5 bats tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Identidad del humano al volante + memoria auto persistida fuera del repo.
 
 ## Estructura
 
-`.claude/{agents(88), commands(571), profiles, hooks(118/121reg), rules/{domain,languages}, skills(134), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
+`.claude/{agents(88), commands(571), profiles, hooks(118/121reg), rules/{domain,languages}, skills(132), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
 
 ## Reglas Críticas (Rules 1-8, inline)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Identidad del humano al volante + memoria auto persistida fuera del repo.
 
 ## Estructura
 
-`.claude/{agents(88), commands(571), profiles, hooks(118/121reg), rules/{domain,languages}, skills(131), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
+`.claude/{agents(88), commands(571), profiles, hooks(118/121reg), rules/{domain,languages}, skills(134), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
 
 ## Reglas Críticas (Rules 1-8, inline)
 

--- a/docs/propuestas/LOG.md
+++ b/docs/propuestas/LOG.md
@@ -6,6 +6,13 @@
 > Each entry: date, spec ID, status transition, optional rationale.
 > Ref: SE-222 S1 OKF Adoptable Patterns (log.md convention).
 
+## 2026-09-01 SE-365 APPROVED→IMPLEMENTED
+Company as Code (renumerado de SE-265, que colisionaba con court-model-tiers):
+estándar de entidades organizacionales como código. org-registrar.py valida
+(frontmatter común, vocabulario de relaciones cerrado, consistencia referencial,
+origin/source SE-352), indexa el grafo company/projects/resources, propone con
+escritura mediada. Skill org-registrar + grafo piloto (5 entidades). 6 pytest + 5 bats.
+
 ## 2026-08-31 SE-359 APPROVED→IMPLEMENTED
 REVIEW.md policy (origen Anthropic playbook Stage 5): passes canónicos, vocab
 cerrado Important|Nit, cap 5 nits, exclusiones; review-policy-parse.py. 7 pytest + 7 bats.

--- a/docs/propuestas/ROADMAP-UNIFIED-20260827.md
+++ b/docs/propuestas/ROADMAP-UNIFIED-20260827.md
@@ -67,6 +67,7 @@ empezar ya.
 | Batch 5 — L26 | ✅ evidencia + FxC + política soberanía/resiliencia | #1029 |
 | Batch 6 — L27 | 🔶 E3/E5 gate PASS + E13 auditor + E14 matriz · **E12 Piloto 1 pendiente (VASS obviado)** | #1033 #1034 |
 | Batch 7 — verticales | ⏳ L24/L25/L12/L9 | — |
+| **Batch 8 — SE-365 Company as Code** | 🔶 estándar de entidades organizacionales (renumerado de SE-265) — en implementación | — |
 | Track B — SE-347 | 🔶 evaluado **RE-EVALUAR** (S3 bloqueado por modelo local ≥8B) | #1027 |
 | SE-348 activaciones | ✅ vector + Shield NER + router SE-346 + hook FxC · ⏳ sandbox (sudo) · ⏳ modelo ≥8B (hardware) | #1031 |
 
@@ -97,6 +98,12 @@ empezar ya.
 
 ### Batch 7 — Verticales y cola (P5-P8 Labs)
 - L24 Farming · L25 Humanity · L12 Sonora (paralela) · L9 Biomimético.
+
+### Batch 8 — SE-365 Company as Code (P0 transversal, 2026-09-01)
+- Estándar de entidades organizacionales como código (renumerado de SE-265, que colisionaba con court-model-tiers).
+- Habilita: federación (SE-263), queryability del grafo organizacional, org-registrar skill.
+- Consume: SE-352 (origin), SE-355 (audit), SE-363 (records-not-files), SE-362 (risk-tiering).
+- Fases: 0 esquema → 1 Company → 2 Projects → 3 Resources → 4 org-registrar.
 
 ### Track B (paralelo, no compite) — SE-347 PMA evaluación
 - S2 (auditoría de red runtime) + S3 (patrones RLM + benchmark). Independiente de los batches de dev.

--- a/docs/specs/SE-365-company-as-code.spec.md
+++ b/docs/specs/SE-365-company-as-code.spec.md
@@ -1,0 +1,273 @@
+# SE-365 — Company as Code: Estándar Unificado de Entidades Organizacionales
+
+**Status:** APPROVED (2026-09-01, operadora grant merge)
+**Fecha:** 2026-09-01
+**Área:** Arquitectura de conocimiento / Gobernanza / Organización
+**Fuente de inspiración:** Company as Code (Rothmann, 42futures, 2025) + Anthropic AI-Native SDLC Playbook ("registros, no archivos")
+**Criterio humano aplicable:** CRIT-001 (todo local, N3+ jamás a cloud)
+
+> **Nota de renumeración**: este spec era originalmente SE-265 (borrador de Mónica).
+> SE-265 ya estaba asignado a `SE-265-court-model-tiers` (fase previa). Se renumeró a
+> **SE-365** para evitar colisión. El contenido es el mismo borrador, adaptado al estado
+> real del workspace en 2026-09-01.
+
+---
+
+## 1. Motivación
+
+Savia resuelve, para agentes IA, el problema que "Company as Code" plantea de forma
+genérica: representar una organización como algo **versionable, consultable y gobernado
+por criterio explícito**, en vez de como documentos estáticos dispersos. `CRITERIO.md`
+y `CONSTITUCION.md` ya son una capa constitucional ejecutable.
+
+Lo que falta es **generalizar el patrón**: un formato estándar para declarar las
+*entidades* sobre las que el criterio opera — la empresa, sus proyectos, sus recursos.
+Sin ese estándar, cada vault modela esta información ad hoc, rompiendo:
+
+- la queryability entre vaults federados (SE-263)
+- la capacidad de un agente de razonar sobre "qué proyectos dependen de qué recurso"
+- la trazabilidad de auditoría (quién cambió qué relación organizacional, cuándo, por qué)
+
+## 2. Alcance
+
+**Dentro:**
+- Formato de declaración de entidades (esquema, sintaxis, ubicación en el vault)
+- Modelo de relaciones entre las tres capas (Company ↔ Projects ↔ Resources)
+- Integración con la capa constitucional (CRITERIO.md como validador, no contenedor)
+- Diseño del skill/agente `org-registrar`
+- Reglas de gobernanza (qué escrituras requieren puerta humana)
+
+**Fuera (specs derivadas):**
+- UI low-code para stakeholders no técnicos
+- Integraciones externas (Azure AD, GitLab issues) más allá de lectura de evidencia
+- Extensión a robots/hardware
+
+## 3. Principios de diseño
+
+1. **Un vault, un grafo, tres capas.** Company, Projects y Resources son tres tipos de
+   nodo en el mismo grafo, con relaciones internas y cruzadas.
+2. **Markdown + frontmatter, no un DSL nuevo.** Cada entidad es un `.md` con frontmatter
+   YAML tipado + cuerpo narrativo. Legibilidad humana, diffs limpios, cero parser propio.
+3. **Relaciones por referencia, no por anidamiento.** Cada entidad referencia a otras por
+   `id` estable (slug). El grafo se reconstruye indexando referencias.
+4. **CRITERIO.md valida, no almacena.** Las entidades viven en su propio árbol
+   (`/company/`, `/projects/`, `/resources/`); la capa constitucional solo valida.
+5. **Escritura con puerta humana, lectura libre para agentes.** Cualquier agente lee y
+   razona; toda escritura que cree/modifique/elimine pasa por confirmación humana.
+6. **Compatible con federación (SE-263).** El formato se sincroniza vía A2A sin cambios;
+   referencias cross-vault se cualifican con el id de instancia.
+7. **Provenance (SE-352).** Cada entidad lleva `origin` (owner/agent) y `source` — el
+   estándar de memoria de SE-352 aplica al grafo organizacional.
+
+## 4. Estructura de directorios
+
+> El grafo vive bajo `org/` (árbol SE-365 dedicado), separado de `projects/` de
+> pm-workspace (que aloja vaults de proyectos con datos y está protegido por
+> `protect-project-privacy`).
+
+```
+org/
+├── company/
+│   ├── _company.md              # nodo raíz: identidad de la organización
+│   ├── roles/<role-slug>.md
+│   ├── units/<unit-slug>.md
+│   ├── people/<person-slug>.md
+│   └── policies/<policy-slug>.md
+├── projects/<project-slug>.md
+└── resources/
+    ├── infra/<resource-slug>.md
+    ├── tools/<resource-slug>.md
+    └── knowledge/<resource-slug>.md
+```
+
+`CRITERIO.md` / `CONSTITUCION.md` permanecen en la raíz, sin cambios de ubicación.
+
+## 5. Esquema de entidad (frontmatter común)
+
+```yaml
+---
+id: <slug único en el vault>
+type: role | unit | person | policy | project | resource
+name: <nombre legible>
+status: active | deprecated | proposed
+owner: <id de person o unit>
+relations:
+  - { type: <RelationType>, target: <id> }
+created: <ISO date>
+updated: <ISO date>
+origin: owner | agent                    # SE-352 provenance
+source: [human | agent:<nombre>]         # quién declaró la entidad
+---
+
+<cuerpo libre en markdown: contexto, notas, historia>
+```
+
+### 5.1 Company as Code
+
+Nodos: `role`, `unit`, `person`, `policy`.
+
+```yaml
+---
+id: role-arquitecto-soluciones
+type: role
+name: "Arquitecto/a de Soluciones"
+responsibilities:
+  - "Diseño de arquitectura hexagonal/DDD"
+relations:
+  - { type: BelongsToUnit, target: unit-consultoria }
+---
+```
+
+```yaml
+---
+id: policy-soberania-datos
+type: policy
+name: "Soberanía de datos"
+enforcement: mandatory
+implements_criterio: CRITERIO#soberania-datos
+relations:
+  - { type: AppliesTo, target: unit-consultoria }
+---
+```
+
+`implements_criterio` es el puente explícito entre una política operativa y el principio
+constitucional que la justifica — permite responder "¿qué políticas implementan qué
+principio?" con una consulta.
+
+### 5.2 Projects as Code
+
+```yaml
+---
+id: project-savia-federacion
+type: project
+name: "Federación multi-instancia Savia"
+status: active
+owner: person-monica
+relations:
+  - { type: ImplementsSpec, target: SE-263 }
+  - { type: UsesResource, target: resource-gitlab-homelab }
+  - { type: OwnedByUnit, target: unit-savia-core }
+milestones:
+  - { name: "Protocolo A2A sobre VPN", status: done }
+---
+```
+
+Se integra con pm-workspace/SDD: un `project` referencia sus specs (`ImplementsSpec`)
+sin duplicar contenido — la fuente de verdad sigue siendo el repo de specs.
+
+### 5.3 Resources as Code
+
+```yaml
+---
+id: resource-gitlab-homelab
+type: resource
+category: infra | tool | knowledge | credential-ref
+name: "GitLab auto-hospedado"
+relations:
+  - { type: UsedByProject, target: project-savia-federacion }
+  - { type: GovernedByPolicy, target: policy-soberania-datos }
+sensitivity: internal | restricted    # nunca "secret" — credenciales nunca viven en el vault
+---
+```
+
+**Regla explícita**: `resources` documenta la *existencia y relaciones*, nunca
+credenciales ni secretos — coherente con CRIT-001.
+
+## 6. Tipos de relación (vocabulario controlado)
+
+| Relación | Dominio → Rango | Semántica |
+|---|---|---|
+| `BelongsToUnit` | person/role → unit | pertenencia jerárquica |
+| `ManagedBy` | person → person | reporta a |
+| `AppliesTo` | policy → unit/role/project | alcance de una política |
+| `ImplementsCriterio` | policy → CRITERIO entry | trazabilidad constitucional |
+| `ImplementsSpec` | project → spec (SE-XXX) | trazabilidad técnica |
+| `UsesResource` / `UsedByProject` | project ↔ resource | dependencia operativa (inversa) |
+| `OwnedByUnit` | project/resource → unit | responsabilidad organizacional |
+| `GovernedByPolicy` | resource → policy | qué política rige ese recurso |
+
+El vocabulario es extensible pero controlado: nuevas relaciones se proponen como entrada
+a esta spec, no se inventan libremente (para que las queries sigan siendo fiables).
+
+## 7. Skill/agente: `org-registrar`
+
+**Responsabilidades:**
+- **Lectura/consulta:** responder "¿qué proyectos usan este recurso?", "¿qué políticas
+  aplican a esta unidad?", "¿qué pasaría si desactivo este recurso?" (impact analysis)
+- **Validación:** verificar contra CRITERIO.md que una entidad/relación nueva no viola
+  un principio inmutable
+- **Escritura mediada:** prepara el diff, lo presenta, lo aplica solo tras confirmación
+- **Consistencia referencial:** comprobar que el `target` existe y el tipo de relación es
+  válido para el par de tipos
+- **Generación de vista humana:** renderizar el grafo como resumen legible
+
+**Fuera:** no decide política ni criterio — solo administra la representación.
+
+## 8. Gobernanza y puerta humana
+
+| Acción | Requiere confirmación humana |
+|---|---|
+| Consultar/leer el grafo | No |
+| Proponer una nueva entidad | Sí (el agente prepara, el humano aprueba) |
+| Modificar relaciones existentes | Sí |
+| Eliminar una entidad | Sí, con verificación de impacto previa |
+| Vincular `policy` a CRITERIO.md | Sí — es modificación de alcance constitucional |
+
+## 9. Compatibilidad con federación (SE-263)
+
+Cada vault mantiene su sub-grafo. Referencias cross-vault se resuelven con el mecanismo
+de context domes; el `id` se cualifica con el id de instancia
+(`instancia-b:resource-gitlab-homelab`).
+
+## 10. Integración con specs ya implementadas (estado 2026-09-01)
+
+| Spec | Aporte a SE-365 |
+|---|---|
+| SE-352 (trust-gated memory) | `origin`/`source` en el frontmatter de entidades |
+| SE-355 (audit ledger) | cada escritura al grafo emite receipt `enforced` |
+| SE-363 (records-not-files) | patrón: Markdown = vista, JSONL/índice = dato consultable |
+| SE-362 (risk-tiering) | la escritura de entidades se clasifica por tier (T1 docs / T3 políticas) |
+| SE-258 (identidad) | `owner`/`person` validados contra los activos de identidad |
+| SE-263 (federación) | referencias cross-vault cualificadas |
+
+## 11. Fases de implementación
+
+1. **Fase 0 — Esquema y vocabulario.** Cerrar frontmatter mínimo y vocabulario (esta spec).
+2. **Fase 1 — Company as Code.** Modelar roles/unidades/personas/políticas del propio
+   workspace como piloto, con puente `ImplementsCriterio`.
+3. **Fase 2 — Projects as Code.** Integrar con pm-workspace: cada spec activa obtiene su
+   nodo `project`, sin duplicar contenido.
+4. **Fase 3 — Resources as Code.** Catalogar infraestructura local (GitLab homelab, etc.).
+5. **Fase 4 — `org-registrar`.** Implementar el skill/agente (lectura primero, escritura mediada después).
+
+## 12. Criterios de aceptación
+
+- **AC-0** Frontmatter común validado por `org-registrar validate` (test con fixture)
+- **AC-1** Vocabulario de relaciones cerrado: relación no listada → WARN + rechazo
+- **AC-2** Consistencia referencial: `target` inexistente → error
+- **AC-3** Entidad con `origin: owner` + `source: human` es la única que puede declarar
+  políticas; `agent` puede proponer (marca `proposed`)
+- **AC-4** Escritura mediada: el skill prepara diff y requiere confirmación (exit 2 sin ella)
+- **AC-5** Grafo indexado consultable ("qué proyectos usan recurso X") en <2s
+- **AC-6** CRITERIO.md intacto (la capa valida, no almacena)
+- **AC-7** Sin regresión: suite SE-363/355/352 verde
+
+## 13. Preguntas abiertas (decididas en implementación)
+
+- `org-registrar` como skill invocado bajo demanda (decidido: skill, no agente con ciclo de vida)
+- `type: team` entre `unit` y `project` (aplazado — Savia Flow lo define por separado)
+- Vocabulario de relaciones versionado como sección de esta spec (decidido: sección 6)
+
+## Validación (ejecutada en esta sesión)
+
+- `scripts/org-registrar.py`: valida frontmatter común, vocabulario de relaciones cerrado,
+  consistencia referencial, origin/source (SE-352), sensitivity nunca secret; 6 pytest + 5 bats verdes
+- Grafo piloto: 5 entidades en `org/` (unit-savia-core, person-monica, policy-soberania-datos,
+  resource-gitlab-homelab, project-savia-federacion) — validadas OK
+- Skill `org-registrar` (peripheral, governance) creado; SCM + SKILLS.md + rules INDEX regenerados
+
+## Referencias
+
+- Company as Code: Rothmann, 42futures, 2025
+- Savia: CRITERIO.md, SE-258, SE-263, SE-352, SE-355, SE-362, SE-363
+- CRIT-001 · `autonomous-safety.md`

--- a/org/company/people/person-monica.md
+++ b/org/company/people/person-monica.md
@@ -1,0 +1,17 @@
+---
+id: person-monica
+type: person
+name: "Mónica González Paz"
+status: active
+owner: person-monica
+relations:
+  - { type: ManagedBy, target: person-monica }
+created: 2026-09-01
+updated: 2026-09-01
+origin: owner
+source: human
+---
+
+# Mónica
+
+Operadora y creadora de Savia. Principal única (CONSTITUCION.md ART-16).

--- a/org/company/policies/policy-soberania-datos.md
+++ b/org/company/policies/policy-soberania-datos.md
@@ -1,0 +1,20 @@
+---
+id: policy-soberania-datos
+type: policy
+name: "Soberanía de datos"
+status: active
+enforcement: mandatory
+implements_criterio: CRITERIO#soberania-datos
+owner: person-monica
+relations:
+  - { type: AppliesTo, target: unit-savia-core }
+created: 2026-09-01
+updated: 2026-09-01
+origin: owner
+source: human
+---
+
+# Soberanía de datos
+
+Implementa CRITERIO#soberania-datos (CRIT-001): los datos N3+ jamás salen a
+proveedores cloud. Todas las entidades `resource` deben cumplir esta política.

--- a/org/company/units/unit-savia-core.md
+++ b/org/company/units/unit-savia-core.md
@@ -1,0 +1,19 @@
+---
+id: company-savia
+type: unit
+name: "Savia — workspace de Mónica"
+status: active
+owner: person-monica
+relations:
+  - { type: OwnedByUnit, target: unit-savia-core }
+created: 2026-09-01
+updated: 2026-09-01
+origin: owner
+source: human
+---
+
+# Savia
+
+Workspace operativo de Mónica (pm-workspace): capa constitucional ejecutable
+(CRITERIO.md, CONSTITUCION.md), 90+ specs, 118 hooks, memoria persistente local.
+CRIT-001: todo local, datos N3+ jamás a proveedores cloud.

--- a/org/projects/project-savia-federacion.md
+++ b/org/projects/project-savia-federacion.md
@@ -1,0 +1,22 @@
+---
+id: project-savia-federacion
+type: project
+name: "Federación multi-instancia Savia"
+status: active
+owner: person-monica
+relations:
+  - { type: ImplementsSpec, target: SE-263 }
+  - { type: UsesResource, target: resource-gitlab-homelab }
+  - { type: OwnedByUnit, target: unit-savia-core }
+created: 2026-09-01
+updated: 2026-09-01
+origin: owner
+source: human
+milestones:
+  - { name: "Protocolo A2A sobre VPN", status: done }
+---
+
+# Federación multi-instancia
+
+Federación de vaults vía A2A sobre VPN homelab. SE-263 especifica el protocolo.
+Este nodo es el índice organizacional del proyecto.

--- a/org/resources/infra/resource-gitlab-homelab.md
+++ b/org/resources/infra/resource-gitlab-homelab.md
@@ -1,0 +1,21 @@
+---
+id: resource-gitlab-homelab
+type: resource
+category: infra
+name: "GitLab auto-hospedado (plano de estado)"
+status: active
+owner: person-monica
+relations:
+  - { type: GovernedByPolicy, target: policy-soberania-datos }
+  - { type: UsedByProject, target: project-savia-federacion }
+created: 2026-09-01
+updated: 2026-09-01
+sensitivity: internal
+origin: owner
+source: human
+---
+
+# GitLab homelab
+
+Repositorio auto-hospedado en infraestructura propia (CRIT-001). Documenta
+existencia y relaciones — las credenciales nunca viven en el vault.

--- a/scripts/org-registrar.py
+++ b/scripts/org-registrar.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+org-registrar.py — SE-365: validador y consulta del grafo de entidades organizacionales.
+
+Company as Code: entidades en markdown+frontmatter (roles/units/people/policies,
+projects, resources) con vocabulario de relaciones controlado. CRITERIO.md valida,
+no almacena. Escritura mediada por humano.
+
+Uso:
+  org-registrar.py validate --file entity.md [--known-ids "id1 id2"]
+  org-registrar.py index --dir company/ [--json]
+  org-registrar.py query --graph graph.json --what uses_resource --id resource-x
+  org-registrar.py propose --file entity.md --out proposals/   # genera diff sin aplicar
+
+Ref: SE-365 — Company as Code
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+VALID_TYPES = {"role", "unit", "person", "policy", "project", "resource"}
+VALID_RELATIONS = {
+    "BelongsToUnit", "ManagedBy", "AppliesTo", "ImplementsCriterio",
+    "ImplementsSpec", "UsesResource", "UsedByProject", "OwnedByUnit", "GovernedByPolicy",
+}
+VALID_STATUS = {"active", "deprecated", "proposed"}
+VALID_CATEGORIES = {"infra", "tool", "knowledge", "credential-ref"}
+OWNER_ONLY_TYPES = {"policy"}  # políticas solo las declara origin: owner
+
+# pares válidos (dominio → rango aproximado) — validación estructural
+RELATION_DOMAINS = {
+    "BelongsToUnit": {"person", "role"},
+    "ManagedBy": {"person"},
+    "AppliesTo": {"policy"},
+    "ImplementsCriterio": {"policy"},
+    "ImplementsSpec": {"project"},
+    "UsesResource": {"project"},
+    "UsedByProject": {"resource"},
+    "OwnedByUnit": {"project", "resource"},
+    "GovernedByPolicy": {"resource"},
+}
+
+
+def _parse_frontmatter(text: str) -> tuple[dict | None, str]:
+    m = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", text, re.S)
+    if not m:
+        return None, text
+    yaml_block, body = m.group(1), m.group(2)
+    # parse YAML simple (sin dep) — claves top-level y listas de dicts
+    data: dict = {}
+    current_key = None
+    in_list = False
+    for line in yaml_block.splitlines():
+        m2 = re.match(r"^(\w+):\s*(.*)$", line)
+        if m2:
+            key, val = m2.group(1), m2.group(2).strip().strip('"').strip("'")
+            data[key] = val if val else ""
+            current_key = key
+            in_list = key in ("relations", "responsibilities")
+            continue
+        if in_list and line.lstrip().startswith("- {"):
+            m3 = re.match(r"-\s*\{\s*type:\s*(\w+)\s*,\s*target:\s*([\w\-.]+)\s*\}", line.lstrip())
+            if m3:
+                if not isinstance(data.get(current_key), list):
+                    data[current_key] = []
+                data[current_key].append({"type": m3.group(1), "target": m3.group(2)})
+    return data, body
+
+
+def validate(path: Path, known_ids: set[str] | None = None) -> dict:
+    """Valida una entidad contra el esquema común."""
+    if not path.exists():
+        return {"valid": False, "errors": [f"archivo no existe: {path}"]}
+    text = path.read_text(encoding="utf-8")
+    data, _ = _parse_frontmatter(text)
+    if data is None:
+        return {"valid": False, "errors": ["frontmatter ausente o malformado"]}
+
+    errors: list[str] = []
+
+    # campos requeridos
+    for field in ("id", "type", "name", "status"):
+        if not data.get(field):
+            errors.append(f"falta campo obligatorio: {field}")
+
+    if data.get("type") not in VALID_TYPES:
+        errors.append(f"type inválido: {data.get('type')} (válidos: {sorted(VALID_TYPES)})")
+    if data.get("status") not in VALID_STATUS:
+        errors.append(f"status inválido: {data.get('status')}")
+    if data.get("type") == "resource":
+        cat = data.get("category", "")
+        if cat not in VALID_CATEGORIES:
+            errors.append(f"resource category inválida: {cat}")
+
+    # sensitivity nunca "secret" (CRIT-001)
+    if data.get("sensitivity") == "secret":
+        errors.append("sensitivity 'secret' prohibida: credenciales nunca viven en el vault")
+
+    # origin/source (SE-352)
+    origin = data.get("origin", "")
+    source = data.get("source", "")
+    if origin not in ("owner", "agent"):
+        errors.append(f"origin inválido: {origin} (owner|agent)")
+    if origin == "owner" and source != "human":
+        errors.append("origin: owner requiere source: human")
+
+    # políticas solo por owner
+    if data.get("type") in OWNER_ONLY_TYPES and origin != "owner":
+        errors.append(f"tipo {data['type']} solo puede declararlo origin: owner")
+
+    # relaciones: vocabulario cerrado + consistencia referencial
+    for rel in data.get("relations", []) or []:
+        rtype = rel.get("type", "")
+        target = rel.get("target", "")
+        if rtype not in VALID_RELATIONS:
+            errors.append(f"relación no listada: {rtype} (vocabulario cerrado)")
+        if known_ids is not None and target and target not in known_ids:
+            errors.append(f"target inexistente: {target}")
+
+    if not errors:
+        return {"valid": True, "errors": [], "entity": data}
+    return {"valid": False, "errors": errors, "entity": data}
+
+
+def index_dir(directory: Path) -> dict:
+    """Indexa entidades de un directorio → grafo {id: {type, relations}}."""
+    graph: dict[str, dict] = {}
+    if not directory.exists():
+        return {"entities": graph, "count": 0}
+    for f in sorted(directory.rglob("*.md")):
+        if f.name.startswith("_"):
+            continue
+        text = f.read_text(encoding="utf-8")
+        data, _ = _parse_frontmatter(text)
+        # solo entidades válidas (id + type conocido); ignora README/templates/docs
+        if data and data.get("id") and data.get("type") in VALID_TYPES:
+            graph[data["id"]] = {
+                "type": data.get("type", ""),
+                "file": str(f),
+                "relations": data.get("relations", []) or [],
+            }
+    return {"entities": graph, "count": len(graph)}
+
+
+def query_uses_resource(graph: dict, resource_id: str) -> list[str]:
+    """¿Qué entidades usan el recurso X?"""
+    result = []
+    for eid, ent in graph.items():
+        for rel in ent.get("relations", []):
+            if rel.get("type") in ("UsesResource", "UsedByProject") and rel.get("target") == resource_id:
+                result.append(eid)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="org-registrar (SE-365)")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_val = sub.add_parser("validate", help="valida una entidad")
+    p_val.add_argument("--file", required=True)
+    p_val.add_argument("--known-ids", default="", help="ids separados por espacio")
+
+    p_idx = sub.add_parser("index", help="indexa un directorio a grafo")
+    p_idx.add_argument("--dir", required=True)
+    p_idx.add_argument("--json", action="store_true")
+
+    p_q = sub.add_parser("query", help="consulta el grafo")
+    p_q.add_argument("--graph", required=True, help="JSON del grafo (index --json)")
+    p_q.add_argument("--what", default="uses_resource")
+    p_q.add_argument("--id", required=True)
+
+    p_prop = sub.add_parser("propose", help="prepara una propuesta sin aplicarla")
+    p_prop.add_argument("--file", required=True)
+    p_prop.add_argument("--out", default="proposals/")
+
+    args = parser.parse_args()
+
+    if args.cmd == "validate":
+        known = set(args.known_ids.split()) if args.known_ids else None
+        res = validate(Path(args.file), known)
+        print(json.dumps(res, indent=2, ensure_ascii=False))
+        return 0 if res["valid"] else 2
+
+    if args.cmd == "index":
+        res = index_dir(Path(args.dir))
+        print(json.dumps(res, indent=2, ensure_ascii=False) if args.json else f"indexado: {res['count']} entidades")
+        return 0
+
+    if args.cmd == "query":
+        try:
+            graph = json.loads(Path(args.graph).read_text()).get("entities", {})
+        except Exception:
+            graph = {}
+        if args.what == "uses_resource":
+            result = query_uses_resource(graph, args.id)
+            print(json.dumps(result))
+        return 0
+
+    if args.cmd == "propose":
+        res = validate(Path(args.file))
+        out_dir = Path(args.out)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_file = out_dir / Path(args.file).name
+        out_file.write_text(Path(args.file).read_text(encoding="utf-8"), encoding="utf-8")
+        print(f"propuesta preparada en {out_file} — requiere confirmación humana (escritura mediada)")
+        return 0 if res["valid"] else 2
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/org-registrar.sh
+++ b/scripts/org-registrar.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# org-registrar.sh — SE-365: CLI del grafo organizacional (wrapper).
+# set -uo pipefail
+#
+# Envuelve org-registrar.py: validar entidades, indexar el grafo, consultar
+# dependencias, preparar propuestas (escritura mediada).
+#
+# Uso:
+#   org-registrar.sh validate --file entity.md
+#   org-registrar.sh index --dir . --json
+#   org-registrar.sh query --graph graph.json --what uses_resource --id X
+#   org-registrar.sh propose --file entity.md
+# Ref: SE-365 — Company as Code
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PY="${PYTHON:-python3}"
+
+exec "$PY" "$ROOT/scripts/org-registrar.py" "$@"

--- a/tests/bats/test-se365-org-registrar.bats
+++ b/tests/bats/test-se365-org-registrar.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+# test-se365-org-registrar.bats — BATS tests for SE-365 Company as Code
+# Ref: SE-365 — org-registrar, entidades, vocabulario de relaciones
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  REG="$REPO_ROOT/scripts/org-registrar.py"
+  export REPO_ROOT REG
+  export TEST_ORG="$(mktemp -d)"
+}
+
+teardown() {
+  if [[ -d "${TEST_ORG:-}" ]]; then
+    rm -rf "$TEST_ORG"
+  fi
+}
+
+@test "entidad piloto del repo es válida" {
+  run python3 "$REG" validate --file "$REPO_ROOT/org/company/policies/policy-soberania-datos.md"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "index del grafo piloto devuelve entidades" {
+  run python3 "$REG" index --dir "$REPO_ROOT/org/company" --json
+  [[ "$status" -eq 0 ]]
+  echo "$output" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert d['count'] >= 3, f'count={d[\"count\"]}'
+"
+}
+
+@test "query uses_resource encuentra el recurso" {
+  # grafo combinado: company + resources + projects
+  python3 - "$REPO_ROOT" "$TEST_ORG/graph.json" << 'PY'
+import json, subprocess, sys
+root, out = sys.argv[1], sys.argv[2]
+merged = {"entities": {}, "count": 0}
+for sub in ("org/company", "org/resources", "org/projects"):
+    r = json.loads(subprocess.run(
+        ["python3", f"{root}/scripts/org-registrar.py", "index", "--dir", f"{root}/{sub}", "--json"],
+        capture_output=True, text=True).stdout)
+    merged["entities"].update(r["entities"])
+    merged["count"] = len(merged["entities"])
+json.dump(merged, open(out, "w"))
+PY
+  run python3 "$REG" query --graph "$TEST_ORG/graph.json" --what uses_resource --id resource-gitlab-homelab
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"project-savia-federacion"* ]]
+}
+
+@test "propuesta de entidad inválida → exit != 0" {
+  local bad="$TEST_ORG/bad.md"
+  printf -- '---\nid: x\ntype: rocket\n---\n' > "$bad"
+  run python3 "$REG" propose --file "$bad" --out "$TEST_ORG/proposals"
+  [[ "$status" -ne 0 ]]
+}
+
+@test "propuesta válida genera diff sin aplicar" {
+  local good="$TEST_ORG/good.md"
+  cat > "$good" << 'EOF'
+---
+id: role-auditor
+type: role
+name: "Auditor/a"
+status: active
+origin: owner
+source: human
+---
+EOF
+  run python3 "$REG" propose --file "$good" --out "$TEST_ORG/proposals"
+  [[ "$status" -eq 0 ]]
+  [[ -f "$TEST_ORG/proposals/good.md" ]]
+  # la entidad NO se aplicó al grafo del repo (company/ no contiene role-auditor)
+  run python3 "$REG" index --dir "$REPO_ROOT/org/company" --json
+  echo "$output" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert 'role-auditor' not in d['entities'], 'no debe estar en el grafo real'
+"
+}

--- a/tests/scripts/test_org_registrar.py
+++ b/tests/scripts/test_org_registrar.py
@@ -1,0 +1,108 @@
+"""
+tests/scripts/test_org_registrar.py — pytest para SE-365 org-registrar validate.
+
+Cubre: validación de frontmatter común, vocabulario de relaciones cerrado,
+consistencia referencial, reglas de origin/source, escritura mediada.
+
+Ref: SE-365 — Company as Code
+"""
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "org-registrar.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("org_registrar", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def org():
+    return _load()
+
+
+def _write_entity(tmp_path, content):
+    p = tmp_path / "entity.md"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+VALID_ENTITY = """---
+id: role-arquitecto
+type: role
+name: "Arquitecto/a de Soluciones"
+status: active
+owner: person-monica
+relations:
+  - { type: BelongsToUnit, target: unit-consultoria }
+created: 2026-09-01
+updated: 2026-09-01
+origin: owner
+source: human
+---
+Contexto narrativo.
+"""
+
+
+def test_entidad_valida_pasa(org, tmp_path):
+    p = _write_entity(tmp_path, VALID_ENTITY)
+    res = org.validate(p)
+    assert res["valid"] is True, res["errors"]
+
+
+def test_type_invalido_rechazado(org, tmp_path):
+    content = VALID_ENTITY.replace("type: role", "type: rocket")
+    p = _write_entity(tmp_path, content)
+    res = org.validate(p)
+    assert res["valid"] is False
+    assert any("type" in e for e in res["errors"])
+
+
+def test_relacion_no_listada_rechazada(org, tmp_path):
+    content = VALID_ENTITY.replace("BelongsToUnit", "FliesToMoon")
+    p = _write_entity(tmp_path, content)
+    res = org.validate(p)
+    assert res["valid"] is False
+    assert any("relaci" in e.lower() or "FliesToMoon" in e for e in res["errors"])
+
+
+def test_consistencia_referencial_target_inexistente(org, tmp_path):
+    # entidad de ejemplo con target inexistente
+    p = _write_entity(tmp_path, VALID_ENTITY)
+    # se valida contra un índice sin ese target
+    res = org.validate(p, known_ids={"person-monica"})
+    assert res["valid"] is False
+    assert any("unit-consultoria" in e for e in res["errors"])
+
+
+def test_policy_requiere_origin_owner(org, tmp_path):
+    content = VALID_ENTITY.replace("type: role", "type: policy").replace(
+        "origin: owner", "origin: agent"
+    ).replace("source: human", "source: agent:org-registrar")
+    p = _write_entity(tmp_path, content)
+    res = org.validate(p)
+    # policy con origin agent → rechazada (políticas solo las declara origin: owner)
+    assert res["valid"] is False
+
+
+def test_resource_secret_sensitivity_rechazada(org, tmp_path):
+    content = """---
+id: resource-x
+type: resource
+category: infra
+name: "X"
+sensitivity: secret
+origin: owner
+source: human
+---
+"""
+    p = _write_entity(tmp_path, content)
+    res = org.validate(p)
+    assert res["valid"] is False  # sensitivity nunca "secret"


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este PR crea un estándar para representar la organización como código (Company as Code): roles, unidades, personas, políticas, proyectos y recursos se declaran como archivos Markdown con metadatos estructurados, versionados en git y consultables. Un nuevo "registrador de organización" valida que cada entidad cumpla el esquema, que las relaciones usen un vocabulario controlado y que las referencias existan. Las escrituras se proponen primero y requieren confirmación humana; la lectura es libre para los agentes. Incluye un grafo de ejemplo con las entidades del propio workspace y el estándar se añade al plan unificado de prioridades. Todo es local.

## Summary

feat(se365): company as code — estándar de entidades organizacionales + org-registrar

### Changes

- Spec SE-365 (renumerado de SE-265, colisión con court-model-tiers)
- `org-registrar.py`: validate/index/query/propose (escritura mediada)
- Grafo piloto `org/`: unit, person, policy, resource, project
- Skill org-registrar + roadmap Batch 8
- 6 pytest + 5 bats verdes

## Test plan

- [x] 6 pytest + 5 bats verdes
- [x] CI passed
- [x] Signed
## Summary
feat(se365): company as code
### Changes
- fbfb96b8 feat(se365): company as code — estándar de entidades organizacionales + org-registrar
### Stats
20 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed
