### PR TITLE
fix(hooks): block-branch-switch-dirty checks the repo the command targets, not the hook cwd

### DIFF
--- a/.claude/hooks/block-branch-switch-dirty.sh
+++ b/.claude/hooks/block-branch-switch-dirty.sh
@@ -16,16 +16,20 @@ if [[ ! -t 0 ]]; then
 fi
 [[ -z "$INPUT" ]] && exit 0
 
-# Extract command from hook JSON
-COMMAND=$(echo "$INPUT" | python3 -c "
+# Extract command + session cwd from hook JSON (two lines: command, cwd)
+PARSED=$(echo "$INPUT" | python3 -c "
 import sys, json
 d = json.load(sys.stdin)
-print(d.get('tool_input', {}).get('command', ''))
+cmd = d.get('tool_input', {}).get('command', '') or ''
+print(cmd.replace(chr(10), ' '))
+print(d.get('cwd', '') or '')
 " 2>/dev/null)
+COMMAND=$(echo "$PARSED" | sed -n '1p')
+SESSION_CWD=$(echo "$PARSED" | sed -n '2p')
 [[ -z "$COMMAND" ]] && exit 0
 
-# Only check git checkout/switch commands that change branch
-if ! echo "$COMMAND" | grep -qE 'git (checkout|switch)\s'; then
+# Only check git checkout/switch commands that change branch (also `git -C <dir> switch`)
+if ! echo "$COMMAND" | grep -qE 'git (-C\s+\S+\s+)?(checkout|switch)\s'; then
   exit 0
 fi
 
@@ -34,14 +38,40 @@ if echo "$COMMAND" | grep -qE 'git checkout\s+--\s'; then
   exit 0
 fi
 
-# Check for uncommitted changes (tracked + untracked)
-DIRTY=$(git status --porcelain 2>/dev/null | head -20)
+# Resolve the repo the command actually targets. The hook's own cwd is the
+# workspace, NOT necessarily the repo the command runs in (cd X && git switch).
+# Priority: `git -C <dir>` > leading `cd <dir> &&|;` > session cwd (hook JSON) > hook cwd.
+TARGET_DIR=""
+if [[ "$COMMAND" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]\;\&\|]+) ]]; then
+  TARGET_DIR="${BASH_REMATCH[1]}"
+elif [[ "$COMMAND" =~ (^|[[:space:]]|\&\&|\;)cd[[:space:]]+([^[:space:]\;\&\|]+)[[:space:]]*(\&\&|\;) ]]; then
+  TARGET_DIR="${BASH_REMATCH[2]}"
+elif [[ -n "$SESSION_CWD" ]]; then
+  TARGET_DIR="$SESSION_CWD"
+fi
+# Strip surrounding quotes, expand ~ / $HOME, resolve relative to session cwd
+TARGET_DIR="${TARGET_DIR%\"}"; TARGET_DIR="${TARGET_DIR#\"}"
+TARGET_DIR="${TARGET_DIR%\'}"; TARGET_DIR="${TARGET_DIR#\'}"
+TARGET_DIR="${TARGET_DIR/#\~/$HOME}"
+TARGET_DIR="${TARGET_DIR/#\$HOME/$HOME}"
+if [[ -n "$TARGET_DIR" && "$TARGET_DIR" != /* && -n "$SESSION_CWD" ]]; then
+  TARGET_DIR="$SESSION_CWD/$TARGET_DIR"
+fi
+[[ -z "$TARGET_DIR" ]] && TARGET_DIR="$PWD"
+[[ -d "$TARGET_DIR" ]] || exit 0
+
+# Not a git repo → nothing to protect
+TARGET_ROOT=$(git -C "$TARGET_DIR" rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Check for uncommitted changes (tracked + untracked) IN THE TARGET REPO
+DIRTY=$(git -C "$TARGET_DIR" status --porcelain 2>/dev/null | head -20)
 if [[ -n "$DIRTY" ]]; then
   TRACKED=$(echo "$DIRTY" | grep -cE '^ M| ^M|^MM|^A |^D ' || echo "0")
   UNTRACKED=$(echo "$DIRTY" | grep -c '^??' || echo "0")
 
   echo "BLOQUEADO: Cambio de rama con cambios sin commitear." >&2
   echo "" >&2
+  echo "  Repo: $TARGET_ROOT" >&2
   echo "  Ficheros modificados: $TRACKED" >&2
   echo "  Ficheros sin rastrear: $UNTRACKED" >&2
   echo "" >&2
@@ -55,8 +85,10 @@ fi
 
 # SE-300: clear stale per-branch PR summary on legitimate branch switch so a
 # previous PR's natural-language paragraph does not leak into the next PR body.
-if [[ -f "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/.pr-summary.md" ]]; then
-  rm -f "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/.pr-summary.md"
+# Only when the switch happens in THIS workspace — never touch another repo's state.
+WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+if [[ "$(cd "$TARGET_ROOT" && pwd -P)" == "$WORKSPACE_ROOT" && -f "$WORKSPACE_ROOT/.pr-summary.md" ]]; then
+  rm -f "$WORKSPACE_ROOT/.pr-summary.md"
 fi
 
 exit 0

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=9ab4a059a956f607f9c622b27db991a1bf6d63a30683f4d0e664856fa9b8a6d4
-timestamp=2026-09-03T07:20:24Z
+diff_hash=652040fa9d42d3bdf24a2726720a423b9426acb3dccc22684b9307c9ee9902fa
+timestamp=2026-09-03T07:29:26Z
 branch=fix/branch-switch-hook-target-repo
-head_commit=60cc4810
-signature=7e5ffba0e9c256726e5ec381359080cf68e9d165a91df4eb5e01e7c381430da5
+head_commit=95ec74d5
+signature=39f1e7c3e5ac005fb607e5d3b58d056717952737c059fd0a58b0fb0378e430e9

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=9b1aa9c0512b0cfdc01735761c9494804d5b283b2a7820554999fa524f1d0967
-timestamp=2026-09-03T07:18:52Z
+diff_hash=9ab4a059a956f607f9c622b27db991a1bf6d63a30683f4d0e664856fa9b8a6d4
+timestamp=2026-09-03T07:20:24Z
 branch=fix/branch-switch-hook-target-repo
-head_commit=d2aea674
-signature=541aeb8133c1b0cae61b6bb48af638f576f764b499c492a99425c7b53d8268d1
+head_commit=60cc4810
+signature=7e5ffba0e9c256726e5ec381359080cf68e9d165a91df4eb5e01e7c381430da5

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=95eb50af9fe88aec020269ae49c3fe34d9ffe27bd471dc6def9f74cf936db259
-timestamp=2026-09-02T20:37:16Z
-branch=agent/changelog-fix-20260902
-head_commit=b5933234
-signature=b2b59983da7ab82f17f0e89ccd2657e7b065a176483217f693b91d87c2c37096
+diff_hash=9b1aa9c0512b0cfdc01735761c9494804d5b283b2a7820554999fa524f1d0967
+timestamp=2026-09-03T07:18:52Z
+branch=fix/branch-switch-hook-target-repo
+head_commit=d2aea674
+signature=541aeb8133c1b0cae61b6bb48af638f576f764b499c492a99425c7b53d8268d1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13148,6 +13148,7 @@ Initial public release of PM-Workspace.
 
 - **Documentation** with methodology
 
+[6.16.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.16.0...v6.16.1
 [6.16.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.15.0...v6.16.0
 [6.15.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.3.0...v6.15.0
 [6.3.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.2.0...v6.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.16.1] — 2026-09-03
+
+### Fixed
+
+- block-branch-switch-dirty.sh: el hook comprobaba `git status` en su propio cwd (el workspace) y no en el repo destino del comando, así que un workspace sucio bloqueaba `cd otro-repo && git switch` en cualquier proyecto, y un repo destino sucio nunca se protegía. Ahora resuelve el repo destino (`git -C <dir>` > `cd <dir> &&` > `cwd` del JSON del hook), intercepta también `git -C <dir> switch|checkout`, nombra el repo en el mensaje de bloqueo y limita el borrado SE-300 de `.pr-summary.md` al propio workspace. 9 tests BATS nuevos (8 en rojo con el hook anterior).
+
 ## [6.16.0] — 2026-09-02
 
 ### Added

--- a/tests/test-block-branch-switch-dirty.bats
+++ b/tests/test-block-branch-switch-dirty.bats
@@ -227,6 +227,116 @@ setup_clean_repo() {
   cd "$BATS_TEST_DIRNAME/.."
 }
 
+# ── Target repo resolution (bug: hook cwd != command cwd) ──────────
+# The hook runs with cwd = workspace (repo A). When the command targets another
+# repo (cd B && git switch / git -C B switch / session cwd = B), the dirty check
+# MUST run against B, not A.
+# NOTE: assertions use [ ] / grep (not [[ ]]) so they also fail under bash 3.2 (macOS).
+
+setup_second_repo() {
+  OTHER_REPO=$(mktemp -d "$TMPDIR/bbsd-other-XXXXXX")
+  ( cd "$OTHER_REPO" && git init -q -b main 2>/dev/null || git init -q
+    git config user.email "t@t" && git config user.name "t"
+    echo "b" > b.txt && git add b.txt && git commit -qm "init" && git branch feature )
+}
+
+@test "target: cd B && git switch — A dirty, B clean → exits 0" {
+  setup_clean_repo
+  echo "dirty A" > a.txt
+  setup_second_repo
+  run bash "$HOOK_ABS" <<< "{\"tool_input\":{\"command\":\"cd $OTHER_REPO && git switch -c nueva\"}}"
+  [ "$status" -eq 0 ]
+  rm -rf "$OTHER_REPO"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "target: cd B && git switch — A clean, B dirty → exits 2" {
+  setup_clean_repo
+  setup_second_repo
+  echo "dirty B" > "$OTHER_REPO/b.txt"
+  run bash "$HOOK_ABS" <<< "{\"tool_input\":{\"command\":\"cd $OTHER_REPO && git switch feature\"}}"
+  [ "$status" -eq 2 ]
+  echo "${output}${stderr:-}" | grep -q "BLOQUEADO"
+  rm -rf "$OTHER_REPO"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "target: git -C B switch — A dirty, B clean → exits 0" {
+  setup_clean_repo
+  echo "dirty A" > a.txt
+  setup_second_repo
+  run bash "$HOOK_ABS" <<< "{\"tool_input\":{\"command\":\"git -C $OTHER_REPO switch feature\"}}"
+  [ "$status" -eq 0 ]
+  rm -rf "$OTHER_REPO"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "target: git -C B switch — B dirty → exits 2 (git -C is intercepted)" {
+  setup_clean_repo
+  setup_second_repo
+  echo "dirty B" > "$OTHER_REPO/b.txt"
+  run bash "$HOOK_ABS" <<< "{\"tool_input\":{\"command\":\"git -C $OTHER_REPO switch feature\"}}"
+  [ "$status" -eq 2 ]
+  rm -rf "$OTHER_REPO"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "target: session cwd = B (hook JSON cwd) — A dirty, B clean → exits 0" {
+  setup_clean_repo
+  echo "dirty A" > a.txt
+  setup_second_repo
+  run bash "$HOOK_ABS" <<< "{\"cwd\":\"$OTHER_REPO\",\"tool_input\":{\"command\":\"git switch feature\"}}"
+  [ "$status" -eq 0 ]
+  rm -rf "$OTHER_REPO"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "target: session cwd = B dirty → exits 2 even if hook cwd A is clean" {
+  setup_clean_repo
+  setup_second_repo
+  echo "dirty B" > "$OTHER_REPO/b.txt"
+  run bash "$HOOK_ABS" <<< "{\"cwd\":\"$OTHER_REPO\",\"tool_input\":{\"command\":\"git switch feature\"}}"
+  [ "$status" -eq 2 ]
+  rm -rf "$OTHER_REPO"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "target: cd to non-git dir && git switch → exits 0 (nothing to protect)" {
+  setup_clean_repo
+  echo "dirty A" > a.txt
+  NOGIT=$(mktemp -d "$TMPDIR/bbsd-nogit-XXXXXX")
+  run bash "$HOOK_ABS" <<< "{\"tool_input\":{\"command\":\"cd $NOGIT && git switch feature\"}}"
+  [ "$status" -eq 0 ]
+  rm -rf "$NOGIT"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "target: block message names the repo that is dirty" {
+  setup_clean_repo
+  setup_second_repo
+  echo "dirty B" > "$OTHER_REPO/b.txt"
+  run bash "$HOOK_ABS" <<< "{\"tool_input\":{\"command\":\"cd $OTHER_REPO && git switch feature\"}}"
+  [ "$status" -eq 2 ]
+  echo "${output}${stderr:-}" | grep -q "Repo:"
+  rm -rf "$OTHER_REPO"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "target: SE-300 .pr-summary.md NOT deleted when switching in another repo" {
+  setup_clean_repo
+  setup_second_repo
+  # workspace = dir containing the hook's ../.. (the test checkout)
+  WS="$(cd "$(dirname "$HOOK_ABS")/../.." && pwd -P)"
+  local had=0; [[ -f "$WS/.pr-summary.md" ]] && had=1
+  [[ $had -eq 0 ]] && echo "sentinel" > "$WS/.pr-summary.md"
+  run bash "$HOOK_ABS" <<< "{\"tool_input\":{\"command\":\"cd $OTHER_REPO && git switch feature\"}}"
+  [ "$status" -eq 0 ]
+  [ -f "$WS/.pr-summary.md" ]
+  [[ $had -eq 0 ]] && rm -f "$WS/.pr-summary.md"
+  rm -rf "$OTHER_REPO"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
 # ── Edge cases ─────────────────────────────────────────
 
 @test "edge: very large dirty tree (>20 files) listed truncated" {


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Savia tiene una protección que impide cambiar de rama en git cuando hay cambios sin guardar, para que no se pierda trabajo. Hasta ahora esa protección miraba siempre el estado del workspace de Savia, aunque el comando de git se estuviera ejecutando en otro repositorio distinto. Resultado: si el workspace de Savia tenía algún fichero modificado (algo habitual, por ejemplo con ajustes personales), cualquier cambio de rama en cualquier otro proyecto quedaba bloqueado con un mensaje que hablaba de ficheros que ni siquiera pertenecían a ese proyecto. Y al revés: si el otro proyecto sí tenía cambios sin guardar pero el workspace estaba limpio, la protección no saltaba y se podía perder trabajo.

A partir de este cambio, la protección comprueba el repositorio sobre el que actúa realmente el comando: el que se indica con un `cd` previo, el que se pasa a git como directorio de trabajo, o el directorio actual de la sesión. Si ese repositorio está limpio, el cambio de rama pasa. Si está sucio, se bloquea, y el mensaje ahora dice de qué repositorio se trata. Si el destino no es un repositorio git, no hay nada que proteger y se deja pasar.

Además, el borrado del resumen de PR pendiente (que se limpia al cambiar de rama para que no se cuele en el siguiente PR) ahora solo ocurre cuando el cambio de rama es en el propio workspace de Savia, nunca cuando se cambia de rama en otro proyecto.

Riesgo abierto: la detección del directorio destino se basa en leer el texto del comando; construcciones poco habituales (varios `cd` encadenados, subshells) se resuelven con el directorio de la sesión, que es el comportamiento anterior. No hay nada que activar ni desactivar: el cambio sustituye al comportamiento anterior.

## Summary

- `block-branch-switch-dirty.sh` resolves the target repo from `git -C <dir>`, a leading `cd <dir> &&|;`, or the hook JSON `cwd`, and runs `git status` there instead of in the hook's cwd (the workspace).
- `git -C <dir> switch|checkout` is now intercepted (previously passed through unchecked).
- Block message includes `Repo: <path>`.
- SE-300 `.pr-summary.md` cleanup only fires when the switch happens in the workspace itself.
- 9 new BATS cases (`target:` section) reproducing the bug: 8/9 fail on the old hook, 45/45 pass on the new one. Assertions use `[ ]`/`grep` so they also fail under bash 3.2 (macOS), where `[[ ]]` failures are not caught by bats.

## Verification

- `npx bats tests/test-block-branch-switch-dirty.bats` → 45/45 on macOS (bash 3.2).
- Old hook against the new tests → 8 failures in the `target:` section (red/green confirmed).
- Direct invocation with the workspace dirty (3 files) and Claude Code-shaped JSON (`cwd` + `tool_input.command`): `cd <cleanRepo> && git switch` → exit 0; same with dirty target → blocked naming the target; no `cd` + dirty session cwd → blocked; multi-line command with `cd` on the second line → resolved correctly.
- Not verified: the hook swapped in place inside a live Claude Code session (blocked by the auto-mode classifier); the invocation above mirrors the hook contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbzhbasC7cS9P8hUYTtMLi
