### PR TITLE
feat(skills): adopta Obscura como navegador headless nativo de Savia (depreca Lightpanda)

### DIFF
--- a/.claude/skills/lightpanda-browser/SKILL.md
+++ b/.claude/skills/lightpanda-browser/SKILL.md
@@ -1,17 +1,23 @@
 ---
 layer: peripheral
 name: lightpanda-browser
-description: "Usar cuando se necesita navegacion web headless avanzada (JS-heavy sites, SPAs, extraccion markdown de URLs, web scraping que requiere renderizado JS). Triggers: 'navega a', 'extrae contenido de', 'scrapea', 'renderiza esta pagina', 'dump markdown', 'web automation', 'headless browser'."
+description: "DEPRECATED 2026-09-04 — sustituida por obscura-browser. No usar en casos nuevos. Se conserva como referencia histórica: Obscura gana en licencia (Apache-2.0 vs AGPL), telemetría (cero vs ON por defecto) y recursos (41MB RAM)."
 metadata:
   # --- metadata.savia.* (SE-333) ---
   savia.category: tool
   savia.context: project
-  savia.maturity: experimental
-  savia.priority: medium
-  savia.tags: "browser, headless, web, scraping, markdown, mcp, automation, lightpanda"
+  savia.maturity: deprecated
+  savia.priority: low
+  savia.tags: "browser, headless, web, scraping, markdown, mcp, automation, lightpanda, deprecated"
 ---
 
 # lightpanda-browser
+
+> **DEPRECATED 2026-09-04** — Sustituida por `obscura-browser`.
+> Motivo (benchmark `output/research/obscura-vs-playwright-20260904.md`):
+> Obscura ofrece Apache-2.0 bundlable vs AGPL, cero telemetría (Lightpanda la
+> tiene ON por defecto) y 3x menos RAM. No iniciar casos nuevos con Lightpanda.
+> Contenido conservado como referencia.
 
 Navegador headless optimizado para IA. 9x mas rapido y 16x menos RAM que Chrome.
 Escrito en Zig. AGPL-3.0 — solo como herramienta externa, nunca bundled.

--- a/.claude/skills/obscura-browser/SKILL.md
+++ b/.claude/skills/obscura-browser/SKILL.md
@@ -1,0 +1,101 @@
+---
+layer: peripheral
+name: obscura-browser
+description: "Navegador headless nativo de Savia para fetch/scrape (Rust, sin Chromium, 41MB RAM, sin telemetria). Usar cuando se navega a, se extrae contenido de, se scrapea, se renderiza JS, o se necesita CDP/MCP headless. NO para e2e (usar Playwright)."
+metadata:
+  savia.category: tool
+  savia.context: project
+  savia.maturity: experimental
+  savia.priority: high
+  savia.tags: "browser, headless, scraping, markdown, cdp, mcp, obscura, rust"
+  savia.loop_level: "L0"
+  savia.trigger_keywords: "navega a, extrae contenido de, scrapea, renderiza esta pagina, headless browser, obscura"
+---
+
+# Skill: obscura-browser
+
+Motor headless nativo de Savia: Rust + V8, motor de render propio, CDP drop-in
+para Playwright/Puppeteer, MCP nativo, anti-detect opcional, guard SSRF,
+cero telemetria. Adoptado 2026-09-04 tras benchmark vs Playwright (3x menos
+RAM, arranque frio 76ms). Depreca a lightpanda-browser.
+
+## Authoritative Paths
+
+> **Lee estos paths antes de actuar. NUNCA asumas firmas, NUNCA inventes paths.**
+
+| Para | Lee este path |
+|---|---|
+| Binario instalado | `~/.local/bin/obscura` (v0.2.1) + `~/.local/bin/obscura-worker` |
+| Fork interno (pin 8a3d048) | `~/tools/obscura` — remotes: `upstream` (h4ckf0r0day/obscura), `fork` |
+| Referencia CLI completa | `~/tools/obscura/README.md` (secciones CLI Reference, CDP API, MCP) |
+| Variables de entorno | `~/tools/obscura/docs/Environment-variables.md` |
+| Benchmark de adopcion | `output/research/obscura-vs-playwright-20260904.md` |
+| Skill deprecada (referencia) | `../lightpanda-browser/SKILL.md` |
+
+**Reglas duras**:
+- Si `~/.local/bin/obscura` no existe, ABORTA y reporta — no lo descargues sin confirmar.
+- Fork interno NUNCA recibe push a upstream. Sync solo: `git -C ~/tools/obscura fetch upstream`.
+- Apache-2.0: conserva LICENSE/NOTICE del fork. Bundling permitido (a diferencia de Lightpanda/AGPL).
+
+## Cuándo usar
+
+- Fetch con JS de paginas/SPAs y dump markdown/text/links (uso principal: research y digests)
+- Scraping paralelo de N URLs (`obscura scrape`)
+- Servidor CDP para automation ligera (Playwright `connectOverCDP`)
+- Servidor MCP para agentes (stdio o HTTP)
+- Anti-detect/stealth para sitios con bloqueo headless
+
+## Cuándo NO usar
+
+- E2E testing de web apps → Playwright + Chromium real (fidelidad de motor)
+- Visual QA / screenshots de fidelidad pixel → Playwright
+- HTML estatico simple → `curl` (mas ligero)
+- PDF de fidelidad print → Playwright (Obscura exporta PDF pero motor propio)
+
+## Decision Checklist
+
+1. ¿Es un test e2e o validacion visual? → SI: Playwright. NO: continuar.
+2. ¿Pagina estatica sin JS? → SI: curl. NO: continuar.
+3. ¿Datos N3+ en la sesion? → verifica que solo fluyen al sitio objetivo (motor local, cero telemetria).
+
+### Abort Conditions
+
+- Binario ausente o corrupto → reportar, no reinstalar autonomamente
+- Sitio exige Chromium real (DRM, WebGL pesado, media) → delegar a Playwright
+
+## Workflow
+
+```
+URL(s) + objetivo (markdown/text/eval)
+    ↓
+obscura fetch / scrape / serve (según volumen)
+    ↓
+output estructurado → digest / research / informe
+```
+
+### Detalle de cada paso
+
+1. **Un URL**: `obscura fetch "$URL" --dump markdown --quiet`
+   - Titulo rapido: `--eval "document.title"`
+   - Screenshot: `--screenshot out.png`
+   - Dev server local: `--allow-private-network`
+   - Proxy: `--proxy socks5://...` (global, antes del subcomando)
+2. **Volumen**: `obscura scrape url1 url2 ... --concurrency 10 --format json --quiet`
+3. **Sesion interactiva**: `obscura serve --port 9222 [--stealth] [--obey-robots]`
+   + Playwright: `chromium.connectOverCDP({ endpointURL: 'ws://127.0.0.1:9222' })`
+
+## Outputs esperados
+
+- stdout: markdown/text/html/json segun `--dump`/`--format`
+- Ficheros: screenshots/PDFs en `output/` con naming YYYYMMDD
+
+## Memory hooks
+
+- Fallos de sitio (Obscura no renderiza X) → `bash scripts/memory-store.sh save --type pattern --title "obscura-fallo:<dominio>" --content "<detalle>" --source skill:obscura-browser`
+
+## Related
+
+- Skill: `../lightpanda-browser/SKILL.md` (DEPRECATED — sustituida por esta)
+- Skill: `../tier3-probes/SKILL.md`
+- Research: `output/research/obscura-vs-playwright-20260904.md`
+- Upstream: https://github.com/h4ckf0r0day/obscura (Apache-2.0)

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=49de87c33994ac75c015bcac53ede6c3d29cecff525c96c6f310b33a170c9beb
-timestamp=2026-09-03T23:24:14Z
-branch=agent/se373-workspace-spec
-head_commit=f7cbc830
-signature=78196fd2f3d7ccb4519480b2dbe95fdd363fbaa3068dfd40d4bea968625b3c3f
+diff_hash=06b80a99178074074a6215b5a2eb3e3b16037864a54277ce0a9a5a6ec2f9a0c8
+timestamp=2026-09-04T11:04:48Z
+branch=agent/obscura-20260904-native-browser
+head_commit=160915e9
+signature=f1c0b3650577949a53806567dc799be6c1d73c83855f4e8804330118ab80e090

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=64eebf60675b9e9a14704fcd0dae2d8ddc98d24921e00178134a8c973ea477b3
-timestamp=2026-09-04T11:07:18Z
+timestamp=2026-09-04T12:02:39Z
 branch=agent/obscura-20260904-native-browser
-head_commit=14499b78
+head_commit=0f0489fd
 signature=4448dd6a50c73508040fd7a3ef4ef131ae42cfcf1723c19f04eda45780be4be0

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=64eebf60675b9e9a14704fcd0dae2d8ddc98d24921e00178134a8c973ea477b3
-timestamp=2026-09-04T12:02:39Z
+diff_hash=1f1979d168b69019433accde14b6d2cde9e32e473b95c1911d8198a3fec24603
+timestamp=2026-09-04T12:02:47Z
 branch=agent/obscura-20260904-native-browser
-head_commit=0f0489fd
-signature=4448dd6a50c73508040fd7a3ef4ef131ae42cfcf1723c19f04eda45780be4be0
+head_commit=382d2339
+signature=325b268d0d0a4f7dcbc0ec65ec8ae91ea75458b9fd07d8eb9a600e62b24600e7

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=06b80a99178074074a6215b5a2eb3e3b16037864a54277ce0a9a5a6ec2f9a0c8
-timestamp=2026-09-04T11:04:48Z
+diff_hash=64eebf60675b9e9a14704fcd0dae2d8ddc98d24921e00178134a8c973ea477b3
+timestamp=2026-09-04T11:07:18Z
 branch=agent/obscura-20260904-native-browser
-head_commit=160915e9
-signature=f1c0b3650577949a53806567dc799be6c1d73c83855f4e8804330118ab80e090
+head_commit=14499b78
+signature=4448dd6a50c73508040fd7a3ef4ef131ae42cfcf1723c19f04eda45780be4be0

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: 97b9ec700875 | resources: 1442
-> 295 commands · 134 skills · 88 agents · 925 scripts
+> hash: dfb6fa3a894a | resources: 1443
+> 295 commands · 135 skills · 88 agents · 925 scripts
 
 [analysis] Trace Optimize — across,distributed,optimize,rates,sampling — cmd:.claude/commands/trace-optimize.md
 [analysis] agent-activity — activity,agent,executions,recent,show — cmd:.claude/commands/agent-activity.md
@@ -873,7 +873,7 @@
 [planning] lib/mock-env — environment,library,mock,reusable,scripts — script:scripts/lib/mock-env.sh
 [planning] lib/os-detect — defaults,detect,detection,path,portable — script:scripts/lib/os-detect.sh
 [planning] lib/slm-common — common,helpers,shared,slice,subcommands — script:scripts/lib/slm-common.sh
-[planning] lightpanda-browser — avanzada,contenido,dump,extraccion,extrae — skill:.claude/skills/lightpanda-browser/SKILL.md
+[planning] lightpanda-browser — agpl,apache,browser,casos,cero — skill:.claude/skills/lightpanda-browser/SKILL.md
 [planning] llms-txt-generate — docs,full,generate,llms — script:scripts/llms-txt-generate.sh
 [planning] loop-budget-check — budget,check,loop,scripts — script:scripts/loop-budget-check.sh
 [planning] loop-run-log — append,autónomas,gestión,loop,only — script:scripts/loop-run-log.sh
@@ -905,6 +905,7 @@
 [planning] nuclei-scanning — conocidas,cves,escanean,misconfigs,nuclei — skill:.claude/skills/nuclei-scanning/SKILL.md
 [planning] objective-contract — antagonista,contract,delegado,objective,objetivo — script:scripts/objective-contract.sh
 [planning] obs-status — check,conectadas,fuentes,health,observabilidad — cmd:.claude/commands/obs-status.md
+[planning] obscura-browser — chromium,contenido,extrae,fetch,headless — skill:.claude/skills/obscura-browser/SKILL.md
 [planning] ollama-classify — clasificacion,classify,local,ollama,texto — script:scripts/ollama-classify.sh
 [planning] ollama-hardware-check — check,hardware,ollama — script:scripts/ollama-hardware-check.sh
 [planning] onboard —  — cmd:.claude/commands/onboard.md

--- a/.scm/categories/planning.scm
+++ b/.scm/categories/planning.scm
@@ -1,5 +1,5 @@
 # planning — Savia Capability Map (L1)
-> 623 resources
+> 624 resources
 
 - **/decide-architecture** (cmd): Clasifica una tarea como WORKFLOW (deterministica) o AGENT (loop). Bias hacia workflow per Anthropic. Sugiere plantilla inicial. Mide accuracy contra corpus curado de 20 tareas.
 - **_template** (skill): TEMPLATE — copia este directorio para crear una skill nueva. NO se carga en runtime.
@@ -317,7 +317,7 @@
 - **lib/mock-env** (script): mock-env.sh — Reusable mock environment library for pm-workspace scripts
 - **lib/os-detect** (script): scripts/lib/os-detect.sh — Portable OS detection and path defaults
 - **lib/slm-common** (script): slm-common.sh — Shared helpers for SLM subcommands (SE-049 Slice 1).
-- **lightpanda-browser** (skill): Usar cuando se necesita navegacion web headless avanzada (JS-heavy sites, SPAs, extraccion markdown de URLs, web scraping que requiere renderizado JS). Triggers: 'navega a', 'extrae contenido de', 'scrapea', 'renderiza esta pagina', 'dump m
+- **lightpanda-browser** (skill): DEPRECATED 2026-09-04 — sustituida por obscura-browser. No usar en casos nuevos. Se conserva como referencia histórica: Obscura gana en licencia (Apache-2.0 vs AGPL), telemetría (cero vs ON por defecto) y recursos (41MB RAM).
 - **llms-txt-generate** (script): llms-txt-generate.sh — Genera docs/llms.txt y docs/llms-full.txt (SE-269 S5)
 - **loop-budget-check** (script): scripts/loop-budget-check.sh
 - **loop-run-log** (script): loop-run-log.sh — CLI para gestión del run-log append-only de skills autónomas
@@ -349,6 +349,7 @@
 - **nuclei-scanning** (skill): Usar cuando se escanean vulnerabilidades conocidas (CVEs, misconfigs) con Nuclei.
 - **objective-contract** (script): objective-contract.sh — SE-273 S7: Objetivo delegado con antagonista obligatorio
 - **obs-status** (cmd): Health check de todas las fuentes de observabilidad conectadas
+- **obscura-browser** (skill): Navegador headless nativo de Savia para fetch/scrape (Rust, sin Chromium, 41MB RAM, sin telemetria). Usar cuando se navega a, se extrae contenido de, se scrapea, se renderiza JS, o se necesita CDP/MCP headless. NO para e2e (usar Playwright)
 - **ollama-classify** (script): ollama-classify.sh — Clasificacion local de texto con Ollama
 - **ollama-hardware-check** (script): ── ollama-hardware-check.sh ─────────────────────────────────────────────────
 - **onboard** (cmd): >

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "3f7d109856b7",
-  "total": 1442,
+  "hash": "87355d4fb9f0",
+  "total": 1443,
   "resources": [
     {
       "category": "analysis",
@@ -11544,15 +11544,15 @@
       "category": "planning",
       "name": "lightpanda-browser",
       "intents": [
-        "avanzada",
-        "contenido",
-        "dump",
-        "extraccion",
-        "extrae"
+        "agpl",
+        "apache",
+        "browser",
+        "casos",
+        "cero"
       ],
       "kind": "skill",
       "path": ".claude/skills/lightpanda-browser/SKILL.md",
-      "description": "Usar cuando se necesita navegacion web headless avanzada (JS-heavy sites, SPAs, extraccion markdown de URLs, web scraping que requiere renderizado JS). Triggers: 'navega a', 'extrae contenido de', 'scrapea', 'renderiza esta pagina', 'dump m"
+      "description": "DEPRECATED 2026-09-04 — sustituida por obscura-browser. No usar en casos nuevos. Se conserva como referencia histórica: Obscura gana en licencia (Apache-2.0 vs AGPL), telemetría (cero vs ON por defecto) y recursos (41MB RAM)."
     },
     {
       "category": "planning",
@@ -11968,6 +11968,20 @@
       "kind": "cmd",
       "path": ".claude/commands/obs-status.md",
       "description": "Health check de todas las fuentes de observabilidad conectadas"
+    },
+    {
+      "category": "planning",
+      "name": "obscura-browser",
+      "intents": [
+        "chromium",
+        "contenido",
+        "extrae",
+        "fetch",
+        "headless"
+      ],
+      "kind": "skill",
+      "path": ".claude/skills/obscura-browser/SKILL.md",
+      "description": "Navegador headless nativo de Savia para fetch/scrape (Rust, sin Chromium, 41MB RAM, sin telemetria). Usar cuando se navega a, se extrae contenido de, se scrapea, se renderiza JS, o se necesita CDP/MCP headless. NO para e2e (usar Playwright)"
     },
     {
       "category": "planning",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13211,6 +13211,7 @@ Initial public release of PM-Workspace.
 
 - **Documentation** with methodology
 
+[6.17.12]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.11...v6.17.12
 [6.17.11]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.10...v6.17.11
 [6.17.10]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.9...v6.17.10
 [6.17.9]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.17.8...v6.17.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.17.12] — 2026-09-04
+
+### Added
+- Obscura como motor de navegador headless nativo de Savia para fetch/scrape (skill obscura-browser): Rust, Apache-2.0, sin Chromium, ~41MB RAM, sin telemetria propia. Adoptado tras benchmark vs Playwright (output/research/obscura-vs-playwright-20260904.md). Depreca lightpanda-browser (AGPL no-bundlable, telemetria ON). Playwright+Chromium se conservan para e2e. Fork referenciado en ~/tools/obscura (upstream h4ckf0r0day/obscura, CRIT-001).
+
 ## [6.17.11] — 2026-09-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Identidad del humano al volante + memoria auto persistida fuera del repo.
 
 ## Estructura
 
-`.claude/{agents(88), commands(571), profiles, hooks(119/124reg), rules/{domain,languages}, skills(133), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
+`.claude/{agents(88), commands(571), profiles, hooks(119/124reg), rules/{domain,languages}, skills(134), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
 
 ## Reglas Críticas (Rules 1-8, inline)
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -77,7 +77,7 @@ To use a skill: read `<path>` and follow its instructions.
 | iac-security-scanner | `.opencode/skills/iac-security-scanner/SKILL.md` | Usar cuando se escanea IaC (Terraform, Bicep, Dockerfile, docker-compose) con Trivy config para d... |
 | knowledge-graph | `.opencode/skills/knowledge-graph/SKILL.md` | Usar cuando se construye o consulta el grafo de conocimiento de entidades del proyecto. |
 | legal-compliance | `.opencode/skills/legal-compliance/SKILL.md` | Usar cuando se audita compliance legal contra legislación española consolidada. |
-| lightpanda-browser | `.opencode/skills/lightpanda-browser/SKILL.md` | Usar cuando se necesita navegacion web headless avanzada (JS-heavy sites, SPAs, extraccion markdo... |
+| lightpanda-browser | `.opencode/skills/lightpanda-browser/SKILL.md` | DEPRECATED 2026-09-04 — sustituida por obscura-browser. No usar en casos nuevos. Se conserva co... |
 | managed-content | `.opencode/skills/managed-content/SKILL.md` | Usar cuando se regeneran secciones auto-generadas en documentos con marcadores de seguridad. |
 | meeting-transcript-extract | `.opencode/skills/meeting-transcript-extract/SKILL.md` | Usar cuando se necesita extraer la transcripción de una reunión Teams desde el browser. |
 | memvid-backup | `.opencode/skills/memvid-backup/SKILL.md` | Usar cuando se crea un backup portable de la memoria externa de Savia. |
@@ -87,6 +87,7 @@ To use a skill: read `<path>` and follow its instructions.
 | mutation-audit | `.opencode/skills/mutation-audit/SKILL.md` | Usar cuando se quiere medir la calidad real de los tests mediante mutation testing. |
 | network-recon | `.opencode/skills/network-recon/SKILL.md` | Reconocimiento de red: port scan con nmap/RustScan + HTTP detection con httpx. |
 | nuclei-scanning | `.opencode/skills/nuclei-scanning/SKILL.md` | Usar cuando se escanean vulnerabilidades conocidas (CVEs, misconfigs) con Nuclei. |
+| obscura-browser | `.opencode/skills/obscura-browser/SKILL.md` | Navegador headless nativo de Savia para fetch/scrape (Rust, sin Chromium, 41MB RAM, sin telemetri... |
 | onboarding-dev | `.opencode/skills/onboarding-dev/SKILL.md` | Usar cuando se incorpora un desarrollador nuevo al proyecto y necesita buddy IA. |
 | org-meeting-capture | `.opencode/skills/org-meeting-capture/SKILL.md` | Captura de Conocimiento Tácito de Reunión: extrae decisores, acuerdos informales y señales pol... |
 | org-political-landscape | `.opencode/skills/org-political-landscape/SKILL.md` | Análisis de Paisaje Político Interno: detecta tensiones, alianzas y centros de poder a partir d... |


### PR DESCRIPTION
## Resumen

Tras analizar y testear [h4ckf0r0day/obscura](https://github.com/h4ckf0r0day/obscura) frente a Playwright, este PR adopta Obscura — motor de navegador headless en Rust (Apache-2.0, sin Chromium: V8 embebido + motor de render propio + CDP + MCP) — como motor de **fetch/scrape nativo** de Savia. La evaluación completa con benchmark está en `output/research/obscura-vs-playwright-20260904.md`.

## Qué cambia

- **Skill nueva** `.claude/skills/obscura-browser/SKILL.md`: navegador headless nativo (paths autoritativos, triggers, anti-patrones, workflow fetch/scrape/serve-CDP).
- **Skill deprecada** `.claude/skills/lightpanda-browser/SKILL.md`: sustituida por Obscura (gana en licencia Apache-2.0 vs AGPL no-bundlable, cero telemetría vs telemetría ON, ~3x menos RAM). Contenido conservado como referencia.
- **Índices**: `SKILLS.md` regenerado (obscura-browser añadida, lightpanda marcada deprecated), counter de skills en `CLAUDE.md` 133→134.

## Métricas medidas (2026-09-04, máquina local)

| Test | Obscura v0.2.1 | Chromium/Playwright |
|---|---|---|
| RAM pico (fetch HN + JS) | **41 MB** | ~129 MB |
| Arranque frío example.com | **76 ms** | 423 ms |
| Wikipedia (layout complejo) | 1890–2491 ms | **920 ms** |
| CDP drop-in (`connectOverCDP`) | Verificado, enmascara Chrome/145 | nativo |
| Telemetría propia | **cero** (auditado en fuente) | — |

## Por qué así (y por qué no es un reemplazo total)

- **Sí**: fetch/scrape/research (domina el uso de navegador en Savia) — 3x menos RAM, arranque frío 10x, markdown nativo, scraping paralelo, MCP, anti-detect opcional, guard SSRF, cero telemetría.
- **CRIT-001 (soberanía)**: PASS. Motor 100% local, sin phone-home, bloquea trackers de terceros (3.520 dominios) — minimiza fuga incidental de datos N3+. Equivalente a Playwright en soberanía, superior en minimización.
- **No**: NO sustituye a Playwright para e2e/visual QA. Motor de render propio joven (artefactos de glifo incluso en example.com); testear contra motor no-Chromium daría falsa confianza. `web-e2e-tester` y `visual-qa-agent` conservan Playwright+Chromium.

## Fork absorbido (fuera del diff, infraestructura local)

- Fork standalone: `~/tools/obscura` (historial completo; remotes `fork` + `upstream` → h4ckf0r0day/obscura; pin `8a3d048`, v0.2.1). Referenciado para futuras actualizaciones — sync manual `git -C ~/tools/obscura fetch upstream`.
- Binarios: `~/.local/bin/obscura` + `obscura-worker` (v0.2.1, build con render).
- Fuera del repo pm-workspace por diseño (motor externo, no código del workspace).

## Riesgo estimado

**Bajo-medio.** Cambio aditivo (skill nueva + deprecación) sin tocar pipelines ni agentes existentes. Riesgo de fondo: Obscura es proyecto joven (2026-04) con bus factor concentrado (SGavrl ~65% commits recientes) — mitigado por el fork referenciado. No hay cambios en tiempo de ejecución de Savia hasta que una skill/agente invoque el binario.

## Notas

- `package.json` quedó modificado en el working tree de main (añade `playwright`), **excluido** de este PR — cambio no atribuido a esta tarea, pendiente de inspección.
- Sin auto-merge. Revisión humana requerida.