### PR TITLE
fix(hooks): block-branch-switch-dirty resolves the target from the switch invocation itself

### DIFF
--- a/.claude/hooks/block-branch-switch-dirty.sh
+++ b/.claude/hooks/block-branch-switch-dirty.sh
@@ -28,36 +28,56 @@ COMMAND=$(echo "$PARSED" | sed -n '1p')
 SESSION_CWD=$(echo "$PARSED" | sed -n '2p')
 [[ -z "$COMMAND" ]] && exit 0
 
-# Only check git checkout/switch commands that change branch (also `git -C <dir> switch`)
-if ! echo "$COMMAND" | grep -qE 'git (-C\s+\S+\s+)?(checkout|switch)\s'; then
+# Locate the branch-changing invocation itself: `git [-C <dir>] (checkout|switch) <args>`.
+# Only THAT invocation's -C counts — a foreign `git -C X status` elsewhere in the
+# command must not decide the target repo.
+if ! [[ "$COMMAND" =~ (^|[^[:alnum:]_./-])git[[:space:]]+(-C[[:space:]]+([^[:space:]\;\&\|]+)[[:space:]]+)?(checkout|switch)[[:space:]]+(.*) ]]; then
+  exit 0
+fi
+GIT_C_DIR="${BASH_REMATCH[3]}"
+GIT_SUBCMD="${BASH_REMATCH[4]}"
+GIT_ARGS="${BASH_REMATCH[5]}"
+PREFIX="${COMMAND%%"${BASH_REMATCH[0]}"*}"   # text before the git invocation
+
+# Skip file restores (git checkout -- file), also with -C
+if [[ "$GIT_SUBCMD" == "checkout" && "$GIT_ARGS" =~ ^--([[:space:]]|$) ]]; then
   exit 0
 fi
 
-# Skip file restores (git checkout -- file)
-if echo "$COMMAND" | grep -qE 'git checkout\s+--\s'; then
-  exit 0
-fi
+# Last `cd <dir> &&|;` BEFORE the git invocation (cd A && cd B && git switch → B)
+CD_DIR=""
+REST="$PREFIX"
+while [[ "$REST" =~ (^|[[:space:]]|\&\&|\;)cd[[:space:]]+([^[:space:]\;\&\|]+)[[:space:]]*(\&\&|\;)(.*)$ ]]; do
+  CD_DIR="${BASH_REMATCH[2]}"
+  REST="${BASH_REMATCH[4]}"
+done
 
 # Resolve the repo the command actually targets. The hook's own cwd is the
 # workspace, NOT necessarily the repo the command runs in (cd X && git switch).
-# Priority: `git -C <dir>` > leading `cd <dir> &&|;` > session cwd (hook JSON) > hook cwd.
+# Priority: -C of the invocation > last cd before it > session cwd (hook JSON) > hook cwd.
+FALLBACK_DIR="${SESSION_CWD:-$PWD}"
 TARGET_DIR=""
-if [[ "$COMMAND" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]\;\&\|]+) ]]; then
-  TARGET_DIR="${BASH_REMATCH[1]}"
-elif [[ "$COMMAND" =~ (^|[[:space:]]|\&\&|\;)cd[[:space:]]+([^[:space:]\;\&\|]+)[[:space:]]*(\&\&|\;) ]]; then
-  TARGET_DIR="${BASH_REMATCH[2]}"
-elif [[ -n "$SESSION_CWD" ]]; then
-  TARGET_DIR="$SESSION_CWD"
+if [[ -n "$GIT_C_DIR" ]]; then
+  TARGET_DIR="$GIT_C_DIR"
+elif [[ -n "$CD_DIR" ]]; then
+  TARGET_DIR="$CD_DIR"
 fi
 # Strip surrounding quotes, expand ~ / $HOME, resolve relative to session cwd
 TARGET_DIR="${TARGET_DIR%\"}"; TARGET_DIR="${TARGET_DIR#\"}"
 TARGET_DIR="${TARGET_DIR%\'}"; TARGET_DIR="${TARGET_DIR#\'}"
 TARGET_DIR="${TARGET_DIR/#\~/$HOME}"
 TARGET_DIR="${TARGET_DIR/#\$HOME/$HOME}"
-if [[ -n "$TARGET_DIR" && "$TARGET_DIR" != /* && -n "$SESSION_CWD" ]]; then
-  TARGET_DIR="$SESSION_CWD/$TARGET_DIR"
+# Anything we cannot expand statically ($VAR, $(...), backticks) → conservative fallback
+if [[ "$TARGET_DIR" == *'$'* || "$TARGET_DIR" == *'`'* ]]; then
+  TARGET_DIR=""
 fi
-[[ -z "$TARGET_DIR" ]] && TARGET_DIR="$PWD"
+if [[ -n "$TARGET_DIR" && "$TARGET_DIR" != /* ]]; then
+  TARGET_DIR="$FALLBACK_DIR/$TARGET_DIR"
+fi
+# Unresolvable or non-existent target → fall back to the session cwd, never pass through
+if [[ -z "$TARGET_DIR" || ! -d "$TARGET_DIR" ]]; then
+  TARGET_DIR="$FALLBACK_DIR"
+fi
 [[ -d "$TARGET_DIR" ]] || exit 0
 
 # Not a git repo → nothing to protect
@@ -66,8 +86,9 @@ TARGET_ROOT=$(git -C "$TARGET_DIR" rev-parse --show-toplevel 2>/dev/null) || exi
 # Check for uncommitted changes (tracked + untracked) IN THE TARGET REPO
 DIRTY=$(git -C "$TARGET_DIR" status --porcelain 2>/dev/null | head -20)
 if [[ -n "$DIRTY" ]]; then
-  TRACKED=$(echo "$DIRTY" | grep -cE '^ M| ^M|^MM|^A |^D ' || echo "0")
-  UNTRACKED=$(echo "$DIRTY" | grep -c '^??' || echo "0")
+  # grep -c prints the count even when it is 0 (and exits 1) — never append a second "0"
+  TRACKED=$(echo "$DIRTY" | grep -cE '^ M| ^M|^MM|^A |^D ' || true)
+  UNTRACKED=$(echo "$DIRTY" | grep -c '^??' || true)
 
   echo "BLOQUEADO: Cambio de rama con cambios sin commitear." >&2
   echo "" >&2

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=8ae5e85c993081611ba5adf971779588f39915226bd019a6aeb26cad749fa9ab
-timestamp=2026-09-03T20:07:02Z
-branch=agent/se371-cache-hygiene
-head_commit=575d8612
-signature=ef49a992a0438f81efb3ced0b4c88189c373b7044ee7777622a999f894b69e01
+diff_hash=3edcb66597ccefc2ee2a8acef90bda1d6fa217036245ec8f7977be3a02d9c735
+timestamp=2026-09-03T20:22:31Z
+branch=fix/branch-switch-hook-target-resolution
+head_commit=c8679e82
+signature=7542438c4e0e4ec3a8e028d039ce2c81b0f95a44507c9d671a5121f42e51f0fb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.17.7] — 2026-09-03
+
+### Fixed
+
+- block-branch-switch-dirty.sh (seguimiento de #1066): la resolución del repo destino tenía tres huecos vistos en prueba real. (1) `cd $VAR && git …` con la variable sin expandir, o un directorio inexistente, dejaba pasar el cambio de rama sin comprobar nada; ahora cae al cwd de la sesión. (2) Cualquier `git -C <dir>` en el comando (p. ej. dentro de un `echo $(...)`) decidía el destino aunque no fuera el del cambio de rama; ahora solo cuenta el `-C` de la propia invocación, y si no lo hay, el último `cd` anterior a ella. (3) La restauración de fichero con `--` no estaba exenta cuando iba precedida de `-C`. También se elimina la línea `0` suelta del mensaje de bloqueo (doble conteo de `grep -c`). 9 tests BATS nuevos (7 en rojo con el hook anterior).
+
 ## [6.17.6] — 2026-09-03
 
 ### Added
@@ -13181,6 +13187,7 @@ Initial public release of PM-Workspace.
 
 - **Documentation** with methodology
 
+[6.17.7]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.6...v6.17.7
 [6.17.6]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.5...v6.17.6
 [6.17.5]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.4...v6.17.5
 [6.17.4]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.3...v6.17.4

--- a/tests/test-block-branch-switch-dirty.bats
+++ b/tests/test-block-branch-switch-dirty.bats
@@ -227,6 +227,97 @@ setup_clean_repo() {
   cd "$BATS_TEST_DIRNAME/.."
 }
 
+# ── Target resolution edge cases (follow-up to PR #1066) ──────────
+# (a) unexpandable cd target ($VAR) must fall back to the session cwd, never pass through;
+# (b) only the -C of the checkout/switch invocation counts, not a foreign `git -C X status`;
+# (c) `git -C dir checkout -- file` is a restore and is exempt;
+# (d) the last cd before the git invocation wins; (e) no stray "0" line in the block message.
+
+@test "resolution: cd \$UNSET && git switch — session cwd dirty → exits 2 (no pass-through)" {
+  setup_clean_repo
+  echo "dirty A" > a.txt
+  run bash "$HOOK_ABS" <<< "{\"cwd\":\"$TEST_REPO\",\"tool_input\":{\"command\":\"cd \$B && git switch feature\"}}"
+  [ "$status" -eq 2 ]
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "resolution: cd \$UNSET && git switch — session cwd clean → exits 0" {
+  setup_clean_repo
+  run bash "$HOOK_ABS" <<< "{\"cwd\":\"$TEST_REPO\",\"tool_input\":{\"command\":\"cd \$B && git switch feature\"}}"
+  [ "$status" -eq 0 ]
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "resolution: cd to non-existent dir && git switch — session cwd dirty → exits 2" {
+  setup_clean_repo
+  echo "dirty A" > a.txt
+  run bash "$HOOK_ABS" <<< "{\"cwd\":\"$TEST_REPO\",\"tool_input\":{\"command\":\"cd /nonexistent/dir/xyz && git switch feature\"}}"
+  [ "$status" -eq 2 ]
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "resolution: foreign git -C A status before cd B && git switch — A dirty, B clean → exits 0" {
+  setup_clean_repo
+  echo "dirty A" > a.txt
+  setup_second_repo
+  run bash "$HOOK_ABS" <<< "{\"tool_input\":{\"command\":\"echo \$(git -C $TEST_REPO status --short); cd $OTHER_REPO && git switch feature\"}}"
+  [ "$status" -eq 0 ]
+  rm -rf "$OTHER_REPO"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "resolution: cd B && git switch; git -C A status after — A dirty, B clean → exits 0" {
+  setup_clean_repo
+  echo "dirty A" > a.txt
+  setup_second_repo
+  run bash "$HOOK_ABS" <<< "{\"tool_input\":{\"command\":\"cd $OTHER_REPO && git switch feature && git -C $TEST_REPO status\"}}"
+  [ "$status" -eq 0 ]
+  rm -rf "$OTHER_REPO"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "resolution: git -C B checkout -- file is a restore → exits 0 even with B dirty" {
+  setup_clean_repo
+  setup_second_repo
+  echo "dirty B" > "$OTHER_REPO/b.txt"
+  run bash "$HOOK_ABS" <<< "{\"tool_input\":{\"command\":\"git -C $OTHER_REPO checkout -- b.txt\"}}"
+  [ "$status" -eq 0 ]
+  rm -rf "$OTHER_REPO"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "resolution: cd A && cd B && git switch — last cd wins (A dirty, B clean) → exits 0" {
+  setup_clean_repo
+  echo "dirty A" > a.txt
+  setup_second_repo
+  run bash "$HOOK_ABS" <<< "{\"tool_input\":{\"command\":\"cd $TEST_REPO && cd $OTHER_REPO && git switch feature\"}}"
+  [ "$status" -eq 0 ]
+  rm -rf "$OTHER_REPO"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "resolution: cd A && cd B && git switch — last cd wins (A clean, B dirty) → exits 2" {
+  setup_clean_repo
+  setup_second_repo
+  echo "dirty B" > "$OTHER_REPO/b.txt"
+  run bash "$HOOK_ABS" <<< "{\"tool_input\":{\"command\":\"cd $TEST_REPO && cd $OTHER_REPO && git switch feature\"}}"
+  [ "$status" -eq 2 ]
+  rm -rf "$OTHER_REPO"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "resolution: block message has no stray '0' line (grep -c double count)" {
+  setup_clean_repo
+  echo "modified" > a.txt
+  run bash "$HOOK_ABS" <<< '{"tool_input":{"command":"git checkout feature"}}'
+  [ "$status" -eq 2 ]
+  # `! cmd` is exempt from errexit — count explicitly so the assertion really fails
+  [ "$(echo "${output}${stderr:-}" | grep -cx '0')" -eq 0 ]
+  echo "${output}${stderr:-}" | grep -q "Ficheros modificados: 1"
+  echo "${output}${stderr:-}" | grep -q "Ficheros sin rastrear: 0"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
 # ── Target repo resolution (bug: hook cwd != command cwd) ──────────
 # The hook runs with cwd = workspace (repo A). When the command targets another
 # repo (cd B && git switch / git -C B switch / session cwd = B), the dirty check


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Es la continuación del cambio que se mergeó esta tarde (#1066) en la protección que impide cambiar de rama con trabajo sin guardar. Al probar esa protección en una sesión real aparecieron tres situaciones en las que decidía mal a qué repositorio mirar. Primera: si el comando usaba una variable para indicar la carpeta (por ejemplo `cd $CARPETA`), o una carpeta que no existe, la protección no encontraba nada que comprobar y dejaba pasar el cambio de rama sin mirar. Ahora, cuando no puede saber a qué carpeta va el comando, comprueba la carpeta en la que está la sesión, que es lo más conservador. Segunda: si en el mismo comando había otra orden de git dirigida a otro repositorio (por ejemplo, consultar el estado del workspace antes de cambiar de rama en otro proyecto), esa otra orden decidía el destino y podía bloquear por el repositorio equivocado. Ahora solo cuenta la carpeta de la propia orden de cambio de rama y, si no la indica, la última carpeta a la que se entró antes de ella. Tercera: restaurar un fichero indicando la carpeta del repositorio se trataba como un cambio de rama y se bloqueaba; ahora se reconoce como restauración y se deja pasar, igual que ya ocurría sin indicar carpeta.

También se corrige un detalle visual: el mensaje de bloqueo mostraba una línea con un `0` suelto cuando no había ficheros sin rastrear.

Riesgo abierto: la detección sigue basándose en leer el texto del comando. Construcciones más raras (subshells con `cd` dentro, funciones) se resuelven con la carpeta de la sesión, que es el comportamiento seguro por defecto. No hay nada que activar ni desactivar.

## Summary

- Match the branch-changing invocation itself (`git [-C <dir>] (checkout|switch)`), so only its `-C` decides the target; otherwise the last `cd <dir> &&|;` before it; otherwise the hook JSON `cwd`.
- Unexpandable (`$VAR`, backticks) or non-existent targets fall back to the session cwd instead of passing through.
- `git -C <dir> checkout -- <file>` is exempt as a restore.
- Block message no longer prints a stray `0` line (`grep -c` already prints the count when it is 0).
- 9 new BATS cases (`resolution:` section): 7 fail on the current hook, 54/54 pass on the new one. Assertions avoid `[[ ]]` and `! cmd`, which bats does not catch under bash 3.2 (macOS).

## Verification

- `npx bats tests/test-block-branch-switch-dirty.bats` → 54/54 (macOS, bash 3.2).
- Current hook against the new tests → 7 failures in `resolution:` (red/green confirmed).
- Direct invocation with Claude Code-shaped JSON (`cwd` = dirty workspace): `cd $B && git switch` → blocked on the workspace (was pass-through); `echo $(git -C <workspace> status); cd <cleanRepo> && git switch` → exit 0 (was blocked on the workspace); `git -C <dirtyRepo> checkout -- file` → exit 0 (was blocked); `cd <dirtyRepo> && git switch` → blocked naming that repo; block output has no `0` line.
- Not verified in-place inside a live Claude Code session: the live hook is still the #1066 version until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbzhbasC7cS9P8hUYTtMLi
