### PR TITLE
feat(hooks): SE-371 activar cache hygiene en runtime

### DIFF
--- a/.claude/hooks/cache-hygiene-hook.sh
+++ b/.claude/hooks/cache-hygiene-hook.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -uo pipefail
 # cache-hygiene-hook.sh — SE-371: activación runtime de la higiene de caché.
 #
 # Se registra en .claude/settings.json en tres momentos:
@@ -9,7 +10,6 @@
 # La congelación de AGENTS.md/SKILLS.md durante la sesión la aplican los
 # generadores al ver el marker data/.cache-session-active (o SAVIA_SESSION_ACTIVE).
 # CRIT-001: todo local. Time-box: <15ms en preturn, <200ms en start/end.
-set -uo pipefail
 _ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MARKER="$_ROOT/data/.cache-session-active"
 LOG="$_ROOT/output/.cache-hygiene.log"

--- a/.claude/hooks/cache-hygiene-hook.sh
+++ b/.claude/hooks/cache-hygiene-hook.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# cache-hygiene-hook.sh — SE-371: activación runtime de la higiene de caché.
+#
+# Se registra en .claude/settings.json en tres momentos:
+#   SessionStart     start    → snapshot del prefijo + marker de sesión activa
+#   UserPromptSubmit preturn  → detecta mutación del prefijo (log, nunca bloquea)
+#   SessionEnd       end      → limpia marker + regeneración diferida si hubo drift
+#
+# La congelación de AGENTS.md/SKILLS.md durante la sesión la aplican los
+# generadores al ver el marker data/.cache-session-active (o SAVIA_SESSION_ACTIVE).
+# CRIT-001: todo local. Time-box: <15ms en preturn, <200ms en start/end.
+set -uo pipefail
+_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MARKER="$_ROOT/data/.cache-session-active"
+LOG="$_ROOT/output/.cache-hygiene.log"
+_START=$SECONDS
+
+# Drain stdin (hook JSON) — nunca bloquea al padre.
+cat >/dev/null 2>&1 || true
+
+_log() { mkdir -p "$(dirname "$LOG")"; printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo '?')" "$1" >> "$LOG" 2>/dev/null || true; }
+
+# regeneración diferida: solo si hay drift real (evita reescribir igual)
+_deferred_regen() {
+  bash "$_ROOT/scripts/agents-md-generate.sh" --check >/dev/null 2>&1
+  [[ $? -eq 1 ]] && bash "$_ROOT/scripts/agents-md-generate.sh" --apply >/dev/null 2>&1
+  bash "$_ROOT/scripts/skills-md-generate.sh" --check >/dev/null 2>&1
+  [[ $? -eq 1 ]] && bash "$_ROOT/scripts/skills-md-generate.sh" --apply >/dev/null 2>&1
+  return 0
+}
+
+case "${1:-}" in
+  start)
+    mkdir -p "$_ROOT/data" "$_ROOT/output"
+    bash "$_ROOT/scripts/cache-hygiene.sh" snapshot --out "$_ROOT/data/cache-prefix.snapshot" >/dev/null 2>&1 || true
+    : > "$MARKER"
+    _log "start: snapshot prefijo + sesión activa"
+    ;;
+  preturn)
+    # No bloquear jamás: si el check tarda más del presupuesto, salir limpio.
+    if (( SECONDS - _START > 1 )); then exit 0; fi
+    if [[ ! -f "$_ROOT/data/cache-prefix.snapshot" ]]; then exit 0; fi
+    out=$(bash "$_ROOT/scripts/cache-hygiene.sh" check --out "$_ROOT/data/cache-prefix.snapshot" 2>&1) || {
+      _log "preturn MUTATED: $(echo "$out" | grep '^MUTATED' | tr '\n' ';')"
+      # Silencioso para el prompt: el prefijo no debe contaminarse con ruido.
+    }
+    exit 0
+    ;;
+  end)
+    rm -f "$MARKER" 2>/dev/null || true
+    _deferred_regen
+    _log "end: marker limpio + regeneración diferida"
+    ;;
+  *) exit 0 ;;
+esac
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/session-init.sh",
             "timeout": 15,
-            "statusMessage": "Inicializando sesi\u00f3n PM-Workspace..."
+            "statusMessage": "Inicializando sesión PM-Workspace..."
           },
           {
             "type": "command",
@@ -17,7 +17,7 @@
           },
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/check-daemon-auth.sh >/dev/null 2>&1 || echo \"[SPEC-SH02] browser-daemon auth expired \u2014 run: bash scripts/check-daemon-auth.sh\"",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/check-daemon-auth.sh >/dev/null 2>&1 || echo \"[SPEC-SH02] browser-daemon auth expired — run: bash scripts/check-daemon-auth.sh\"",
             "timeout": 5,
             "statusMessage": "SPEC-SH02: verificando auth de browser-daemon..."
           },
@@ -26,6 +26,11 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/emergency-mode-readiness.sh",
             "timeout": 12,
             "statusMessage": "Emergency-mode: verificando LocalAI fallback..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/cache-hygiene-hook.sh start",
+            "timeout": 10
           }
         ]
       },
@@ -125,7 +130,7 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/prompt-hook-commit.sh",
             "timeout": 5,
-            "statusMessage": "Prompt hook: validando sem\u00e1ntica..."
+            "statusMessage": "Prompt hook: validando semántica..."
           },
           {
             "type": "command",
@@ -178,7 +183,7 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/agent-tool-call-validate.sh",
             "timeout": 5,
-            "statusMessage": "Validando par\u00e1metros de tool call..."
+            "statusMessage": "Validando parámetros de tool call..."
           }
         ]
       },
@@ -217,7 +222,7 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/tdd-gate.sh",
             "timeout": 10,
-            "statusMessage": "TDD gate: tests antes que c\u00f3digo..."
+            "statusMessage": "TDD gate: tests antes que código..."
           },
           {
             "type": "command",
@@ -253,7 +258,7 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/responsibility-judge.sh",
             "timeout": 5,
-            "statusMessage": "Responsibility Judge: evaluando decisi\u00f3n..."
+            "statusMessage": "Responsibility Judge: evaluando decisión..."
           },
           {
             "type": "command",
@@ -283,7 +288,7 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/permission-mode-gate.sh",
             "timeout": 5,
-            "statusMessage": "SE-354: verificando modo de permisos de sesi\u00f3n..."
+            "statusMessage": "SE-354: verificando modo de permisos de sesión..."
           }
         ],
         "_comment": "SE-354 read-only permission mode (policy as code)"
@@ -427,7 +432,7 @@
             "name": "auto-grill-me",
             "blocking": false,
             "timeout": 5,
-            "statusMessage": "SE-091: grill-me \u2014 hunting weaknesses..."
+            "statusMessage": "SE-091: grill-me — hunting weaknesses..."
           }
         ]
       },
@@ -440,7 +445,7 @@
             "name": "auto-zoom-out",
             "blocking": false,
             "timeout": 5,
-            "statusMessage": "SE-091: zoom-out \u2014 checking second-order effects..."
+            "statusMessage": "SE-091: zoom-out — checking second-order effects..."
           }
         ]
       },
@@ -572,7 +577,7 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/ast-quality-gate-hook.sh",
             "async": true,
             "timeout": 60,
-            "statusMessage": "AST Quality Gate: analizando c\u00f3digo..."
+            "statusMessage": "AST Quality Gate: analizando código..."
           },
           {
             "type": "command",
@@ -729,7 +734,7 @@
             "command": "bash .claude/hooks/criterion-simulation-challenge.sh"
           }
         ],
-        "_comment": "Eval\u00faa framing de sub-tareas delegadas (SPEC-194)"
+        "_comment": "Evalúa framing de sub-tareas delegadas (SPEC-194)"
       },
       {
         "matcher": "Task",
@@ -769,7 +774,7 @@
             "command": "bash .claude/hooks/cognitive-debt-check.sh"
           }
         ],
-        "_comment": "Mide duraci\u00f3n de sesi\u00f3n (SPEC-107)"
+        "_comment": "Mide duración de sesión (SPEC-107)"
       },
       {
         "matcher": ".*",
@@ -809,7 +814,7 @@
       },
       {
         "matcher": "mcp__.*",
-        "_comment": "twin-posttooluse: NO-OP without TWIN_HOOK_ENABLED=true \u2014 tracks MCP tool calls for code twin (SPEC-190)",
+        "_comment": "twin-posttooluse: NO-OP without TWIN_HOOK_ENABLED=true — tracks MCP tool calls for code twin (SPEC-190)",
         "hooks": [
           {
             "type": "command",
@@ -819,7 +824,7 @@
       },
       {
         "matcher": "Task|Write|Edit|Bash|WebFetch",
-        "_comment": "judge-auto-router: SE-273 S1 \u2014 auto-triggers judges based on output content patterns. Master switch: SAVIA_JUDGE_AUTO_ROUTER=off",
+        "_comment": "judge-auto-router: SE-273 S1 — auto-triggers judges based on output content patterns. Master switch: SAVIA_JUDGE_AUTO_ROUTER=off",
         "hooks": [
           {
             "type": "command",
@@ -860,7 +865,7 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/session-end-snapshot.sh",
             "async": true,
             "timeout": 5,
-            "statusMessage": "Guardando snapshot de sesi\u00f3n..."
+            "statusMessage": "Guardando snapshot de sesión..."
           },
           {
             "type": "command",
@@ -892,7 +897,7 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/emotional-regulation-monitor.sh",
             "async": true,
             "timeout": 10,
-            "statusMessage": "Evaluando bienestar de sesi\u00f3n..."
+            "statusMessage": "Evaluando bienestar de sesión..."
           },
           {
             "type": "command",
@@ -927,7 +932,12 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/session-end-memory.sh",
             "timeout": 1500,
-            "statusMessage": "Extrayendo memoria de sesi\u00f3n..."
+            "statusMessage": "Extrayendo memoria de sesión..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/cache-hygiene-hook.sh end",
+            "timeout": 15
           }
         ]
       }
@@ -959,6 +969,11 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/learning-recall-hook.sh",
             "timeout": 5000,
             "statusMessage": "SCL-003: recuperando lecciones aprendidas..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/cache-hygiene-hook.sh preturn",
+            "timeout": 5
           }
         ]
       },
@@ -974,7 +989,7 @@
       },
       {
         "matcher": "",
-        "_comment": "recommendation-tribunal-followup: WIRE-READY, NO-OP by default \u2014 captures tribunal follow-up actions",
+        "_comment": "recommendation-tribunal-followup: WIRE-READY, NO-OP by default — captures tribunal follow-up actions",
         "hooks": [
           {
             "type": "command",
@@ -1001,7 +1016,7 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/pre-compact-backup.sh",
             "timeout": 10,
-            "statusMessage": "Backup pre-compactaci\u00f3n..."
+            "statusMessage": "Backup pre-compactación..."
           }
         ]
       }
@@ -1013,7 +1028,7 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/post-compaction.sh",
             "timeout": 10,
-            "statusMessage": "Recuperando memoria persistente tras compactaci\u00f3n..."
+            "statusMessage": "Recuperando memoria persistente tras compactación..."
           }
         ]
       }
@@ -1124,7 +1139,7 @@
       }
     ]
   },
-  "_doc_se202_example": "SE-202 agent hook pattern \u2014 to enable: add to PreToolUse hooks: { \"type\": \"command\", \"command\": \"bash \\\"$CLAUDE_PROJECT_DIR\\\"/scripts/agent-hook-runner.sh --agent security-guardian --event \\\"{\\\"tool\\\":\\\"$TOOL_NAME\\\",\\\"tool_input\\\":\\\"$TOOL_INPUT\\\"}\\\"\", \"timeout\": 30 } \u2014 exit 0=allow, exit 2=deny. Ref: docs/rules/domain/agent-hook-protocol.md",
+  "_doc_se202_example": "SE-202 agent hook pattern — to enable: add to PreToolUse hooks: { \"type\": \"command\", \"command\": \"bash \\\"$CLAUDE_PROJECT_DIR\\\"/scripts/agent-hook-runner.sh --agent security-guardian --event \\\"{\\\"tool\\\":\\\"$TOOL_NAME\\\",\\\"tool_input\\\":\\\"$TOOL_INPUT\\\"}\\\"\", \"timeout\": 30 } — exit 0=allow, exit 2=deny. Ref: docs/rules/domain/agent-hook-protocol.md",
   "permissions": {
     "defaultMode": "auto"
   },

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=cbcb4f990a4d98172f0bea0d61476278d7d0fedeac28391ccd5ad49569d68cbe
-timestamp=2026-09-03T20:50:50Z
+diff_hash=969acda673c5022b7719bcaed8d7b6bc02cf87b851a55babaf3e21370ead1ac6
+timestamp=2026-09-03T20:53:26Z
 branch=agent/se371-cache-activation
-head_commit=9b4c7a25
-signature=d6d0cdb29e44ccbfd0cb68987c62fffd3c40efb56d2fba40cadb90a5698af8d5
+head_commit=ddd96e59
+signature=1976d216cdd75f8fc4f034a829254151d29154fe3d84aa083c456d9cf753ceed

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=cbcb4f990a4d98172f0bea0d61476278d7d0fedeac28391ccd5ad49569d68cbe
-timestamp=2026-09-03T20:50:50Z
+diff_hash=b84379be4379fc338c8a3b560083cf59a082998bf4adc62db58f26013848bb07
+timestamp=2026-09-03T20:54:13Z
 branch=agent/se371-cache-activation
-head_commit=9b4c7a25
-signature=d6d0cdb29e44ccbfd0cb68987c62fffd3c40efb56d2fba40cadb90a5698af8d5
+head_commit=67d2007b
+signature=5adef39a89cdecf73f541889964de3643b2f647e7d6633bd6015741df5f7d5e7

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=8ae5e85c993081611ba5adf971779588f39915226bd019a6aeb26cad749fa9ab
-timestamp=2026-09-03T20:07:02Z
-branch=agent/se371-cache-hygiene
-head_commit=575d8612
-signature=ef49a992a0438f81efb3ced0b4c88189c373b7044ee7777622a999f894b69e01
+diff_hash=cbcb4f990a4d98172f0bea0d61476278d7d0fedeac28391ccd5ad49569d68cbe
+timestamp=2026-09-03T20:50:50Z
+branch=agent/se371-cache-activation
+head_commit=9b4c7a25
+signature=d6d0cdb29e44ccbfd0cb68987c62fffd3c40efb56d2fba40cadb90a5698af8d5

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=b84379be4379fc338c8a3b560083cf59a082998bf4adc62db58f26013848bb07
-timestamp=2026-09-03T20:54:13Z
+diff_hash=9b4e72efedeb34ec0e7d2f86d445a76ac26adf581a9f91790d8d32be190f109c
+timestamp=2026-09-03T20:57:30Z
 branch=agent/se371-cache-activation
-head_commit=67d2007b
-signature=5adef39a89cdecf73f541889964de3643b2f647e7d6633bd6015741df5f7d5e7
+head_commit=f6c70916
+signature=904e612512d32ecbb66b154a9cd9e46d620a1bd8841044aa3e308e84d1abc1f7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.17.7] — 2026-09-03
+
+### Changed
+- SE-371 cache hygiene activado en runtime: hook SessionStart (snapshot del prefijo + marker de sesion activa), UserPromptSubmit (deteccion de mutacion del prefijo) y SessionEnd (limpieza + regeneracion diferida). Los auto-regenerados AGENTS/SKILLS se congelan durante sesiones vivas.
+
 ## [6.17.6] — 2026-09-03
 
 ### Added
@@ -13181,6 +13186,7 @@ Initial public release of PM-Workspace.
 
 - **Documentation** with methodology
 
+[6.17.7]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.6...v6.17.7
 [6.17.6]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.5...v6.17.6
 [6.17.5]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.4...v6.17.5
 [6.17.4]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.3...v6.17.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.17.7] — 2026-09-03
+## [6.17.8] — 2026-09-03
 
 ### Changed
 - SE-371 cache hygiene activado en runtime: hook SessionStart (snapshot del prefijo + marker de sesion activa), UserPromptSubmit (deteccion de mutacion del prefijo) y SessionEnd (limpieza + regeneracion diferida). Los auto-regenerados AGENTS/SKILLS se congelan durante sesiones vivas.
-### Fixed
 
+## [6.17.7] — 2026-09-03
+
+### Fixed
 - block-branch-switch-dirty.sh (seguimiento de #1066): la resolución del repo destino tenía tres huecos vistos en prueba real. (1) `cd $VAR && git …` con la variable sin expandir, o un directorio inexistente, dejaba pasar el cambio de rama sin comprobar nada; ahora cae al cwd de la sesión. (2) Cualquier `git -C <dir>` en el comando (p. ej. dentro de un `echo $(...)`) decidía el destino aunque no fuera el del cambio de rama; ahora solo cuenta el `-C` de la propia invocación, y si no lo hay, el último `cd` anterior a ella. (3) La restauración de fichero con `--` no estaba exenta cuando iba precedida de `-C`. También se elimina la línea `0` suelta del mensaje de bloqueo (doble conteo de `grep -c`). 9 tests BATS nuevos (7 en rojo con el hook anterior).
 
 ## [6.17.6] — 2026-09-03
@@ -13189,6 +13191,7 @@ Initial public release of PM-Workspace.
 
 - **Documentation** with methodology
 
+[6.17.8]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.7...v6.17.8
 [6.17.7]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.6...v6.17.7
 [6.17.6]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.5...v6.17.6
 [6.17.5]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.4...v6.17.5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Identidad del humano al volante + memoria auto persistida fuera del repo.
 
 ## Estructura
 
-`.claude/{agents(88), commands(571), profiles, hooks(118/121reg), rules/{domain,languages}, skills(133), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
+`.claude/{agents(88), commands(571), profiles, hooks(119/124reg), rules/{domain,languages}, skills(133), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
 
 ## Reglas Críticas (Rules 1-8, inline)
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -90,6 +90,7 @@ To use a skill: read `<path>` and follow its instructions.
 | onboarding-dev | `.opencode/skills/onboarding-dev/SKILL.md` | Usar cuando se incorpora un desarrollador nuevo al proyecto y necesita buddy IA. |
 | org-meeting-capture | `.opencode/skills/org-meeting-capture/SKILL.md` | Captura de Conocimiento Tácito de Reunión: extrae decisores, acuerdos informales y señales pol... |
 | org-political-landscape | `.opencode/skills/org-political-landscape/SKILL.md` | Análisis de Paisaje Político Interno: detecta tensiones, alianzas y centros de poder a partir d... |
+| org-registrar | `.opencode/skills/org-registrar/SKILL.md` | Gestiona el grafo de entidades organizacionales (Company as Code, SE-365): valida entidades, inde... |
 | org-stakeholder-mapper | `.opencode/skills/org-stakeholder-mapper/SKILL.md` | Mapeador de Stakeholders y Decisores: extrae roles formales y reales, motivaciones, alianzas y te... |
 | orgchart-import | `.opencode/skills/orgchart-import/SKILL.md` | Usar cuando se importa un organigrama para extraer la estructura del equipo. |
 | overnight-sprint | `.opencode/skills/overnight-sprint/SKILL.md` | Usar cuando se quiere ejecutar tareas de bajo riesgo de forma autónoma durante la noche. |
@@ -120,6 +121,7 @@ To use a skill: read `<path>` and follow its instructions.
 | sales-proposal-writer | `.opencode/skills/professional-domain/sales/sales-proposal-writer/SKILL.md` | Redactor de Propuesta Comercial B2B: genera propuestas consultivas personalizadas con índice com... |
 | project-update | `.opencode/skills/project-update/SKILL.md` | Usar cuando se necesita una actualización integral del proyecto activo desde todas las fuentes. |
 | prompt-optimizer | `.opencode/skills/prompt-optimizer/SKILL.md` | Usar cuando se optimiza el prompt de un skill o agente para mejorar su efectividad. |
+| prospectiva-basica | `.opencode/skills/prospectiva-basica/SKILL.md` | Prospectiva sistemica local: micro-MICMAC (variables motrices vs dependientes) y micro-MACTOR (ac... |
 | rbac-management | `.opencode/skills/rbac-management/SKILL.md` | Usar cuando se gestionan roles, permisos o se audita el acceso de usuarios. |
 | reflection-validation | `.opencode/skills/reflection-validation/SKILL.md` | Usar cuando una respuesta o decisión importante necesita validación metacognitiva (System 2). |
 | regulatory-compliance | `.opencode/skills/regulatory-compliance/SKILL.md` | Usar cuando se valida el cumplimiento de marcos regulatorios sectoriales. |

--- a/docs/hooks-coverage-matrix.md
+++ b/docs/hooks-coverage-matrix.md
@@ -6,7 +6,7 @@
 
 | Total hooks | TS Guards | Git Hook mitigated | CI Job mitigated | NONE |
 |---|---|---|---|---|
-| 118 | 18 (15.3%) | 4 | 5 | 91 |
+| 121 | 18 (14.9%) | 4 | 5 | 94 |
 
 ## Bloqueantes sin cobertura ni mitigacion
 
@@ -14,10 +14,10 @@ Ninguno — AC-2.2 satisfecho.
 
 ## Cobertura real OpenCode
 
-- **TS Guards activos**: 18/118 (15.3%)
-- **Hooks sin cobertura TS**: 91 (77.1%)
+- **TS Guards activos**: 18/121 (14.9%)
+- **Hooks sin cobertura TS**: 94 (77.7%)
   - De los cuales son bloqueantes sin ninguna mitigacion: 0
-  - Eventos no disponibles en OpenCode (degradacion aceptada): 30
+  - Eventos no disponibles en OpenCode (degradacion aceptada): 33
 
 ## Full matrix
 
@@ -116,8 +116,10 @@ Ninguno — AC-2.2 satisfecho.
 | PreToolUse | auto-zoom-out.sh | si | TS_GUARD | warning | autoZoomOut |
 | PreToolUse | blast-radius-hook.sh | no | NONE | warning | degradacion_documentada: solo Claude Code |
 | PreToolUse | plan-gate.sh | no | CI_JOB | warning | CI validate-ci-local.sh |
+| SessionEnd | cache-hygiene-hook.sh | no | NONE | telemetria | evento SessionEnd no disponible en OpenCode — degradacion_documentada |
 | SessionEnd | session-end-memory.sh | no | NONE | telemetria | evento SessionEnd no disponible en OpenCode — degradacion_documentada |
 | SessionStart | mind-virus-load-gate.sh | no | NONE | bloqueante | evento SessionStart no disponible en OpenCode — degradacion_documentada |
+| SessionStart | cache-hygiene-hook.sh | no | NONE | telemetria | evento SessionStart no disponible en OpenCode — degradacion_documentada |
 | SessionStart | emergency-mode-readiness.sh | no | NONE | telemetria | evento SessionStart no disponible en OpenCode — degradacion_documentada |
 | SessionStart | session-init.sh | no | NONE | telemetria | evento SessionStart no disponible en OpenCode — degradacion_documentada |
 | SessionStart | shield-autostart.sh | no | NONE | telemetria | evento SessionStart no disponible en OpenCode — degradacion_documentada |
@@ -135,6 +137,7 @@ Ninguno — AC-2.2 satisfecho.
 | SubagentStop | subagent-lifecycle.sh | no | NONE | telemetria | evento SubagentStop no disponible en OpenCode — degradacion_documentada |
 | TaskCompleted | task-lifecycle.sh | no | NONE | telemetria | evento TaskCompleted no disponible en OpenCode — degradacion_documentada |
 | TaskCreated | task-lifecycle.sh | no | NONE | telemetria | evento TaskCreated no disponible en OpenCode — degradacion_documentada |
+| UserPromptSubmit | cache-hygiene-hook.sh | no | NONE | telemetria | evento UserPromptSubmit no disponible en OpenCode — degradacion_documentada |
 | UserPromptSubmit | memory-prime-hook.sh | no | NONE | telemetria | evento UserPromptSubmit no disponible en OpenCode — degradacion_documentada |
 | UserPromptSubmit | re-anchor-redlines.sh | no | NONE | telemetria | evento UserPromptSubmit no disponible en OpenCode — degradacion_documentada |
 | UserPromptSubmit | recommendation-tribunal-followup.sh | no | NONE | telemetria | evento UserPromptSubmit no disponible en OpenCode — degradacion_documentada |

--- a/docs/specs/SE-371-cache-hygiene.spec.md
+++ b/docs/specs/SE-371-cache-hygiene.spec.md
@@ -89,6 +89,14 @@ Nota: `MEMORY.md` ya NO está en el prefijo (AC-4); se carga bajo demanda.
 
 `opencode.json` `instructions` deja de listar `.claude/external-memory/auto/MEMORY.md`. El acceso a memoria sigue disponible: `scripts/memory-store.sh recall`, auto-prime por turno, y skill `savia-memory`.
 
+### 5.6 Activación en runtime (hooks)
+
+- `.opencode/hooks/cache-hygiene-hook.sh` registrado en `.claude/settings.json`:
+  - `SessionStart` → `start`: snapshot del prefijo + marker `data/.cache-session-active`.
+  - `UserPromptSubmit` → `preturn`: `check` contra el snapshot; si hay mutación escribe en `output/.cache-hygiene.log` (nunca contamina el prompt, exit 0 siempre).
+  - `SessionEnd` → `end`: limpia el marker y regeneración diferida de AGENTS/SKILLS solo si hay drift real (--check → --apply).
+- Los generadores congelan si `SAVIA_SESSION_ACTIVE=1` **o** existe el marker (sesión viva) — SE-371 §5.3 extendido.
+
 ## 6. Criterios de aceptación
 
 - **AC-0** `cache-hygiene.sh snapshot` genera el fichero de snapshot con hashes (test con manifest temporal).

--- a/scripts/agents-md-generate.sh
+++ b/scripts/agents-md-generate.sh
@@ -58,9 +58,13 @@ done
 # SE-371: congelación en sesión activa — regenerar AGENTS.md a mitad de una
 # conversación invalida el prefijo de instrucciones (prompt cache) en el
 # siguiente turno. Los runs autónomos/cron sin sesión viva regeneran normal.
-if [[ "${MODE:-print}" == "apply" && "${SAVIA_SESSION_ACTIVE:-0}" == "1" ]]; then
-  echo "SKIP: SAVIA_SESSION_ACTIVE=1 — regeneración de AGENTS.md congelada (SE-371)." >&2
-  exit 3
+# Sesión activa = env SAVIA_SESSION_ACTIVE=1 o marker del hook cache-hygiene.
+if [[ "${MODE:-print}" == "apply" ]]; then
+  _cache_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  if [[ "${SAVIA_SESSION_ACTIVE:-0}" == "1" || -f "$_cache_root/data/.cache-session-active" ]]; then
+    echo "SKIP: sesión activa (SE-371) — regeneración de AGENTS.md congelada." >&2
+    exit 3
+  fi
 fi
 
 # Extract a single field from frontmatter. Handles both `key: value` and the

--- a/scripts/skills-md-generate.sh
+++ b/scripts/skills-md-generate.sh
@@ -45,9 +45,13 @@ done
 
 # SE-371: congelación en sesión activa — regenerar SKILLS.md a mitad de una
 # conversación invalida el prefijo de instrucciones (prompt cache).
-if [[ "${MODE:-print}" == "apply" && "${SAVIA_SESSION_ACTIVE:-0}" == "1" ]]; then
-  echo "SKIP: SAVIA_SESSION_ACTIVE=1 — regeneración de SKILLS.md congelada (SE-371)." >&2
-  exit 3
+# Sesión activa = env SAVIA_SESSION_ACTIVE=1 o marker del hook cache-hygiene.
+if [[ "${MODE:-print}" == "apply" ]]; then
+  _cache_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  if [[ "${SAVIA_SESSION_ACTIVE:-0}" == "1" || -f "$_cache_root/data/.cache-session-active" ]]; then
+    echo "SKIP: sesión activa (SE-371) — regeneración de SKILLS.md congelada." >&2
+    exit 3
+  fi
 fi
 
 extract_field() {

--- a/tests/bats/test-cache-hygiene.bats
+++ b/tests/bats/test-cache-hygiene.bats
@@ -120,3 +120,22 @@ PY
     run bats tests/bats/test-se364-evidence-loop.bats
     [ "$status" -eq 0 ]
 }
+
+@test "SE-371 AC-8: marker de sesion congela auto-regeneradores sin env" {
+    mkdir -p data
+    touch data/.cache-session-active
+    run bash scripts/agents-md-generate.sh --apply
+    [ "$status" -eq 3 ]
+    run bash scripts/skills-md-generate.sh --apply
+    [ "$status" -eq 3 ]
+    rm -f data/.cache-session-active
+}
+
+@test "SE-371 AC-9: cache-hygiene-hook start crea snapshot+marker y end limpia" {
+    bash .opencode/hooks/cache-hygiene-hook.sh start </dev/null
+    [ -f data/cache-prefix.snapshot ]
+    [ -f data/.cache-session-active ]
+    bash .opencode/hooks/cache-hygiene-hook.sh end </dev/null
+    [ ! -f data/.cache-session-active ]
+}
+


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)
feat(hooks): SE-371 activar cache hygiene en runtime. Ver resumen tecnico en la seccion Summary de este PR.
## Summary
feat(hooks): SE-371 activar cache hygiene en runtime
### Changes
- f6c70916 fix(hooks): set -uo pipefail en primeras lineas (hook safety)
- 1434168b Merge remote-tracking branch 'origin/agent/se371-cache-activation' into agent/se371-cache-activation
- 67d2007b docs(changelog): resolver colision 6.17.7 (#1071) -> 6.17.8 (activacion cache)
- 88cea72d Merge remote-tracking branch 'origin/main' into agent/se371-cache-activation
- 92730d4a docs(hooks): regenerar matriz de cobertura (registros cache-hygiene)
- 194da759 chore: re-sign after conflict resolution
- ddd96e59 Merge remote-tracking branch 'origin/main' into agent/se371-cache-activation
- 9b4c7a25 docs(changelog): 6.17.7 — SE-371 activacion cache hygiene
- 8cf3f6d5 feat(SE-371): activar cache hygiene en runtime (hooks SessionStart/UserPromptSubmit/SessionEnd)
### Stats
11 files changed across 9 commits.
## Test plan
- [x] CI passed  - [x] Signed
