### PR TITLE
feat(scripts): SE-371 cache hygiene y metricas de prefijo

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=b28da01b652551f954b16f11a0c6f9bddf731032e34df5993411d167c14feb63
-timestamp=2026-09-03T19:56:18Z
-branch=agent/overnight-20260902-l28-harness-map-ablation
-head_commit=f53bcb4f
-signature=e6009af10a80855220d5cfaaa7a379cb0aba21da4b23177d1adf9d90eb2f656b
+diff_hash=8ae5e85c993081611ba5adf971779588f39915226bd019a6aeb26cad749fa9ab
+timestamp=2026-09-03T20:07:02Z
+branch=agent/se371-cache-hygiene
+head_commit=575d8612
+signature=ef49a992a0438f81efb3ced0b4c88189c373b7044ee7777622a999f894b69e01

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: ae5a60dcd888 | resources: 1438
-> 295 commands · 134 skills · 88 agents · 921 scripts
+> hash: d94c77dd4b05 | resources: 1440
+> 295 commands · 134 skills · 88 agents · 923 scripts
 
 [analysis] Trace Optimize — across,distributed,optimize,rates,sampling — cmd:.claude/commands/trace-optimize.md
 [analysis] agent-activity — activity,agent,executions,recent,show — cmd:.claude/commands/agent-activity.md
@@ -445,6 +445,8 @@
 [governance] vertical-legal — compliance,contract,ediscovery,extensión,gdpr — cmd:.claude/commands/vertical-legal.md
 [memory] auto-compact — auto,automáticamente,compact,contexto,disparado — script:scripts/auto-compact.sh
 [memory] cache-analytics — ahorrados,ahorro,costes,latencia,métricas — cmd:.claude/commands/cache-analytics.md
+[memory] cache-hygiene — cache,caching,disciplina,hygiene,prefijo — script:scripts/cache-hygiene.sh
+[memory] cache-metrics — cache,ledger,local,metrics,métricas — script:scripts/cache-metrics.sh
 [memory] changelog-consolidate — changelog,consolidate,fragments — script:scripts/changelog-consolidate.sh
 [memory] changelog-consolidate-if-needed — automation,changelog,consolidate,merge,needed — script:scripts/changelog-consolidate-if-needed.sh
 [memory] coherence-court-orchestrator — applies,coherence,consolidates,convenes,court — agent:.opencode/agents/coherence-court-orchestrator.md

--- a/.scm/categories/memory.scm
+++ b/.scm/categories/memory.scm
@@ -1,8 +1,10 @@
 # memory — Savia Capability Map (L1)
-> 110 resources
+> 112 resources
 
 - **auto-compact** (script): auto-compact.sh — Disparado automáticamente cuando contexto > 85%
 - **cache-analytics** (cmd): Métricas de hit rate, tokens ahorrados, latencia, ahorro de costes
+- **cache-hygiene** (script): cache-hygiene.sh — SE-371: disciplina de prefijo para prompt caching.
+- **cache-metrics** (script): cache-metrics.sh — SE-371: ledger local de métricas de prompt cache.
 - **changelog-consolidate** (script): changelog-consolidate.sh — consolidate CHANGELOG.d/*.md fragments into
 - **changelog-consolidate-if-needed** (script): changelog-consolidate-if-needed.sh — SE-053 Slice 1 post-merge automation.
 - **coherence-court-orchestrator** (agent): Convenes the Coherence Court, consolidates .coherence.crc, applies human gate

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "60cfffde439c",
-  "total": 1438,
+  "hash": "c9fa20e5a965",
+  "total": 1440,
   "resources": [
     {
       "category": "analysis",
@@ -5891,6 +5891,34 @@
       "kind": "cmd",
       "path": ".claude/commands/cache-analytics.md",
       "description": "Métricas de hit rate, tokens ahorrados, latencia, ahorro de costes"
+    },
+    {
+      "category": "memory",
+      "name": "cache-hygiene",
+      "intents": [
+        "cache",
+        "caching",
+        "disciplina",
+        "hygiene",
+        "prefijo"
+      ],
+      "kind": "script",
+      "path": "scripts/cache-hygiene.sh",
+      "description": "cache-hygiene.sh — SE-371: disciplina de prefijo para prompt caching."
+    },
+    {
+      "category": "memory",
+      "name": "cache-metrics",
+      "intents": [
+        "cache",
+        "ledger",
+        "local",
+        "metrics",
+        "métricas"
+      ],
+      "kind": "script",
+      "path": "scripts/cache-metrics.sh",
+      "description": "cache-metrics.sh — SE-371: ledger local de métricas de prompt cache."
     },
     {
       "category": "memory",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.17.6] — 2026-09-03
+
+### Added
+- SE-371 Cache Hygiene: snapshot/check del prefijo de instrucciones, congelacion de auto-regenerados AGENTS/SKILLS en sesion activa, ledger local de metricas de cache (hit rate) y MEMORY.md fuera del prefijo.
+
 ## [6.17.5] — 2026-09-03
 
 ### Added
@@ -13176,6 +13181,7 @@ Initial public release of PM-Workspace.
 
 - **Documentation** with methodology
 
+[6.17.6]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.5...v6.17.6
 [6.17.5]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.4...v6.17.5
 [6.17.4]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.3...v6.17.4
 [6.17.3]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.2...v6.17.3

--- a/config/cache-prefix.txt
+++ b/config/cache-prefix.txt
@@ -1,0 +1,17 @@
+# config/cache-prefix.txt — orden canónico del prefijo de instrucciones (SE-371)
+# Un path por línea. Cada fichero se carga estable en cada turno (OpenCode
+# instructions + Claude Code @imports/CLAUDE.md). El orden NO debe cambiar sin
+# revisión: cualquier mutación a mitad de sesión invalida el prompt cache.
+# NOTA: MEMORY.md NO está en el prefijo (estado mutable, se consolida por save).
+# Regenerado/validado por scripts/cache-hygiene.sh --validate.
+AGENTS.md
+SKILLS.md
+CLAUDE.md
+.claude/profiles/savia.md
+.claude/profiles/active-user.md
+docs/rules/domain/radical-honesty.md
+docs/rules/domain/autonomous-safety.md
+docs/rules/domain/caveman-default.md
+docs/rules/domain/agents-catalog.md
+.claude/CONSTITUCION.md
+docs/critical-facts.md

--- a/docs/propuestas/ROADMAP-UNIFIED-20260827.md
+++ b/docs/propuestas/ROADMAP-UNIFIED-20260827.md
@@ -68,7 +68,8 @@ empezar ya.
 | Batch 6 — L27 | 🔶 E3/E5 gate PASS + E13 auditor + E14 matriz · **E12 Piloto 1 pendiente (VASS obviado)** | #1033 #1034 |
 | Batch 7 — verticales | ⏳ L24/L25/L12/L9 | — |
 | **Batch 8 — SE-365 Company as Code** | 🔶 estándar de entidades organizacionales (renumerado de SE-265) — en implementación | — |
-| **Batch 9 — SE-366..370 (verificación, temporalidad, contratos)** | 🟡 5 specs PROPOSED (análisis open-source 2026-09-02) — esperan aprobación | — |
+| **Batch 9 — SE-366..370 (verificación, temporalidad, contratos)** | ✅ SE-366 ledger bitemporal (#1069) · SE-367 derivation path (#1070) · SE-369 contract pins (#1072) · SE-370 research lane (#1067) · SE-368 pendiente | #1067 #1069 #1070 #1072 |
+| **Batch 10 — SE-371 cache hygiene (nuevo, 2026-09-03)** | 🔶 spec APPROVED — snapshot prefijo + congelación auto-regenerados + métricas cache locales | — |
 | Track B — SE-347 | 🔶 evaluado **RE-EVALUAR** (S3 bloqueado por modelo local ≥8B) | #1027 |
 | SE-348 activaciones | ✅ vector + Shield NER + router SE-346 + hook FxC · ⏳ sandbox (sudo) · ⏳ modelo ≥8B (hardware) | #1031 |
 

--- a/docs/specs/SE-371-cache-hygiene.spec.md
+++ b/docs/specs/SE-371-cache-hygiene.spec.md
@@ -1,0 +1,135 @@
+# SE-371 — Cache Hygiene + Métricas: disciplina de prefijo para prompt caching
+
+**Status:** APPROVED (2026-09-03, orden operadora: implementar mejoras de caché)
+**Fecha:** 2026-09-03
+**Área:** Contexto / Coste / Rendimiento
+**Fuente de inspiración:** análisis de caché 2026-09-03 (artículo Daniel Ávila + aider `--cache-keepalive` + OpenCode rules estáticas) → diagnóstico de Savia (MEMORY.md en prefijo mutable, auto-regenerados AGENTS/SKILLS a mitad de sesión, multi-modelo, cero métricas).
+**Criterio humano aplicable:** CRIT-001 (todo local; métricas y snapshots locales; cero egress).
+
+---
+
+## 1. Motivación
+
+El prompt cache del provider es **prefijo-exacto**: un byte distinto en el prefijo invalida el cache desde ese punto. Savia monta un prefijo de instrucciones estable (11 ficheros en `opencode.json` + 6 @imports de CLAUDE.md), pero tres mecánicas lo rompen sin que nadie lo detecte:
+
+1. `MEMORY.md` (estado mutable, se consolida con cada `save`) está en el prefijo de `instructions`.
+2. `AGENTS.md`/`SKILLS.md` se auto-regeneran a mitad de sesión por hooks → el prefijo cambia entre turnos.
+3. Cero métricas de cache: no se sabe hit rate ni coste de invalidación.
+
+Sin higiene ni métrica no hay gestión. Esta spec entrega la **disciplina medible**: snapshot del prefijo al inicio de sesión, detector de mutación entre turnos, congelación de auto-regenerados durante sesiones activas, y un ledger local de métricas de cache consumible por sesión.
+
+## 2. Alcance
+
+**Dentro:**
+- Manifest del orden canónico del prefijo (`config/cache-prefix.txt`) verificable.
+- `scripts/cache-hygiene.sh`: `snapshot` (guarda hashes del prefijo), `check` (detecta mutación → avisa qué fichero), `--validate` (manifest coherente con `opencode.json`).
+- Guard de congelación en los auto-regeneradores (`SAVIA_SESSION_ACTIVE=1` → abort sin tocar ficheros).
+- `scripts/cache-metrics.sh`: `record` (ingiere usage del provider) y `report` (hit rate por modelo/sesión) en ledger local `data/cache-metrics.jsonl`.
+- MEMORY.md fuera del prefijo de `opencode.json` (se carga bajo demanda vía auto-prime/recall).
+- Principio de estabilidad de modelo por conversación documentado (sección 4).
+
+**Fuera:**
+- Keep-alive pings activos estilo aider (evaluar post-métricas; no es premisa de esta spec).
+- Cache local de veredictos con grounding (fase 2 de L28, spec aparte).
+- Migración de sesiones/frontends (Claude Code vs OpenCode) — el manifest cubre ambos por diseño.
+
+## 3. Principios de diseño
+
+1. **El prefijo es un contrato**: orden canónico versionado y verificable, no tácito.
+2. **Mutable fuera, estable dentro**: nada que cambie por turno o por `save` vive en el prefijo.
+3. **Congelación durante la sesión**: los auto-regenerados esperan al cierre; la consistencia no se persigue a mitad de una conversación viva.
+4. **Medir antes de optimizar**: métricas locales de cache (hit/costes) sin telemetría a proveedor.
+5. **CRIT-001**: snapshots, manifest y ledger son locales; cero red.
+
+## 4. Modelo estable por conversación
+
+Cambiar de modelo a mitad de una conversación principal deja el KV cache inalcanzable (los providers no comparten cache entre modelos). Regla de política (sección de diseño, no ejecutable):
+- El **modelo del hilo principal** no cambia a mitad de conversación.
+- El routing multi-modelo queda para **subagentes** (su cache no se comparte de todos modos y el aislamiento es una virtud) y para decisiones **entre** sesiones.
+- `config/model-capabilities.yaml` documenta `recommended_compact_threshold_pct`; la compactación es complementaria al cache (tras compactar el prefijo cambia igualmente) — no un sustituto.
+
+## 5. Diseño técnico
+
+### 5.1 `config/cache-prefix.txt` (manifest)
+
+Orden canónico del prefijo de instrucciones, un path por línea (los dos frontends):
+```
+AGENTS.md
+SKILLS.md
+CLAUDE.md
+.claude/profiles/savia.md
+.claude/profiles/active-user.md
+docs/rules/domain/radical-honesty.md
+docs/rules/domain/autonomous-safety.md
+docs/rules/domain/caveman-default.md
+docs/rules/domain/agents-catalog.md
+.claude/CONSTITUCION.md
+docs/critical-facts.md
+```
+Nota: `MEMORY.md` ya NO está en el prefijo (AC-4); se carga bajo demanda.
+
+### 5.2 `scripts/cache-hygiene.sh`
+
+- `snapshot [--out data/cache-prefix.snapshot]`: sha256 de cada path del manifest + línea `# manifest <sha>` del propio manifest.
+- `check [--out ...]`: compara con el snapshot; por cada fichero mutado imprime `MUTATED <path>`; exit 0 limpio / 1 mutación / 2 sin snapshot.
+- `--validate`: cada path del manifest existe; los primeros N del manifest coinciden con `instructions` de `opencode.json` en orden (con tolerancia a ficheros frontend-específicos al final).
+
+### 5.3 Congelación de auto-regenerados
+
+`agents-md-auto-regenerate.sh` y `skills-md-generate.sh`: si `SAVIA_SESSION_ACTIVE=1`, abortan (exit 3) sin regenerar. Justificación: regenerar a mitad de sesión invalida el prefijo en el siguiente turno. El valor lo establece el launcher de sesión interactiva (documentado); los runs autónomos/cron sin sesión viva regeneran con normalidad.
+
+### 5.4 `scripts/cache-metrics.sh`
+
+- `record --model M --input N --cache-read R --cache-creation C [--session S]` → append línea a `data/cache-metrics.jsonl` (local).
+- `report [--session S] [--model M]`: agrega por modelo/sesión: total input, cache_read, ratio `R/(N+R)` (hit rate), y coste relativo estimado (reads×0.1 + writes×1.25 vs input full).
+- `--validate`: schema de líneas.
+- Entrada programática: un hook PostToolUse/Stop puede volcar `usage` de la respuesta del provider (formato Anthropic: `input_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`) vía `record --usage-json`.
+
+### 5.5 MEMORY.md fuera del prefijo
+
+`opencode.json` `instructions` deja de listar `.claude/external-memory/auto/MEMORY.md`. El acceso a memoria sigue disponible: `scripts/memory-store.sh recall`, auto-prime por turno, y skill `savia-memory`.
+
+## 6. Criterios de aceptación
+
+- **AC-0** `cache-hygiene.sh snapshot` genera el fichero de snapshot con hashes (test con manifest temporal).
+- **AC-1** `cache-hygiene.sh check` detecta mutación de un fichero del prefijo (exit 1, mensaje `MUTATED`) (test: mutar un fichero temporal del manifest).
+- **AC-1b** `check` limpio → exit 0 (test).
+- **AC-2** `cache-hygiene.sh --validate` falla si un path del manifest no existe (exit 1) (test).
+- **AC-3** Con `SAVIA_SESSION_ACTIVE=1`, los auto-regeneradores abortan (exit 3) sin tocar su fichero de salida (test: ejecutar con variable, comprobar que el fichero no cambia).
+- **AC-4** `MEMORY.md` no está en `instructions` de `opencode.json` (test de grep).
+- **AC-5** `cache-metrics.sh record` + `report` agregan correctamente (fixture determinista: 3 líneas, hit rate esperado) (test).
+- **AC-6** `cache-metrics.sh record --usage-json` traduce el formato Anthropic a la línea del ledger (test con fixture).
+- **AC-7** Suites BATS existentes de regresión: `test-se355-audit-receipts`, `test-se364-evidence-loop`, `test-context-*` verdes (test).
+
+## 7. OpenCode Implementation Plan
+
+### Bindings touched
+- `config/cache-prefix.txt` (nuevo)
+- `scripts/cache-hygiene.sh` (nuevo)
+- `scripts/cache-metrics.sh` (nuevo)
+- `data/cache-metrics.jsonl` (runtime, gitignored si procede)
+- `.opencode/hooks/agents-md-auto-regenerate.sh` (guard SAVIA_SESSION_ACTIVE)
+- `.opencode/hooks/skills-md-generate.sh` (guard SAVIA_SESSION_ACTIVE)
+- `opencode.json` (quitar MEMORY.md de instructions)
+- `docs/propuestas/ROADMAP-UNIFIED-20260827.md` (Batch 10)
+
+### Verification protocol
+```bash
+bats tests/bats/test-cache-hygiene.bats
+bash scripts/cache-hygiene.sh --validate
+bash scripts/cache-hygiene.sh snapshot --out /tmp/snap && bash scripts/cache-hygiene.sh check --out /tmp/snap
+SAVIA_SESSION_ACTIVE=1 bash scripts/savia-hooks-agent-regen.sh   # si existe; si no, directo en el hook
+bash scripts/cache-metrics.sh record --model glm --input 100 --cache-read 900 --cache-creation 100
+bash scripts/cache-metrics.sh report
+```
+
+### Portability classification
+- Bash + sha256 + Python3 (report/parse opcional); local; portable; CRIT-001.
+
+## 8. Preguntas abiertas
+- ¿Hook de captura de usage por defecto o solo bajo `SAVIA_CACHE_METRICS=1`? Decidido: solo bajo env (evitar overhead por turno); documentar.
+- ¿Congelación también para regeneración de `.scm`? No: `.scm` no está en el prefijo (se regenera sin restricción).
+
+## Referencias
+- Análisis caché 2026-09-03 (artículo prompt caching + aider caching + OpenCode rules)
+- Savia: `docs/harness-map.md` (L28, rol cache), `.claude/skills/context-caching/SKILL.md`, `config/model-capabilities.yaml`, CRIT-001

--- a/opencode.json
+++ b/opencode.json
@@ -6,7 +6,6 @@
     "CLAUDE.md",
     ".claude/profiles/savia.md",
     ".claude/profiles/active-user.md",
-    ".claude/external-memory/auto/MEMORY.md",
     "docs/rules/domain/radical-honesty.md",
     "docs/rules/domain/autonomous-safety.md",
     "docs/rules/domain/caveman-default.md",

--- a/scripts/agents-md-generate.sh
+++ b/scripts/agents-md-generate.sh
@@ -55,6 +55,14 @@ done
 
 [[ -d "${AGENTS_DIR}" ]] || { echo "ERROR: agents dir not found: ${AGENTS_DIR}" >&2; exit 3; }
 
+# SE-371: congelación en sesión activa — regenerar AGENTS.md a mitad de una
+# conversación invalida el prefijo de instrucciones (prompt cache) en el
+# siguiente turno. Los runs autónomos/cron sin sesión viva regeneran normal.
+if [[ "${MODE:-print}" == "apply" && "${SAVIA_SESSION_ACTIVE:-0}" == "1" ]]; then
+  echo "SKIP: SAVIA_SESSION_ACTIVE=1 — regeneración de AGENTS.md congelada (SE-371)." >&2
+  exit 3
+fi
+
 # Extract a single field from frontmatter. Handles both `key: value` and the
 # multiline `key: >` block form (used heavily for `description`).
 extract_field() {

--- a/scripts/cache-hygiene.sh
+++ b/scripts/cache-hygiene.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# cache-hygiene.sh — SE-371: disciplina de prefijo para prompt caching.
+#
+# El prompt cache del provider es prefijo-exacto: un byte distinto en el
+# prefijo de instrucciones invalida el cache desde ese punto. Este script
+# hace visible esa mutación:
+#
+#   snapshot [--out FILE]   guarda sha256 de cada fichero del manifest
+#   check    [--out FILE]   detecta qué fichero mutó desde el snapshot
+#   --validate              manifest coherente (paths existen) y MEMORY.md fuera
+#
+# Manifest: config/cache-prefix.txt (orden canónico del prefijo).
+# CRIT-001: 100% local, sin red, determinista.
+#
+# Exit: snapshot/check 0 ok · 1 mutación o incoherencia · 2 uso/error.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MANIFEST="${CACHE_PREFIX_MANIFEST:-$REPO_ROOT/config/cache-prefix.txt}"
+DEFAULT_SNAPSHOT="$REPO_ROOT/data/cache-prefix.snapshot"
+
+usage() {
+  sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+  exit 2
+}
+
+# sha256 con conteo de lineas: estable pese a mtime. "sha256sum <path>" | cut.
+file_hash() { sha256sum "$1" 2>/dev/null | cut -d' ' -f1; }
+
+manifest_paths() {
+  # devuelve solo paths, ignorando comentarios y vacios
+  grep -vE '^\s*#|^\s*$' "$MANIFEST" 2>/dev/null
+}
+
+cmd_snapshot() {
+  local out="$DEFAULT_SNAPSHOT"
+  [[ "${1:-}" == "--out" ]] && { out="$2"; shift 2; }
+  [[ -f "$MANIFEST" ]] || { echo "ERROR: manifest no encontrado: $MANIFEST" >&2; exit 2; }
+  local dir; dir="$(dirname "$out")"; mkdir -p "$dir"
+  {
+    echo "# cache-prefix snapshot — SE-371 ($(date -u +%Y-%m-%dT%H:%M:%SZ))"
+    echo "# manifest: $(file_hash "$MANIFEST")"
+    local p
+    while IFS= read -r p; do
+      [[ -z "$p" ]] && continue
+      if [[ -f "$REPO_ROOT/$p" ]]; then
+        echo "$p $(file_hash "$REPO_ROOT/$p")"
+      else
+        echo "$p MISSING"
+      fi
+    done < <(manifest_paths)
+  } > "$out"
+  echo "snapshot: $out ($(grep -cE '^[^#]' "$out") ficheros)"
+}
+
+cmd_check() {
+  local out="$DEFAULT_SNAPSHOT"
+  [[ "${1:-}" == "--out" ]] && { out="$2"; shift 2; }
+  [[ -f "$out" ]] || { echo "ERROR: no hay snapshot: $out — ejecuta snapshot primero" >&2; exit 2; }
+  local mutated=0 p cur snap
+  while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    cur="$(file_hash "$REPO_ROOT/$p")"
+    snap="$(grep -E "^$(printf '%s' "$p" | sed 's/[.[\*^$()+?{|]/\\&/g') " "$out" | head -1 | cut -d' ' -f2)"
+    if [[ "$snap" == "MISSING" || -z "$snap" ]]; then
+      echo "MUTATED $p (sin snapshot previo o fichero nuevo)"
+      mutated=1
+    elif [[ "$cur" != "$snap" ]]; then
+      echo "MUTATED $p"
+      mutated=1
+    fi
+  done < <(manifest_paths)
+  if [[ "$mutated" -eq 0 ]]; then
+    echo "check: prefijo estable (0 ficheros mutados)"
+    return 0
+  fi
+  echo "check: PREFIJO MUTADO — el prompt cache se invalidó en el siguiente turno" >&2
+  return 1
+}
+
+cmd_validate() {
+  local fail=0 p
+  [[ -f "$MANIFEST" ]] || { echo "ERROR: manifest no encontrado: $MANIFEST" >&2; exit 2; }
+  while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    if [[ ! -f "$REPO_ROOT/$p" ]]; then
+      echo "FAIL path inexistente en manifest: $p"
+      fail=1
+    fi
+  done < <(manifest_paths)
+  # AC-4: MEMORY.md fuera del prefijo
+  if grep -q 'external-memory/auto/MEMORY.md' "$REPO_ROOT/config/cache-prefix.txt"; then
+    echo "FAIL MEMORY.md no debe estar en el prefijo (SE-371 AC-4)"
+    fail=1
+  fi
+  if grep -q 'MEMORY.md' "$REPO_ROOT/opencode.json"; then
+    echo "FAIL MEMORY.md no debe estar en instructions de opencode.json (SE-371 AC-4)"
+    fail=1
+  fi
+  # MEMORY.md solo puede aparecer como comentario de documentacion
+  if grep -q 'external-memory/auto/MEMORY.md' "$REPO_ROOT/CLAUDE.md"; then
+    # CLAUDE.md lo referencia bajo el bloque lazy (linea "Usuario activo"): la
+    # referencia en tabla lazy es un @import critico -> avisar, no fallar.
+    echo "WARN MEMORY.md referenciado en CLAUDE.md (revisar que sea lazy, no @import)"
+  fi
+  [[ "$fail" -eq 0 ]] && { echo "validate: OK (manifest coherente, MEMORY.md fuera del prefijo)"; return 0; }
+  return 1
+}
+
+case "${1:-}" in
+  snapshot) shift; cmd_snapshot "$@" ;;
+  check)    shift; cmd_check "$@" ;;
+  --validate|validate) cmd_validate ;;
+  -h|--help) usage ;;
+  *) usage ;;
+esac
+exit $?

--- a/scripts/cache-metrics.sh
+++ b/scripts/cache-metrics.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# cache-metrics.sh — SE-371: ledger local de métricas de prompt cache.
+#
+# Sin métrica no hay gestión. Este script registra y agrega usage del cache
+# del provider en un ledger local (CRIT-001: cero telemetría a proveedor).
+#
+#   record --model M --input N [--cache-read R] [--cache-creation C] [--session S]
+#   record --usage-json '{...}' [--model M] [--session S]   # formato Anthropic
+#   report [--session S] [--model M]                        # hit rate + coste relativo
+#   --validate                                              # schema de lineas
+#
+# Linea ledger: {"ts":"...","session":S,"model":M,"input":N,"cache_read":R,
+#                "cache_creation":C}
+# Coste relativo estimado (multiplicadores provider estandar): reads x0.1,
+# writes (cache_creation) x1.25 vs input x1.0.
+# CRIT-001: todo local, sin reloj obligatorio (ts opcional para tests).
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LEDGER="${SAVIA_CACHE_METRICS_DIR:-$REPO_ROOT/data/cache-metrics.jsonl}"
+READ_COST=0.1
+WRITE_COST=1.25
+
+usage() { sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
+
+cmd_record() {
+  local model="" input="" read_="" create_="" session="" usage_json=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --model) model="$2"; shift 2 ;;
+      --input) input="$2"; shift 2 ;;
+      --cache-read) read_="$2"; shift 2 ;;
+      --cache-creation) create_="$2"; shift 2 ;;
+      --session) session="$2"; shift 2 ;;
+      --usage-json) usage_json="$2"; shift 2 ;;
+      *) usage ;;
+    esac
+  done
+  if [[ -n "$usage_json" ]]; then
+    # formato Anthropic: input_tokens, cache_read_input_tokens, cache_creation_input_tokens
+    input="$(python3 -c "import json,sys; print(json.loads('''$usage_json''').get('input_tokens',0))" 2>/dev/null || echo 0)"
+    read_="$(python3 -c "import json,sys; print(json.loads('''$usage_json''').get('cache_read_input_tokens',0))" 2>/dev/null || echo 0)"
+    create_="$(python3 -c "import json,sys; print(json.loads('''$usage_json''').get('cache_creation_input_tokens',0))" 2>/dev/null || echo 0)"
+  fi
+  [[ -n "$model" && -n "$input" ]] || { echo "ERROR: record exige --model y --input (o --usage-json)" >&2; exit 2; }
+  local ts=""; ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo '')"
+  mkdir -p "$(dirname "$LEDGER")"
+  python3 - "$LEDGER" "$ts" "$session" "$model" "$input" "${read_:-0}" "${create_:-0}" <<'PY'
+import json, sys
+ledger, ts, session, model = sys.argv[1:5]
+input_, read_, create_ = (int(float(x)) for x in sys.argv[5:8])
+row = {"model": model, "input": input_, "cache_read": read_,
+       "cache_creation": create_}
+if ts: row["ts"] = ts
+if session: row["session"] = session
+with open(ledger, "a") as f:
+    f.write(json.dumps(row) + "\n")
+print("recorded:", json.dumps(row))
+PY
+}
+
+cmd_report() {
+  local session="" model=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in --session) session="$2"; shift 2 ;; --model) model="$2"; shift 2 ;; *) usage ;; esac
+  done
+  [[ -f "$LEDGER" ]] || { echo "report: ledger vacío o inexistente: $LEDGER"; return 0; }
+  python3 - "$LEDGER" "$session" "$model" <<'PY'
+import json, sys
+from collections import defaultdict
+ledger, fsess, fmodel = sys.argv[1:4]
+agg = defaultdict(lambda: {"input": 0, "read": 0, "create": 0, "n": 0})
+for line in open(ledger):
+    line = line.strip()
+    if not line: continue
+    try: r = json.loads(line)
+    except json.JSONDecodeError: continue
+    if fsess and r.get("session") != fsess: continue
+    if fmodel and r.get("model") != fmodel: continue
+    a = agg[r.get("model", "?")]
+    a["input"] += r.get("input", 0); a["read"] += r.get("cache_read", 0)
+    a["create"] += r.get("cache_creation", 0); a["n"] += 1
+tot_in = sum(a["input"] for a in agg.values())
+tot_read = sum(a["read"] for a in agg.values())
+tot_create = sum(a["create"] for a in agg.values())
+hit = tot_read / (tot_in + tot_read) if (tot_in + tot_read) else 0.0
+# coste relativo: procesar (input+create*1.25) + servir desde cache (read*0.1)
+cost_full = tot_in + tot_read + tot_create
+cost_cache = tot_read * 0.1 + tot_create * 1.25 + tot_in
+saving = (cost_full - cost_cache) / cost_full if cost_full else 0.0
+print(json.dumps({
+    "models": {k: dict(v) for k, v in sorted(agg.items())},
+    "totals": {"input": tot_in, "cache_read": tot_read, "cache_creation": tot_create},
+    "cache_hit_ratio": round(hit, 4),
+    "est_saving_pct": round(saving * 100, 1),
+}, indent=2))
+PY
+}
+
+cmd_validate() {
+  [[ -f "$LEDGER" ]] || { echo "validate: OK (ledger inexistente, valido)"; return 0; }
+  local bad=0
+  python3 - "$LEDGER" <<'PY'
+import json, sys
+bad = 0
+for i, line in enumerate(open(sys.argv[1]), 1):
+    line = line.strip()
+    if not line: continue
+    try:
+        r = json.loads(line)
+        assert isinstance(r.get("model"), str)
+        assert isinstance(r.get("input"), int)
+        assert isinstance(r.get("cache_read"), int)
+        assert isinstance(r.get("cache_creation"), int)
+    except (json.JSONDecodeError, AssertionError):
+        print(f"BAD linea {i}"); bad = 1
+sys.exit(bad)
+PY
+  bad=$?
+  [[ "$bad" -eq 0 ]] && echo "validate: OK (schema valido)"
+  return $bad
+}
+
+case "${1:-}" in
+  record) shift; cmd_record "$@" ;;
+  report) shift; cmd_report "$@" ;;
+  --validate|validate) cmd_validate ;;
+  -h|--help) usage ;;
+  *) usage ;;
+esac
+exit $?

--- a/scripts/skills-md-generate.sh
+++ b/scripts/skills-md-generate.sh
@@ -43,6 +43,13 @@ done
 
 [[ -d "$SKILLS_DIR" ]] || { echo "ERROR: skills dir not found: $SKILLS_DIR" >&2; exit 3; }
 
+# SE-371: congelación en sesión activa — regenerar SKILLS.md a mitad de una
+# conversación invalida el prefijo de instrucciones (prompt cache).
+if [[ "${MODE:-print}" == "apply" && "${SAVIA_SESSION_ACTIVE:-0}" == "1" ]]; then
+  echo "SKIP: SAVIA_SESSION_ACTIVE=1 — regeneración de SKILLS.md congelada (SE-371)." >&2
+  exit 3
+fi
+
 extract_field() {
   local file="$1" field="$2"
   # SE-333 dual-read: canonical metadata.savia.<field> takes precedence;

--- a/tests/bats/test-cache-hygiene.bats
+++ b/tests/bats/test-cache-hygiene.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# SE-371 — Cache Hygiene + Métricas (AC-0..AC-7)
+# Ref: docs/specs/SE-371-cache-hygiene.spec.md
+# CRIT-001: todo local; snapshots y ledger temporales en /tmp.
+
+CH="bash scripts/cache-hygiene.sh"
+CM="bash scripts/cache-metrics.sh"
+
+setup() {
+    TMPD="$(mktemp -d)"
+    # manifest temporal con un fichero controlado
+    echo "data/cache-test-prefix/alpha.md" > "$TMPD/manifest.txt"
+    echo "data/cache-test-prefix/beta.md" >> "$TMPD/manifest.txt"
+    mkdir -p "data/cache-test-prefix"
+    echo "alpha v1" > data/cache-test-prefix/alpha.md
+    echo "beta v1" > data/cache-test-prefix/beta.md
+}
+
+teardown() {
+    rm -rf "$TMPD" data/cache-test-prefix data/cache-metrics.test.jsonl
+}
+
+@test "SE-371 AC-0: snapshot genera fichero con hashes" {
+    env CACHE_PREFIX_MANIFEST="$TMPD/manifest.txt" bash scripts/cache-hygiene.sh snapshot --out "$TMPD/snap.txt"
+    grep -q "alpha.md" "$TMPD/snap.txt"
+    grep -q "beta.md" "$TMPD/snap.txt"
+    grep -qE 'alpha\.md [0-9a-f]{64}$' "$TMPD/snap.txt"
+}
+
+@test "SE-371 AC-1: check limpio → exit 0" {
+    env CACHE_PREFIX_MANIFEST="$TMPD/manifest.txt" bash scripts/cache-hygiene.sh snapshot --out "$TMPD/snap.txt" >/dev/null
+    run env CACHE_PREFIX_MANIFEST="$TMPD/manifest.txt" bash scripts/cache-hygiene.sh check --out "$TMPD/snap.txt"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q 'estable'
+}
+
+@test "SE-371 AC-1b: check detecta mutacion del prefijo → exit 1" {
+    env CACHE_PREFIX_MANIFEST="$TMPD/manifest.txt" bash scripts/cache-hygiene.sh snapshot --out "$TMPD/snap.txt" >/dev/null
+    echo "alpha v2 mutada" > data/cache-test-prefix/alpha.md
+    run env CACHE_PREFIX_MANIFEST="$TMPD/manifest.txt" bash scripts/cache-hygiene.sh check --out "$TMPD/snap.txt"
+    [ "$status" -eq 1 ]
+    echo "$output" | grep -q 'MUTATED data/cache-test-prefix/alpha.md'
+}
+
+@test "SE-371 AC-2: --validate falla si un path del manifest no existe" {
+    echo "docs/no-existe-ya.md" >> "$TMPD/manifest.txt"
+    run env CACHE_PREFIX_MANIFEST="$TMPD/manifest.txt" bash scripts/cache-hygiene.sh --validate
+    [ "$status" -eq 1 ]
+    echo "$output" | grep -q 'path inexistente'
+}
+
+@test "SE-371 AC-2b: --validate pasa con manifest real coherente" {
+    run bash scripts/cache-hygiene.sh --validate
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q 'validate: OK'
+}
+
+@test "SE-371 AC-3: auto-regeneradores congelados con SAVIA_SESSION_ACTIVE=1" {
+    cp AGENTS.md "$TMPD/AGENTS.before"
+    run env SAVIA_SESSION_ACTIVE=1 bash scripts/agents-md-generate.sh --apply
+    [ "$status" -eq 3 ]
+    echo "$output" | grep -q 'congelada'
+    cp "$TMPD/AGENTS.before" AGENTS.md  # restaurar por si acaso
+}
+
+@test "SE-371 AC-3b: skills-md-generate congelado con SAVIA_SESSION_ACTIVE=1" {
+    cp SKILLS.md "$TMPD/SKILLS.before"
+    run env SAVIA_SESSION_ACTIVE=1 bash scripts/skills-md-generate.sh --apply
+    [ "$status" -eq 3 ]
+    cp "$TMPD/SKILLS.before" SKILLS.md
+}
+
+@test "SE-371 AC-3c: sin SAVIA_SESSION_ACTIVE regeneran normal (exit 0)" {
+    run bash scripts/agents-md-generate.sh --check
+    [ "$status" -eq 0 ]
+}
+
+@test "SE-371 AC-4: MEMORY.md fuera del prefijo de opencode.json" {
+    run bash -c "grep -q 'external-memory/auto/MEMORY.md' opencode.json"
+    [ "$status" -eq 1 ]
+    run bash -c "grep -vE '^[[:space:]]*#|^$' config/cache-prefix.txt | grep -q 'MEMORY.md'"
+    [ "$status" -eq 1 ]
+}
+
+@test "SE-371 AC-5: cache-metrics record+report agregan hit rate esperado" {
+    export SAVIA_CACHE_METRICS_DIR="$TMPD/metrics.jsonl"
+    $CM record --model glm --input 100 --cache-read 900 --cache-creation 100 --session s1 >/dev/null
+    $CM record --model glm --input 100 --cache-read 900 --cache-creation 100 --session s1 >/dev/null
+    $CM record --model dsv --input 100 --cache-read 0 --cache-creation 0 --session s2 >/dev/null
+    run $CM report
+    [ "$status" -eq 0 ]
+    HR=$(echo "$output" | python3 -c "import json,sys; print(json.load(sys.stdin)['cache_hit_ratio'])")
+    python3 -c "assert abs(float('$HR') - 0.8571) < 0.001, '$HR'"
+}
+
+@test "SE-371 AC-6: record --usage-json traduce formato Anthropic" {
+    export SAVIA_CACHE_METRICS_DIR="$TMPD/metrics.jsonl"
+    $CM record --usage-json '{"input_tokens":50,"cache_read_input_tokens":450,"cache_creation_input_tokens":10}' --model glm --session s1 >/dev/null
+    python3 - "$TMPD/metrics.jsonl" <<'PY'
+import json, sys
+r = json.loads([l for l in open(sys.argv[1]) if l.strip()][0])
+assert r["input"] == 50 and r["cache_read"] == 450 and r["cache_creation"] == 10, r
+print("ok")
+PY
+}
+
+@test "SE-371: cache-metrics --validate OK y detecta linea mala" {
+    export SAVIA_CACHE_METRICS_DIR="$TMPD/metrics.jsonl"
+    $CM record --model glm --input 1 --cache-read 0 --cache-creation 0 >/dev/null
+    run $CM --validate
+    [ "$status" -eq 0 ]
+    echo '{"model": 5}' >> "$TMPD/metrics.jsonl"
+    run $CM --validate
+    [ "$status" -eq 1 ]
+}
+
+@test "SE-371 AC-7: suites de regresion verdes" {
+    run bats tests/bats/test-se355-audit-receipts.bats
+    [ "$status" -eq 0 ]
+    run bats tests/bats/test-se364-evidence-loop.bats
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Las conversaciones con modelos de IA se vuelven más baratas y rápidas cuando el inicio del mensaje (las reglas e instrucciones que Savia carga en cada turno) no cambia entre turnos: el proveedor "recuerda" esa parte y solo procesa lo nuevo. Eso es el prompt cache. Este cambio pone disciplina y medida en ese mecanismo:

1. **Registra el estado del prefijo** al empezar una conversación y **avisa si algo lo cambió** a mitad (por ejemplo, si los ficheros de reglas se regeneran solos entre turnos — algo que hoy ocurre y anula el ahorro silenciosamente).
2. **Congela la auto-regeneración** de los índices de agentes y skills mientras hay una sesión viva: esperan a que termine en vez de invalidar el contexto en mitad del trabajo.
3. **Quita del prefijo** el índice de memoria, que cambia cada vez que se guarda algo: ahora se consulta solo cuando hace falta.
4. **Registra métricas de caché** por conversación en un fichero local (cuántos tokens se sirvieron desde caché, ahorro estimado) para poder decidir con datos.

Todo corre en local; ninguna métrica ni contenido sale del equipo. Es aditivo: el comportamiento existente no cambia salvo que se active una sesión con estas salvaguardas, y todo es reversible.
## Summary
feat(scripts): SE-371 cache hygiene y metricas de prefijo
### Changes
- 575d8612 feat(SE-371): cache hygiene + metricas (AC-0..AC-7 en verde)
### Stats
14 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed
