### PR TITLE
feat(scripts): SE-375 canonical capability registry (S1)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=a73b4a808987687276b7c227f688643b04c66a07120cc8bb3bb119bbcc550566
-timestamp=2026-09-05T07:26:35Z
-branch=agent/impl-20260905-wave1-coherence
-head_commit=d99b02dd
-signature=045d4dbc5851b9c09c4579cd6dae4c23b4ccaba9cb5a2ad973dad08373dc496e
+diff_hash=f633129d8dd1efa715870d783588cc5eb1cffec02ba6aa0af96aac945600afc4
+timestamp=2026-09-05T07:45:30Z
+branch=agent/impl-20260905-se375-registry
+head_commit=4df07e6d
+signature=16fb76f6d59605d7cacb1c9b260201154c99296fbd0e8d7f7a202a27ca45a104

--- a/.scm/registry.json
+++ b/.scm/registry.json
@@ -1,0 +1,29553 @@
+{
+  "capabilities": [
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/trace-optimize",
+      "intents": [
+        "across",
+        "distributed",
+        "optimize",
+        "rates",
+        "sampling"
+      ],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/trace-optimize.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/agent-activity",
+      "intents": [
+        "activity",
+        "agent",
+        "executions",
+        "recent",
+        "show"
+      ],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/agent-activity.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-activity",
+      "intents": [
+        "activity",
+        "agent",
+        "dashboard"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-activity.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-budget-check",
+      "intents": [
+        "agent",
+        "budget",
+        "check",
+        "limits",
+        "requestor"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-budget-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-budget-lookup",
+      "intents": [
+        "agent",
+        "budget",
+        "extract",
+        "frontmatter",
+        "lookup"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-budget-lookup.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/agent-code-map/SKILL",
+      "intents": [
+        "agente",
+        "arquitectura",
+        "completos",
+        "conocer",
+        "ficheros"
+      ],
+      "kind": "skill",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/agent-code-map/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/agent-cost",
+      "intents": [
+        "agentes",
+        "coste",
+        "estimado",
+        "proyecto",
+        "sprint"
+      ],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/agent-cost.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-degradation-canary",
+      "intents": [
+        "agent",
+        "canary",
+        "degradation"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-degradation-canary.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-depth-limit",
+      "intents": [
+        "agent",
+        "build",
+        "check",
+        "depth",
+        "graph"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-depth-limit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-discipline-audit",
+      "intents": [
+        "agent",
+        "audit",
+        "discipline",
+        "maxsteps",
+        "model"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-discipline-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-effort-meter",
+      "intents": [
+        "actual",
+        "agent",
+        "count",
+        "effort",
+        "measure"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-effort-meter.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-escalation-gate",
+      "intents": [
+        "agent",
+        "declared",
+        "escalation",
+        "gate",
+        "request"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-escalation-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/agent-file-map/SKILL",
+      "intents": [
+        "agentes",
+        "deben",
+        "externos",
+        "ficheros",
+        "localizar"
+      ],
+      "kind": "skill",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/agent-file-map/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-gate",
+      "intents": [
+        "agent",
+        "gate",
+        "gates",
+        "inherited",
+        "quality"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-hook-runner",
+      "intents": [
+        "agent",
+        "gate",
+        "hook",
+        "hooks",
+        "runner"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-hook-runner.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-index-generate",
+      "intents": [
+        "agent",
+        "cards",
+        "federated",
+        "generate",
+        "index"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-index-generate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-journal",
+      "intents": [
+        "agent",
+        "append",
+        "autónomos",
+        "journal",
+        "jsonl"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-journal.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/agent-memory",
+      "intents": [
+        "fragments",
+        "inspect",
+        "manage",
+        "memory",
+        "persistent"
+      ],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/agent-memory.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/agent-messaging/SKILL",
+      "intents": [
+        "agent",
+        "agente",
+        "debe",
+        "enviar",
+        "inbox"
+      ],
+      "kind": "skill",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/agent-messaging/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-messaging",
+      "intents": [
+        "agent",
+        "agente",
+        "lección",
+        "local",
+        "mensajería"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-messaging.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-permission-audit",
+      "intents": [
+        "agent",
+        "audit",
+        "declarations",
+        "permission",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-permission-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-recurrence-report",
+      "intents": [
+        "agent",
+        "identifies",
+        "recurrence",
+        "recurring",
+        "report"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-recurrence-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-request-validate",
+      "intents": [
+        "agent",
+        "incoming",
+        "origin",
+        "request",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-request-validate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/agent-run",
+      "intents": [
+        "agent",
+        "batch",
+        "claude",
+        "launch",
+        "pending"
+      ],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/agent-run.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-run-log",
+      "intents": [
+        "agent",
+        "append",
+        "experiment",
+        "only",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-run-log.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-run-logger",
+      "intents": [
+        "agent",
+        "agentrunsummary",
+        "logger",
+        "telemetry"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-run-logger.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-run-report",
+      "intents": [
+        "agent",
+        "agentrunsummary",
+        "generator",
+        "report"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-run-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/agent-runs-board/SKILL",
+      "intents": [
+        "agent",
+        "autónomo",
+        "board",
+        "code",
+        "consulta"
+      ],
+      "kind": "skill",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/agent-runs-board/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-scratchpad",
+      "intents": [
+        "agent",
+        "agents",
+        "document",
+        "parallel",
+        "scratchpad"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-scratchpad.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-size-audit",
+      "intents": [
+        "agent",
+        "audit",
+        "every",
+        "measure",
+        "probe"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-size-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-size-remediation-plan",
+      "intents": [
+        "agent",
+        "analyzer",
+        "plan",
+        "remediation",
+        "size"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-size-remediation-plan.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-sla-router",
+      "intents": [
+        "agent",
+        "differentiated",
+        "origin",
+        "router",
+        "type"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-sla-router.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-surface-guard",
+      "intents": [
+        "agent",
+        "declared",
+        "editable",
+        "guard",
+        "runs"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-surface-guard.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-tick",
+      "intents": [
+        "abtop",
+        "agent",
+        "heavy",
+        "light",
+        "pattern"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-tick.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-time-budget",
+      "intents": [
+        "agent",
+        "budget",
+        "budgeted",
+        "command",
+        "runner"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-time-budget.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agent-wait-idle",
+      "intents": [
+        "agent",
+        "detect",
+        "idle",
+        "process",
+        "wait"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agent-wait-idle.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/bus-factor-report",
+      "intents": [
+        "ejecutivo",
+        "factor",
+        "informe",
+        "report",
+        "scan"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/bus-factor-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/case-recompute",
+      "intents": [
+        "adjusted",
+        "business",
+        "case",
+        "recompute",
+        "risk"
+      ],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/case-recompute.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/ceo-report",
+      "intents": [
+        "delivery",
+        "dirección",
+        "ejecutivo",
+        "equipo",
+        "informe"
+      ],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/ceo-report.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/classifier-fp-report",
+      "intents": [
+        "classifier",
+        "falsos",
+        "positivos",
+        "report",
+        "reporte"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/classifier-fp-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/completeness-judge",
+      "intents": [
+        "abstract",
+        "covers",
+        "judge",
+        "promises",
+        "report"
+      ],
+      "kind": "agent",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/completeness-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/debt-analyze",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/debt-analyze.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/debt-budget-check",
+      "intents": [
+        "activo",
+        "actual",
+        "budget",
+        "check",
+        "debt"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/debt-budget-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/debt-track",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/debt-track.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/enterprise-dashboard",
+      "intents": [
+        "analytics",
+        "enterprise",
+        "forecasting",
+        "health",
+        "matrix"
+      ],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/enterprise-dashboard.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/billing-report",
+      "intents": [
+        "billing",
+        "ifrs",
+        "project",
+        "report"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/billing-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/client-health-report",
+      "intents": [
+        "client",
+        "health",
+        "intelligence",
+        "report"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/client-health-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/eval-improvement-suggest",
+      "intents": [
+        "eval",
+        "generate",
+        "improvement",
+        "proposals",
+        "reports"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/eval-improvement-suggest.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/executive-reporting/SKILL",
+      "intents": [
+        "dirección",
+        "ejecutivo",
+        "informe",
+        "multi",
+        "proyecto"
+      ],
+      "kind": "skill",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/executive-reporting/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/kg-quality-report",
+      "intents": [
+        "health",
+        "metrics",
+        "quality",
+        "report",
+        "weekly"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/kg-quality-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/kpi-antagonist-gate",
+      "intents": [
+        "antagonist",
+        "anti",
+        "gate",
+        "goodhart"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/kpi-antagonist-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/kpi-catalog-validate",
+      "intents": [
+        "catalog",
+        "validate",
+        "validator"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/kpi-catalog-validate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/kpi-compute",
+      "intents": [
+        "artifacts",
+        "computation",
+        "compute",
+        "verifiable"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/kpi-compute.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/kpi-custody-chain",
+      "intents": [
+        "chain",
+        "custody"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/kpi-custody-chain.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/kpi-dashboard",
+      "intents": [
+        "completo",
+        "dashboard",
+        "definidos",
+        "docs",
+        "equipo"
+      ],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/kpi-dashboard.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/kpi-dora",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/kpi-dora.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/kpi-review-report",
+      "intents": [
+        "periodic",
+        "report",
+        "review"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/kpi-review-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/learning-metric",
+      "intents": [
+        "aprendizaje",
+        "determinista",
+        "learning",
+        "metric",
+        "métrica"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/learning-metric.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/learning-report",
+      "intents": [
+        "aprendizaje",
+        "learning",
+        "periódico",
+        "report",
+        "reporte"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/learning-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/reconciliation-stats",
+      "intents": [
+        "append",
+        "classification",
+        "metrics",
+        "reconciliation",
+        "report"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/reconciliation-stats.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/relacion-report",
+      "intents": [
+        "relacion",
+        "report",
+        "scripts",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/relacion-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/report-capacity",
+      "intents": [
+        "alertas",
+        "asignación",
+        "capacidades",
+        "carga",
+        "disponibilidad"
+      ],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/report-capacity.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/report-executive",
+      "intents": [
+        "dirección",
+        "ejecutivo",
+        "formato",
+        "informe",
+        "multi"
+      ],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/report-executive.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/report-hours",
+      "intents": [
+        "actual",
+        "especificado",
+        "horas",
+        "imputación",
+        "informe"
+      ],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/report-hours.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/report-verify",
+      "intents": [
+        "convene",
+        "evaluate",
+        "judges",
+        "reliability",
+        "report"
+      ],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/report-verify.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/resilience-report",
+      "intents": [
+        "agent",
+        "agentrunsummary",
+        "metrics",
+        "report",
+        "resilience"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/resilience-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/risk-predict",
+      "intents": [
+        "basada",
+        "datos",
+        "históricos",
+        "predicción",
+        "riesgo"
+      ],
+      "kind": "cmd",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/risk-predict.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/risk-scoring/SKILL",
+      "intents": [
+        "calcula",
+        "decidir",
+        "nivel",
+        "requerido",
+        "revisión"
+      ],
+      "kind": "skill",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/risk-scoring/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/rules-traceability/SKILL",
+      "intents": [
+        "completa",
+        "mapean",
+        "negocio",
+        "pbis",
+        "reglas"
+      ],
+      "kind": "skill",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/rules-traceability/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/scope-trace-gate",
+      "intents": [
+        "gate",
+        "runner",
+        "scope",
+        "standalone",
+        "trace"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/scope-trace-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/source-traceability-judge",
+      "intents": [
+        "citation",
+        "claim",
+        "every",
+        "judge",
+        "must"
+      ],
+      "kind": "agent",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/source-traceability-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/telemetry-report",
+      "intents": [
+        "degradación",
+        "estático",
+        "informe",
+        "report",
+        "telemetry"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/telemetry-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/time-tracking-report/SKILL",
+      "intents": [
+        "excel",
+        "generan",
+        "horas",
+        "imputación",
+        "informes"
+      ],
+      "kind": "skill",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/time-tracking-report/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/trace-export-otlp",
+      "intents": [
+        "export",
+        "otlp",
+        "telemetría",
+        "trace"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/trace-export-otlp.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/trace-pattern-extractor",
+      "intents": [
+        "agent",
+        "analyze",
+        "extractor",
+        "pattern",
+        "phase"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/trace-pattern-extractor.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/truth-tribunal",
+      "intents": [
+        "evaluation",
+        "judge",
+        "orchestrate",
+        "reliability",
+        "reports"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/truth-tribunal.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/turn-sdlc-report",
+      "intents": [
+        "report",
+        "reporte",
+        "sdlc",
+        "turn",
+        "ventana"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/turn-sdlc-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/vaults-health-report",
+      "intents": [
+        "health",
+        "quality",
+        "report",
+        "vault",
+        "vaults"
+      ],
+      "kind": "script",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/vaults-health-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/weekly-report/SKILL",
+      "intents": [
+        "estado",
+        "informe",
+        "proyecto",
+        "semanal"
+      ],
+      "kind": "skill",
+      "owner_domain": "analysis",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/weekly-report/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/archive-digest",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/archive-digest.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/contract-pin",
+      "intents": [
+        "contract",
+        "digest",
+        "pins"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/contract-pin.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/digest-extract",
+      "intents": [
+        "capa",
+        "digest",
+        "extracción",
+        "extract",
+        "markitdown"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/digest-extract.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/excel-digest",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/excel-digest.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/glm-compute-digest",
+      "intents": [
+        "compute",
+        "computes",
+        "digest",
+        "governance",
+        "json"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/glm-compute-digest.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/glm-verify",
+      "intents": [
+        "computed",
+        "digest",
+        "manifest",
+        "matches",
+        "value"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/glm-verify.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/inbox-check",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/inbox-check.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/inbox-start",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/inbox-start.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/kg-pipeline",
+      "intents": [
+        "digest",
+        "extract",
+        "output",
+        "persist",
+        "pipeline"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/kg-pipeline.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/masked-digest",
+      "intents": [
+        "digest",
+        "digestion",
+        "masked",
+        "pipeline"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/masked-digest.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/meeting-confidentiality-judge",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/meeting-confidentiality-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/meeting-digest",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/meeting-digest.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/meeting-digest",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/meeting-digest.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/meeting-risk-analyst",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/meeting-risk-analyst.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/meeting-transcript-extract/SKILL",
+      "intents": [
+        "browser",
+        "extraer",
+        "reunión",
+        "teams",
+        "transcripción"
+      ],
+      "kind": "skill",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/meeting-transcript-extract/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/notify",
+      "intents": [
+        "cross",
+        "desktop",
+        "notifications",
+        "notify",
+        "platform"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/notify.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/org-meeting-capture/SKILL",
+      "intents": [
+        "acuerdos",
+        "captura",
+        "conocimiento",
+        "decisores",
+        "extrae"
+      ],
+      "kind": "skill",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/org-meeting-capture/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/pdf-digest",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/pdf-digest.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/pptx-digest",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/pptx-digest.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-announce",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-announce.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-attest",
+      "intents": [
+        "attest",
+        "savia",
+        "scripts",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-attest.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-backup",
+      "intents": [
+        "backup",
+        "restore",
+        "savia",
+        "script"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-backup.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-board",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-board.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-bootstrap-log",
+      "intents": [
+        "arranque",
+        "bootstrap",
+        "consolidacion",
+        "instalación",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-bootstrap-log.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-branch",
+      "intents": [
+        "abstraction",
+        "branch",
+        "company",
+        "layer",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-branch.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-broadcast",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-broadcast.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-compat",
+      "intents": [
+        "compat",
+        "compatibility",
+        "cross",
+        "helpers",
+        "platform"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-compat.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-crypto",
+      "intents": [
+        "crypto",
+        "encryption",
+        "hybrid",
+        "only",
+        "openssl"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-crypto.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-crypto-ops",
+      "intents": [
+        "crypto",
+        "decrypt",
+        "encrypt",
+        "operations",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-crypto-ops.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-directory",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-directory.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-double-optin-check",
+      "intents": [
+        "check",
+        "double",
+        "optin",
+        "savia",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-double-optin-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-dual",
+      "intents": [
+        "anthropic",
+        "dual",
+        "failover",
+        "gemma",
+        "gestiona"
+      ],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-dual.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/savia-dual/SKILL",
+      "intents": [
+        "cloud",
+        "está",
+        "failover",
+        "falla",
+        "inferencia"
+      ],
+      "kind": "skill",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/savia-dual/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-enterprise",
+      "intents": [
+        "enterprise",
+        "lifecycle",
+        "manager",
+        "module",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-enterprise.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-env",
+      "intents": [
+        "agnostic",
+        "environment",
+        "layer",
+        "provider",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-env.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-flow",
+      "intents": [
+        "based",
+        "boards",
+        "branch",
+        "flow",
+        "isolation"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-flow.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-flow-board",
+      "intents": [
+        "ascii",
+        "board",
+        "branch",
+        "flow",
+        "isolation"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-flow-board.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-flow-ops",
+      "intents": [
+        "assignments",
+        "branch",
+        "crud",
+        "flow",
+        "isolation"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-flow-ops.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/savia-flow-practice/SKILL",
+      "intents": [
+        "dual",
+        "flow",
+        "flujo",
+        "implementa",
+        "métricas"
+      ],
+      "kind": "skill",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/savia-flow-practice/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-flow-sprint",
+      "intents": [
+        "branch",
+        "flow",
+        "isolation",
+        "lifecycle",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-flow-sprint.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-flow-tasks",
+      "intents": [
+        "delegates",
+        "flow",
+        "management",
+        "savia",
+        "task"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-flow-tasks.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-flow-templates",
+      "intents": [
+        "branch",
+        "flow",
+        "isolation",
+        "member",
+        "project"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-flow-templates.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-flow-timesheet",
+      "intents": [
+        "branch",
+        "flow",
+        "savia",
+        "time",
+        "timesheet"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-flow-timesheet.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-forget",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-forget.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-gallery",
+      "intents": [
+        "agentes",
+        "catálogo",
+        "comandos",
+        "interactivo",
+        "skills"
+      ],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-gallery.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-goal",
+      "intents": [
+        "codex",
+        "cross",
+        "equivalente",
+        "establece",
+        "gestiona"
+      ],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-goal.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-goal",
+      "intents": [
+        "goal",
+        "lifecycle",
+        "management",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-goal.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-goals",
+      "intents": [
+        "claimed",
+        "durables",
+        "goals",
+        "heartbeats",
+        "lección"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-goals.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-hub-init",
+      "intents": [
+        "init",
+        "initialize",
+        "local",
+        "repository",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-hub-init.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/savia-hub-sync/SKILL",
+      "intents": [
+        "local",
+        "repositorio",
+        "saviahub",
+        "sincroniza",
+        "workspace"
+      ],
+      "kind": "skill",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/savia-hub-sync/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/savia-identity/SKILL",
+      "intents": [
+        "cargar",
+        "completa",
+        "comportamiento",
+        "identidad",
+        "inicio"
+      ],
+      "kind": "skill",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/savia-identity/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-ignore",
+      "intents": [
+        "exclusion",
+        "ignore",
+        "layer",
+        "savia",
+        "specific"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-ignore.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-inbox",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-inbox.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-index",
+      "intents": [
+        "index",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-index.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-index-rebuild",
+      "intents": [
+        "index",
+        "rebuild",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-index-rebuild.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-install",
+      "intents": [
+        "bootstrap",
+        "central",
+        "consolidacion",
+        "idempotente",
+        "install"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-install.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/savia-labs/SKILL",
+      "intents": [
+        "audita",
+        "auditoria",
+        "certificado",
+        "corpus",
+        "desconocidos"
+      ],
+      "kind": "skill",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/savia-labs/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-live",
+      "intents": [
+        "activity",
+        "live",
+        "queue",
+        "recent",
+        "right"
+      ],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-live.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/savia-memory/SKILL",
+      "intents": [
+        "busca",
+        "consolida",
+        "escribe",
+        "memoria",
+        "persistente"
+      ],
+      "kind": "skill",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/savia-memory/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-memory-bootstrap",
+      "intents": [
+        "bootstrap",
+        "canónico",
+        "crea",
+        "externo",
+        "memory"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-memory-bootstrap.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-memory-mcp-stdio",
+      "intents": [
+        "memory",
+        "savia",
+        "spec",
+        "stdio",
+        "wrapper"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-memory-mcp-stdio.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-memory-migrate",
+      "intents": [
+        "canónico",
+        "externos",
+        "internos",
+        "memoria",
+        "memory"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-memory-migrate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-messaging",
+      "intents": [
+        "creation",
+        "delivery",
+        "inbox",
+        "management",
+        "message"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-messaging.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-messaging-actions",
+      "intents": [
+        "actions",
+        "announce",
+        "broadcast",
+        "directory",
+        "messaging"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-messaging-actions.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-messaging-inbox",
+      "intents": [
+        "inbox",
+        "messaging",
+        "operations",
+        "read",
+        "reply"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-messaging-inbox.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-messaging-privacy",
+      "intents": [
+        "check",
+        "messaging",
+        "privacy",
+        "savia",
+        "sensitivity"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-messaging-privacy.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-orchestrator",
+      "intents": [
+        "mínimo",
+        "orchestrator",
+        "orquestador",
+        "sagi",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-orchestrator.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-orchestrator-helper",
+      "intents": [
+        "helper",
+        "orchestrator",
+        "savia",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-orchestrator-helper.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-pbi",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-pbi.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-preferences",
+      "intents": [
+        "manage",
+        "preferences",
+        "savia",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-preferences.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-quota-tracker",
+      "intents": [
+        "quota",
+        "savia",
+        "slice",
+        "spec",
+        "tracker"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-quota-tracker.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-recall",
+      "intents": [
+        "information",
+        "memory",
+        "recall",
+        "retrieve",
+        "savia"
+      ],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-recall.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-reply",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-reply.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-runs",
+      "intents": [
+        "agent",
+        "ledger",
+        "operations",
+        "runs",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-runs.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-sandbox-doctor",
+      "intents": [
+        "doctor",
+        "sandbox",
+        "savia",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-sandbox-doctor.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/savia-school/SKILL",
+      "intents": [
+        "adapta",
+        "edad",
+        "educativo",
+        "entorno",
+        "estudiantes"
+      ],
+      "kind": "skill",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/savia-school/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-school",
+      "intents": [
+        "core",
+        "educational",
+        "library",
+        "management",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-school.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-school-security",
+      "intents": [
+        "access",
+        "control",
+        "encryption",
+        "gdpr",
+        "layer"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-school-security.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-send",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-send.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-setup",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-setup.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-setup",
+      "intents": [
+        "completa",
+        "configuracion",
+        "inicializador",
+        "interactivo",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-setup.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-shield",
+      "intents": [
+        "activar",
+        "comprobar",
+        "datos",
+        "defecto",
+        "desactivado"
+      ],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-shield.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-shield-check",
+      "intents": [
+        "check",
+        "savia",
+        "shield",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-shield-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-shield-setup",
+      "intents": [
+        "instalador",
+        "savia",
+        "setup",
+        "shield"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-shield-setup.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-shield-status",
+      "intents": [
+        "capas",
+        "determinístico",
+        "savia",
+        "shield",
+        "status"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-shield-status.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-skills",
+      "intents": [
+        "management",
+        "savia",
+        "skill",
+        "skills",
+        "unified"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-skills.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-sprint",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-sprint.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-status",
+      "intents": [
+        "doing",
+        "right",
+        "savia",
+        "status",
+        "what"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-status.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-team",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-team.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-timesheet",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-timesheet.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-trace",
+      "intents": [
+        "contexto",
+        "distribuido",
+        "savia",
+        "trace",
+        "traceparent"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-trace.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-travel",
+      "intents": [
+        "core",
+        "lines",
+        "mode",
+        "savia",
+        "travel"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-travel.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-travel-init",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-travel-init.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-travel-init",
+      "intents": [
+        "init",
+        "mode",
+        "savia",
+        "script",
+        "template"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-travel-init.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-travel-ops",
+      "intents": [
+        "init",
+        "operations",
+        "pack",
+        "savia",
+        "travel"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-travel-ops.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/savia-travel-pack",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/savia-travel-pack.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/savia-vaults/SKILL",
+      "intents": [
+        "backup",
+        "backups",
+        "busca",
+        "busqueda",
+        "confidencialidad"
+      ],
+      "kind": "skill",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/savia-vaults/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-voice-chunk",
+      "intents": [
+        "chunk",
+        "savia",
+        "slice",
+        "voice"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-voice-chunk.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-voice-speak",
+      "intents": [
+        "savia",
+        "slice",
+        "speak",
+        "voice"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-voice-speak.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-watch",
+      "intents": [
+        "activity",
+        "feed",
+        "live",
+        "savia",
+        "watch"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-watch.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-watchdog",
+      "intents": [
+        "activate",
+        "detect",
+        "emergency",
+        "fallback",
+        "internet"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-watchdog.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/savia-workspace",
+      "intents": [
+        "agentes",
+        "composicion",
+        "multi",
+        "repo",
+        "repos"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/savia-workspace.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/transcriptor-digest/SKILL",
+      "intents": [
+        "capturadas",
+        "capturas",
+        "carpetas",
+        "detectan",
+        "digerir"
+      ],
+      "kind": "skill",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/transcriptor-digest/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/transcriptor-mark-digested",
+      "intents": [
+        "digerida",
+        "digested",
+        "marcar",
+        "mark",
+        "reunion"
+      ],
+      "kind": "script",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/transcriptor-mark-digested.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/voice-inbox/SKILL",
+      "intents": [
+        "acciones",
+        "convertirlos",
+        "mensajes",
+        "procesan",
+        "transcribirlos"
+      ],
+      "kind": "skill",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/voice-inbox/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/word-digest",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/word-digest.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/zeroclaw-meeting",
+      "intents": [
+        "diarization",
+        "digest",
+        "identification",
+        "live",
+        "meeting"
+      ],
+      "kind": "cmd",
+      "owner_domain": "communication",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/zeroclaw-meeting.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/speckit.checklist",
+      "intents": [
+        "alias",
+        "calidad",
+        "capa",
+        "compatible",
+        "final"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/speckit.checklist.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/speckit.clarify",
+      "intents": [
+        "alias",
+        "ambigüedad",
+        "cerrar",
+        "compatible",
+        "conductor"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/speckit.clarify.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/speckit.constitution",
+      "intents": [
+        "alias",
+        "args",
+        "compatible",
+        "constituir",
+        "constitution"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/speckit.constitution.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/speckit.implement",
+      "intents": [
+        "alias",
+        "aprobada",
+        "compatible",
+        "github",
+        "implementación"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/speckit.implement.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/speckit.plan",
+      "intents": [
+        "alias",
+        "capturada",
+        "compatible",
+        "development",
+        "diseño"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/speckit.plan.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/speckit.specify",
+      "intents": [
+        "alias",
+        "captura",
+        "compatible",
+        "discovery",
+        "github"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/speckit.specify.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/speckit.tasks",
+      "intents": [
+        "accionables",
+        "alias",
+        "compatible",
+        "decomposition",
+        "descomposición"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/speckit.tasks.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/ua-analyze",
+      "intents": [
+        "analyze",
+        "anything",
+        "codebase",
+        "generate",
+        "graph"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/ua-analyze.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/ua-diff",
+      "intents": [
+        "analyze",
+        "changes",
+        "codebase",
+        "graph",
+        "impact"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/ua-diff.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/ua-domain",
+      "intents": [
+        "business",
+        "codebase",
+        "concepts",
+        "domain",
+        "extract"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/ua-domain.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agents-opencode-convert",
+      "intents": [
+        "agents",
+        "convert",
+        "final",
+        "migration",
+        "opencode"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agents-opencode-convert.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ast-quality-gate",
+      "intents": [
+        "agnostic",
+        "analyzer",
+        "code",
+        "gate",
+        "language"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ast-quality-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/authority-claim-judge",
+      "intents": [
+        "claims",
+        "credential",
+        "detects",
+        "investigador",
+        "judge"
+      ],
+      "kind": "agent",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/authority-claim-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/best-practices-check",
+      "intents": [
+        "against",
+        "best",
+        "claude",
+        "code",
+        "evaluate"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/best-practices-check.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/blast-radius",
+      "intents": [
+        "blast",
+        "calcula",
+        "codeflow",
+        "fichero",
+        "inspired"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/blast-radius.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/block-pat-file-write",
+      "intents": [
+        "block",
+        "file",
+        "paths",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/block-pat-file-write.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/budget-guard",
+      "intents": [
+        "budget",
+        "context",
+        "guard",
+        "monitor",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/budget-guard.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/build-azdo-schema-graph",
+      "intents": [
+        "azdo",
+        "build",
+        "graph",
+        "schema",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/build-azdo-schema-graph.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/build-skill-manifest",
+      "intents": [
+        "build",
+        "frontmatter",
+        "manifest",
+        "manifesto",
+        "skill"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/build-skill-manifest.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/calendar-focus",
+      "intents": [
+        "bloque",
+        "crear",
+        "deep",
+        "especifica",
+        "focus"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/calendar-focus.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/caveman/SKILL",
+      "intents": [
+        "before",
+        "brutally",
+        "coating",
+        "committing",
+        "deception"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/caveman/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/changelog-spec-field-check",
+      "intents": [
+        "changelog",
+        "check",
+        "field",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/changelog-spec-field-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/check-coherence",
+      "intents": [
+        "actually",
+        "code",
+        "matches",
+        "objective",
+        "output"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/check-coherence.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ci-reliability-gate",
+      "intents": [
+        "gate",
+        "reliability",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ci-reliability-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/code-comprehension-report/SKILL",
+      "intents": [
+        "completado",
+        "documentar",
+        "implementación",
+        "mental",
+        "modelo"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/code-comprehension-report/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/code-improve",
+      "intents": [
+        "applies",
+        "autonomous",
+        "code",
+        "creates",
+        "detects"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/code-improve.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/code-improvement-loop/SKILL",
+      "intents": [
+        "autónoma",
+        "código",
+        "ejecutar",
+        "mejora",
+        "plano"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/code-improvement-loop/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/code-reviewer",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/code-reviewer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/code-twin-agent",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/code-twin-agent.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/code-twin-anonymize",
+      "intents": [
+        "anonymize",
+        "code",
+        "slice",
+        "spec",
+        "twin"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/code-twin-anonymize.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/code-twin-extract",
+      "intents": [
+        "code",
+        "extract",
+        "slice",
+        "spec",
+        "twin"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/code-twin-extract.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/code-twin-init",
+      "intents": [
+        "code",
+        "estructura",
+        "init",
+        "proyecto",
+        "scaffold"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/code-twin-init.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/code-twin-lint",
+      "intents": [
+        "code",
+        "files",
+        "index",
+        "jsonl",
+        "lint"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/code-twin-lint.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/code-twin-load",
+      "intents": [
+        "code",
+        "load",
+        "slice",
+        "spec",
+        "twin"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/code-twin-load.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/code-twin-simulate",
+      "intents": [
+        "code",
+        "simulate",
+        "slice",
+        "spec",
+        "twin"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/code-twin-simulate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/code-twin-sync-check",
+      "intents": [
+        "check",
+        "code",
+        "slice",
+        "spec",
+        "sync"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/code-twin-sync-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/code-twin-validate-spec",
+      "intents": [
+        "code",
+        "slice",
+        "spec",
+        "twin",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/code-twin-validate-spec.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/codebase-map",
+      "intents": [
+        "agentes",
+        "comandos",
+        "dependencias",
+        "generar",
+        "internas"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/codebase-map.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/codebase-map/SKILL",
+      "intents": [
+        "agentes",
+        "comandos",
+        "dependencias",
+        "mapa",
+        "reglas"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/codebase-map/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/codegraph/SKILL",
+      "intents": [
+        "callees",
+        "callers",
+        "código",
+        "indexación",
+        "navegación"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/codegraph/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/cognitive-debt",
+      "intents": [
+        "cognitive",
+        "debt",
+        "entry",
+        "phase",
+        "point"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/cognitive-debt.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/competitive-design",
+      "intents": [
+        "competitive",
+        "design",
+        "generation",
+        "parallel",
+        "philosophies"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/competitive-design.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/comprehension-report",
+      "intents": [
+        "architectural",
+        "debugging",
+        "decisions",
+        "documents",
+        "failure"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/comprehension-report.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/concession-judge",
+      "intents": [
+        "changes",
+        "detects",
+        "evidence",
+        "judge",
+        "position"
+      ],
+      "kind": "agent",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/concession-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/dag-execute",
+      "intents": [
+        "agentes",
+        "ejecutar",
+        "paralelo",
+        "pipeline",
+        "según"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/dag-execute.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/dag-gate-cost-checker",
+      "intents": [
+        "checker",
+        "cost",
+        "gate"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/dag-gate-cost-checker.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/dag-plan",
+      "intents": [
+        "ahorro",
+        "camino",
+        "crítico",
+        "ejecución",
+        "tiempo"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/dag-plan.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/dag-scheduling/SKILL",
+      "intents": [
+        "agentes",
+        "dependencias",
+        "ellos",
+        "múltiples",
+        "orquestan"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/dag-scheduling/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/dag-typing-validate",
+      "intents": [
+        "prototype",
+        "slice",
+        "typing",
+        "validate",
+        "validator"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/dag-typing-validate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/decide-architecture",
+      "intents": [
+        "architecture",
+        "decide",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/decide-architecture.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/deps-validate",
+      "intents": [
+        "deps",
+        "schema",
+        "slice",
+        "spec",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/deps-validate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/design-an-interface/SKILL",
+      "intents": [
+        "alternativas",
+        "alternatives",
+        "architectural",
+        "design",
+        "designing"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/design-an-interface/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/detect-frontend",
+      "intents": [
+        "detect",
+        "frontend",
+        "installer",
+        "migration",
+        "opencode"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/detect-frontend.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/dev-orchestrator",
+      "intents": [
+        "analiza",
+        "contexto",
+        "crea",
+        "dependencias",
+        "implementación"
+      ],
+      "kind": "agent",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/dev-orchestrator.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/dev-session",
+      "intents": [
+        "aislamiento",
+        "contexto",
+        "desarrollo",
+        "disco",
+        "fases"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/dev-session.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/dev-session-discard",
+      "intents": [
+        "cleanly",
+        "discard",
+        "session"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/dev-session-discard.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/dev-session-resume",
+      "intents": [
+        "checkpoint",
+        "interrumpida",
+        "reanudar",
+        "session",
+        "ultimo"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/dev-session-resume.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/dev-workflow-generate",
+      "intents": [
+        "generate",
+        "orchestrator",
+        "output",
+        "workflow"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/dev-workflow-generate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/agent-manifest-batch-export",
+      "intents": [
+        "agent",
+        "agentes",
+        "batch",
+        "export",
+        "exporta"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/agent-manifest-batch-export.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/agent-manifest-export",
+      "intents": [
+        "agent",
+        "agentes",
+        "export",
+        "exporta",
+        "frameworks"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/agent-manifest-export.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/api-key-create",
+      "intents": [
+        "create",
+        "creation",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/api-key-create.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/api-key-list",
+      "intents": [
+        "inventory",
+        "list",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/api-key-list.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/api-key-revoke",
+      "intents": [
+        "revocation",
+        "revoke",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/api-key-revoke.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/commercial-terms-check",
+      "intents": [
+        "check",
+        "commercial",
+        "license",
+        "spec",
+        "terms"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/commercial-terms-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/compliance-check",
+      "intents": [
+        "check",
+        "compliance",
+        "spec",
+        "validator",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/compliance-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/compliance-evidence-collector",
+      "intents": [
+        "automated",
+        "collector",
+        "compliance",
+        "evidence",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/compliance-evidence-collector.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/compliance-report-generator",
+      "intents": [
+        "compliance",
+        "generator",
+        "report",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/compliance-report-generator.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/delta-tier",
+      "intents": [
+        "delta",
+        "helper",
+        "spec",
+        "tier"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/delta-tier.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/deployment-status",
+      "intents": [
+        "current",
+        "deployment",
+        "mode",
+        "show",
+        "status"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/deployment-status.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/jwt-mint",
+      "intents": [
+        "lived",
+        "mint",
+        "primitive",
+        "short",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/jwt-mint.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/license-generator",
+      "intents": [
+        "components",
+        "enterprise",
+        "generator",
+        "license",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/license-generator.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/mcp-catalog-generate",
+      "intents": [
+        "catalog",
+        "catálogo",
+        "generate",
+        "servers",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/mcp-catalog-generate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/mcp-server-stub",
+      "intents": [
+        "scaffold",
+        "server",
+        "spec",
+        "stub"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/mcp-server-stub.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/metrics-emitter",
+      "intents": [
+        "collector",
+        "emite",
+        "emitter",
+        "metrics",
+        "métricas"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/metrics-emitter.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/model-card-generator",
+      "intents": [
+        "agents",
+        "card",
+        "cards",
+        "generator",
+        "model"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/model-card-generator.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/onboarding-batch",
+      "intents": [
+        "batch",
+        "bulk",
+        "onboarding",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/onboarding-batch.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/otel-collector-config",
+      "intents": [
+        "collector",
+        "config",
+        "configuración",
+        "otel",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/otel-collector-config.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/project-evaluation",
+      "intents": [
+        "code",
+        "evaluation",
+        "lessons",
+        "project"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/project-evaluation.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/project-valuation",
+      "intents": [
+        "business",
+        "case",
+        "code",
+        "project",
+        "valuation"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/project-valuation.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/prospect-create",
+      "intents": [
+        "code",
+        "create",
+        "pipeline",
+        "project",
+        "prospect"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/prospect-create.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/prospect-pipeline",
+      "intents": [
+        "code",
+        "pipeline",
+        "project",
+        "prospect"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/prospect-pipeline.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/reconciliation-status",
+      "intents": [
+        "reconciliation",
+        "slice",
+        "spec",
+        "status",
+        "tenant"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/reconciliation-status.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/sovereign-activate",
+      "intents": [
+        "activate",
+        "configure",
+        "deployment",
+        "sovereign",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/sovereign-activate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/sow-create",
+      "intents": [
+        "code",
+        "create",
+        "definition",
+        "project"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/sow-create.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/sow-validate",
+      "intents": [
+        "code",
+        "definition",
+        "project",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/sow-validate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/sso-adapter-check",
+      "intents": [
+        "adapter",
+        "check",
+        "configuración",
+        "saml",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/sso-adapter-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/epistemic-humility/SKILL",
+      "intents": [
+        "adulación",
+        "asumido",
+        "auto",
+        "cesión",
+        "claim"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/epistemic-humility/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/eval-agent",
+      "intents": [
+        "against",
+        "agent",
+        "bias",
+        "evaluate",
+        "golden"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/eval-agent.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/eval-agent",
+      "intents": [
+        "agent",
+        "eval",
+        "evaluation",
+        "runner",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/eval-agent.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/evals-runner",
+      "intents": [
+        "evals",
+        "evaluation",
+        "local",
+        "runner",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/evals-runner.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/execution-supervisor",
+      "intents": [
+        "advisory",
+        "execution",
+        "reflection",
+        "spec",
+        "supervisor"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/execution-supervisor.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/failure-pattern-memory",
+      "intents": [
+        "failure",
+        "fase",
+        "memory",
+        "pattern",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/failure-pattern-memory.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/feasibility-probe",
+      "intents": [
+        "attempt",
+        "boxed",
+        "feasibility",
+        "prototype",
+        "spec"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/feasibility-probe.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/feasibility-probe/SKILL",
+      "intents": [
+        "implementarla",
+        "spec",
+        "técnicamente",
+        "validar",
+        "viable"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/feasibility-probe/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/feasibility-probe",
+      "intents": [
+        "attempting",
+        "blocking",
+        "boxed",
+        "decomposition",
+        "feasibility"
+      ],
+      "kind": "agent",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/feasibility-probe.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/fiction-framing-judge",
+      "intents": [
+        "content",
+        "detects",
+        "domain",
+        "equivalent",
+        "framing"
+      ],
+      "kind": "agent",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/fiction-framing-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/freetoken-probe",
+      "intents": [
+        "freetoken",
+        "probe",
+        "spec",
+        "valida",
+        "viabilidad"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/freetoken-probe.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/gaia-benchmark-harness",
+      "intents": [
+        "benchmark",
+        "gaia",
+        "harness",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/gaia-benchmark-harness.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/gitagent-export",
+      "intents": [
+        "adapter",
+        "export",
+        "gitagent",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/gitagent-export.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/graph-build",
+      "intents": [
+        "conocimiento",
+        "construye",
+        "grafo",
+        "proyecto"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/graph-build.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/graph-temporal-ops",
+      "intents": [
+        "graph",
+        "spec",
+        "temporal"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/graph-temporal-ops.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hook-multihandler-baseline",
+      "intents": [
+        "baseline",
+        "hook",
+        "multihandler",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hook-multihandler-baseline.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hook-portability-classifier",
+      "intents": [
+        "classifier",
+        "hook",
+        "portability",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hook-portability-classifier.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/human-code-map/SKILL",
+      "intents": [
+        "alguien",
+        "código",
+        "incorpora",
+        "mapa",
+        "módulo"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/human-code-map/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/image-relevance-filter",
+      "intents": [
+        "deterministic",
+        "filter",
+        "first",
+        "image",
+        "primitive"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/image-relevance-filter.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/impact-analysis",
+      "intents": [
+        "analysis",
+        "analyze",
+        "codebase",
+        "files",
+        "impact"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/impact-analysis.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/implementation-readiness",
+      "intents": [
+        "codificar",
+        "falla",
+        "gate",
+        "implementacion",
+        "lista"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/implementation-readiness.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/implementation-readiness",
+      "intents": [
+        "gate",
+        "implementacion",
+        "implementation",
+        "readiness"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/implementation-readiness.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/index-rebuild",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/index-rebuild.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/install-git-hooks",
+      "intents": [
+        "hooks",
+        "instala",
+        "install",
+        "opencode",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/install-git-hooks.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/instinct-collapse-detector",
+      "intents": [
+        "collapse",
+        "detect",
+        "detector",
+        "exploration",
+        "instinct"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/instinct-collapse-detector.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/jwt-mint",
+      "intents": [
+        "ephemeral",
+        "mint",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/jwt-mint.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/kg-export",
+      "intents": [
+        "codebase",
+        "export",
+        "memory",
+        "pattern",
+        "snapshot"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/kg-export.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/llm-training/import-gguf",
+      "intents": [
+        "fine",
+        "gguf",
+        "import",
+        "model",
+        "ollama"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/llm-training/import-gguf.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/llm-training/prepare-training-data",
+      "intents": [
+        "agent",
+        "data",
+        "extract",
+        "prepare",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/llm-training/prepare-training-data.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/localai-readiness-check",
+      "intents": [
+        "check",
+        "localai",
+        "readiness",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/localai-readiness-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/marketplace-install",
+      "intents": [
+        "claude",
+        "code",
+        "components",
+        "install",
+        "marketplace"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/marketplace-install.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/meta-reflection/SKILL",
+      "intents": [
+        "activa",
+        "criterion",
+        "cuestionar",
+        "doubt",
+        "ejecutarla"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/meta-reflection/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/monthly-diagnostic-report",
+      "intents": [
+        "diagnostic",
+        "monthly",
+        "quality",
+        "report",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/monthly-diagnostic-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/nd-autoconfig",
+      "intents": [
+        "accessibility",
+        "auto",
+        "autoconfig",
+        "configure",
+        "neurodivergent"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/nd-autoconfig.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/nidos-dev-lib",
+      "intents": [
+        "lifecycle",
+        "nidos",
+        "savia",
+        "server",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/nidos-dev-lib.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/opencode-config-validate",
+      "intents": [
+        "config",
+        "errata",
+        "opencode",
+        "scripts",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/opencode-config-validate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/opencode-gates-heal",
+      "intents": [
+        "gates",
+        "heal",
+        "leak",
+        "opencode",
+        "process"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/opencode-gates-heal.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/opencode-hooks/run-hook",
+      "intents": [
+        "adecuado",
+        "ejecuta",
+        "hook",
+        "input",
+        "json"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/opencode-hooks/run-hook.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/opencode-install",
+      "intents": [
+        "install",
+        "opencode",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/opencode-install.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/opencode-migration-smoke",
+      "intents": [
+        "final",
+        "migration",
+        "opencode",
+        "prep",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/opencode-migration-smoke.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/opencode-monthly-canary",
+      "intents": [
+        "canary",
+        "monthly",
+        "opencode",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/opencode-monthly-canary.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/org-registrar/SKILL",
+      "intents": [
+        "code",
+        "company",
+        "consulta",
+        "consultan",
+        "dependencias"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/org-registrar/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/parallel-specs-cleanup-stale",
+      "intents": [
+        "cleanup",
+        "parallel",
+        "slice",
+        "specs",
+        "stale"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/parallel-specs-cleanup-stale.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/parallel-specs-db-sandbox",
+      "intents": [
+        "parallel",
+        "sandbox",
+        "slice",
+        "specs",
+        "worker"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/parallel-specs-db-sandbox.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/parallel-specs-merge-queue",
+      "intents": [
+        "cascade",
+        "merge",
+        "parallel",
+        "queue",
+        "rebase"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/parallel-specs-merge-queue.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/parallel-specs-orchestrator",
+      "intents": [
+        "execution",
+        "orchestrates",
+        "orchestrator",
+        "parallel",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/parallel-specs-orchestrator.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pdf-extract-probe",
+      "intents": [
+        "extract",
+        "feasibility",
+        "probe",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pdf-extract-probe.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pipeline-artifacts",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pipeline-artifacts.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pipeline-create",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pipeline-create.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pipeline-engine",
+      "intents": [
+        "definition",
+        "engine",
+        "execution",
+        "orchestrate",
+        "pipeline"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pipeline-engine.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pipeline-local-run",
+      "intents": [
+        "azure",
+        "defined",
+        "jenkins",
+        "local",
+        "needed"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pipeline-local-run.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pipeline-logs",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pipeline-logs.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pipeline-run",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pipeline-run.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pipeline-stage-runner",
+      "intents": [
+        "execute",
+        "pipeline",
+        "runner",
+        "single",
+        "stage"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pipeline-stage-runner.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pipeline-status",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pipeline-status.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pipeline-view",
+      "intents": [
+        "active",
+        "ascii",
+        "probability",
+        "pursuits",
+        "stage"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pipeline-view.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/portfolio-contention",
+      "intents": [
+        "contention",
+        "detector",
+        "portfolio",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/portfolio-contention.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/portfolio-critical-path",
+      "intents": [
+        "analyzer",
+        "critical",
+        "path",
+        "portfolio",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/portfolio-critical-path.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/portfolio-deps-status",
+      "intents": [
+        "dashboard",
+        "deps",
+        "portfolio",
+        "project",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/portfolio-deps-status.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/portfolio-graph",
+      "intents": [
+        "builder",
+        "dependency",
+        "graph",
+        "portfolio",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/portfolio-graph.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pre-push-bats-critical",
+      "intents": [
+        "bats",
+        "critical",
+        "module",
+        "push",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pre-push-bats-critical.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/priority/roadmap-priority-report",
+      "intents": [
+        "priority",
+        "report",
+        "roadmap",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/priority/roadmap-priority-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/priority/validate-spec-frontmatter",
+      "intents": [
+        "frontmatter",
+        "slice",
+        "spec",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/priority/validate-spec-frontmatter.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/prompt-suggestion-engine",
+      "intents": [
+        "driven",
+        "engine",
+        "optimization",
+        "phase",
+        "prompt"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/prompt-suggestion-engine.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/prospectiva-basica/SKILL",
+      "intents": [
+        "actores",
+        "acuerdo",
+        "alianzas",
+        "analiza",
+        "dependientes"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/prospectiva-basica/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/reaction-engine",
+      "intents": [
+        "engine",
+        "phase",
+        "reaction",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/reaction-engine.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/rebuild-folder-indexes",
+      "intents": [
+        "folder",
+        "indexes",
+        "rebuild"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/rebuild-folder-indexes.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/recommendation-tribunal/aggregate",
+      "intents": [
+        "aggregate",
+        "aggregation",
+        "deterministic",
+        "judge",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/recommendation-tribunal/aggregate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/recommendation-tribunal/banner",
+      "intents": [
+        "banner",
+        "render",
+        "slice",
+        "spec",
+        "tribunal"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/recommendation-tribunal/banner.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/recommendation-tribunal/calibrate",
+      "intents": [
+        "calibrate",
+        "derive",
+        "feedback",
+        "followups",
+        "memories"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/recommendation-tribunal/calibrate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/recommendation-tribunal/classifier",
+      "intents": [
+        "actionable",
+        "classifier",
+        "detect",
+        "draft",
+        "recommendations"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/recommendation-tribunal/classifier.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/recommendation-tribunal/early-cancel",
+      "intents": [
+        "cancel",
+        "done",
+        "early",
+        "elements",
+        "freeze"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/recommendation-tribunal/early-cancel.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/recommendation-tribunal/expertise-rewrite",
+      "intents": [
+        "asymmetric",
+        "expertise",
+        "rewrite",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/recommendation-tribunal/expertise-rewrite.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/recommendation-tribunal/followup-record",
+      "intents": [
+        "feedback",
+        "followup",
+        "loop",
+        "memory",
+        "record"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/recommendation-tribunal/followup-record.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/recommendation-tribunal/iterate",
+      "intents": [
+        "controller",
+        "iterate",
+        "iterative",
+        "loop",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/recommendation-tribunal/iterate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/reconciliation-pilot",
+      "intents": [
+        "docs",
+        "pilot",
+        "reconciler",
+        "reconciliation",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/reconciliation-pilot.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/repetition-truth-judge",
+      "intents": [
+        "assumed",
+        "claims",
+        "detects",
+        "judge",
+        "recommendation"
+      ],
+      "kind": "agent",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/repetition-truth-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/requirement-pushback",
+      "intents": [
+        "analyze",
+        "generate",
+        "pushback",
+        "questions",
+        "requirement"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/requirement-pushback.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/rpi-status",
+      "intents": [
+        "active",
+        "implement",
+        "plan",
+        "progress",
+        "research"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/rpi-status.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/rules-domain-index",
+      "intents": [
+        "domain",
+        "index",
+        "rules",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/rules-domain-index.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/scope-creep-check",
+      "intents": [
+        "alcance",
+        "check",
+        "compara",
+        "contra",
+        "creep"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/scope-creep-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/scope-declare",
+      "intents": [
+        "alcance",
+        "declarado",
+        "declare",
+        "extrae",
+        "scope"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/scope-declare.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/sdd-spec-writer",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/sdd-spec-writer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/semantic-compact",
+      "intents": [
+        "compact",
+        "generator",
+        "semantic",
+        "smart",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/semantic-compact.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/semantic-map",
+      "intents": [
+        "code",
+        "compressed",
+        "files",
+        "generate",
+        "maps"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/semantic-map.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sentinel-regen",
+      "intents": [
+        "docs",
+        "domain",
+        "regen",
+        "rules",
+        "safe"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sentinel-regen.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/setup-claude-permissions",
+      "intents": [
+        "backward",
+        "compatibility",
+        "deprecated",
+        "file",
+        "instead"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/setup-claude-permissions.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/setup-opencode-permissions",
+      "intents": [
+        "claude",
+        "json",
+        "local",
+        "permisos",
+        "permissions"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/setup-opencode-permissions.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/setup-savia-web",
+      "intents": [
+        "build",
+        "http",
+        "localhost",
+        "savia",
+        "serve"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/setup-savia-web.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skill-loader",
+      "intents": [
+        "aware",
+        "context",
+        "loader",
+        "loading",
+        "skill"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skill-loader.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skill-pattern-detector",
+      "intents": [
+        "detection",
+        "detector",
+        "pattern",
+        "phase",
+        "scripts"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skill-pattern-detector.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/sldc-context-loop",
+      "intents": [
+        "adrs",
+        "alimenta",
+        "cerrar",
+        "ciclo",
+        "compuerta"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/sldc-context-loop.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sldc-context-loop",
+      "intents": [
+        "context",
+        "feed",
+        "loop",
+        "merge",
+        "post"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sldc-context-loop.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm-deploy",
+      "intents": [
+        "deploy",
+        "deployment",
+        "orchestrate",
+        "post",
+        "scaffolding"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm-deploy.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm-registry",
+      "intents": [
+        "model",
+        "registry",
+        "slms",
+        "spec",
+        "trained"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm-registry.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/smart-routing/SKILL",
+      "intents": [
+        "comando",
+        "descubrir",
+        "disponibles",
+        "enrutar",
+        "específico"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/smart-routing/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sovereignty-pack",
+      "intents": [
+        "build",
+        "fully",
+        "installer",
+        "offline",
+        "pack"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sovereignty-pack.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/spec-156-migrate-token-budget",
+      "intents": [
+        "agents",
+        "budget",
+        "frontmatter",
+        "spec",
+        "token"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/spec-156-migrate-token-budget.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/spec-approval-gate",
+      "intents": [
+        "approval",
+        "enforcement",
+        "gate",
+        "rule",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/spec-approval-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/spec-budget",
+      "intents": [
+        "budget",
+        "dynamic",
+        "effort",
+        "retry",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/spec-budget.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/spec-design",
+      "intents": [
+        "datos",
+        "decisiones",
+        "diseño",
+        "estrategia",
+        "existente"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/spec-design.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/spec-driven-development/SKILL",
+      "intents": [
+        "ejecutable",
+        "escribe",
+        "implementa",
+        "spec",
+        "valida"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/spec-driven-development/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/spec-frontmatter-migrate",
+      "intents": [
+        "frontmatter",
+        "migrate",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/spec-frontmatter-migrate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/spec-generate",
+      "intents": [
+        "azure",
+        "devops",
+        "ejecutable",
+        "implementación",
+        "lista"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/spec-generate.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/spec-id-duplicates-check",
+      "intents": [
+        "check",
+        "duplicates",
+        "gate",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/spec-id-duplicates-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/spec-implement",
+      "intents": [
+        "agente",
+        "asigna",
+        "developer",
+        "humano",
+        "implementa"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/spec-implement.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/spec-judge",
+      "intents": [
+        "acceptance",
+        "approved",
+        "code",
+        "court",
+        "criteria"
+      ],
+      "kind": "agent",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/spec-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/spec-lifecycle",
+      "intents": [
+        "append",
+        "lifecycle",
+        "only",
+        "spec",
+        "status"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/spec-lifecycle.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/spec-opencode-plan-audit",
+      "intents": [
+        "approved",
+        "audit",
+        "every",
+        "implemented",
+        "include"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/spec-opencode-plan-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/spec-quality-auditor",
+      "intents": [
+        "auditor",
+        "deterministic",
+        "quality",
+        "scorer",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/spec-quality-auditor.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/spec-slice",
+      "intents": [
+        "analizar",
+        "contexto",
+        "dividirlo",
+        "implementación",
+        "optimizados"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/spec-slice.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/spec-status-drift-audit",
+      "intents": [
+        "audit",
+        "detect",
+        "disk",
+        "drift",
+        "implemented"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/spec-status-drift-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/spec-status-normalize",
+      "intents": [
+        "across",
+        "audit",
+        "field",
+        "normalize",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/spec-status-normalize.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/spec-validator",
+      "intents": [
+        "field",
+        "frontmatter",
+        "resource",
+        "spec",
+        "validates"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/spec-validator.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/spec-verify-ui",
+      "intents": [
+        "componente",
+        "comprueba",
+        "cumple",
+        "implementado",
+        "spec"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/spec-verify-ui.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/spec156-migrate-token-budget",
+      "intents": [
+        "budget",
+        "flat",
+        "migrate",
+        "nested",
+        "object"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/spec156-migrate-token-budget.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/specs-frontmatter-normalize",
+      "intents": [
+        "frontmatter",
+        "normalization",
+        "normalize",
+        "slice",
+        "specs"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/specs-frontmatter-normalize.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/speculative-telemetry-report",
+      "intents": [
+        "dashboard",
+        "report",
+        "slice",
+        "speculative",
+        "telemetry"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/speculative-telemetry-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/speculative/feasibility-probe",
+      "intents": [
+        "execution",
+        "feasibility",
+        "probe",
+        "slice",
+        "speculative"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/speculative/feasibility-probe.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/statusline-provider",
+      "intents": [
+        "claude",
+        "code",
+        "data",
+        "provider",
+        "statusline"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/statusline-provider.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/sycophancy-judge",
+      "intents": [
+        "conversational",
+        "detects",
+        "drafts",
+        "empty",
+        "judge"
+      ],
+      "kind": "agent",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/sycophancy-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/tech-research",
+      "intents": [
+        "autonomous",
+        "designated",
+        "generates",
+        "human",
+        "investigates"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/tech-research.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/tech-research-agent/SKILL",
+      "intents": [
+        "autónoma",
+        "específico",
+        "investigación",
+        "tema",
+        "técnica"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/tech-research-agent/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/timeline-append",
+      "intents": [
+        "append",
+        "decision",
+        "entry",
+        "file",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/timeline-append.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/timeline-status-guard",
+      "intents": [
+        "append",
+        "changes",
+        "guard",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/timeline-status-guard.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/tolaria-open",
+      "intents": [
+        "base",
+        "desktop",
+        "knowledge",
+        "open",
+        "path"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/tolaria-open.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/tribunal-async-runner",
+      "intents": [
+        "async",
+        "runner",
+        "spec",
+        "tribunal"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/tribunal-async-runner.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/tribunal-benchmark",
+      "intents": [
+        "benchmark",
+        "phase",
+        "spec",
+        "tribunal"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/tribunal-benchmark.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/twin-anonymize",
+      "intents": [
+        "anonymize",
+        "datos",
+        "organización",
+        "spec",
+        "twin"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/twin-anonymize.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/twin-load",
+      "intents": [
+        "carga",
+        "load",
+        "muestra",
+        "proyecto",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/twin-load.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/twin-refresh",
+      "intents": [
+        "predicciones",
+        "recalcula",
+        "refresh",
+        "spec",
+        "twin"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/twin-refresh.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/ua-onboard",
+      "intents": [
+        "codebase",
+        "generate",
+        "guided",
+        "onboarding",
+        "tour"
+      ],
+      "kind": "cmd",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/ua-onboard.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/understand-anything/SKILL",
+      "intents": [
+        "analizar",
+        "anything",
+        "codebase",
+        "dominio",
+        "estructurales"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/understand-anything/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/validate-pbi-spec-links",
+      "intents": [
+        "bidirectional",
+        "check",
+        "links",
+        "spec",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/validate-pbi-spec-links.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/validate-spec",
+      "intents": [
+        "declarative",
+        "spec",
+        "validate",
+        "validation",
+        "without"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/validate-spec.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/vaults-introspect",
+      "intents": [
+        "introspect",
+        "saviavaults",
+        "vault",
+        "vaults"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/vaults-introspect.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/verification-middleware",
+      "intents": [
+        "checks",
+        "implementation",
+        "middleware",
+        "orchestrate",
+        "post"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/verification-middleware.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/workforce-analytics",
+      "intents": [
+        "agentic",
+        "analytics",
+        "scripts",
+        "spec",
+        "workforce"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/workforce-analytics.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/workspace-doctor",
+      "intents": [
+        "check",
+        "doctor",
+        "health",
+        "spec",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/workspace-doctor.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/zoom-out/SKILL",
+      "intents": [
+        "architecture",
+        "before",
+        "decisions",
+        "dependencies",
+        "design"
+      ],
+      "kind": "skill",
+      "owner_domain": "development",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/zoom-out/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/aepd-compliance",
+      "intents": [
+        "aepd",
+        "agéntica",
+        "auditoría",
+        "cumplimiento",
+        "fases"
+      ],
+      "kind": "cmd",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/aepd-compliance.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/audit-all-bats",
+      "intents": [
+        "audit",
+        "auditor",
+        "bats",
+        "over",
+        "probe"
+      ],
+      "kind": "script",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/audit-all-bats.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/audit-chain-append",
+      "intents": [
+        "append",
+        "audit",
+        "chain",
+        "chained",
+        "hash"
+      ],
+      "kind": "script",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/audit-chain-append.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/audit-chain-prune",
+      "intents": [
+        "antiguas",
+        "audit",
+        "cadenas",
+        "chain",
+        "prune"
+      ],
+      "kind": "script",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/audit-chain-prune.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/audit-chain-verify",
+      "intents": [
+        "audit",
+        "chain",
+        "integridad",
+        "verificación",
+        "verify"
+      ],
+      "kind": "script",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/audit-chain-verify.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/audit-context-budget",
+      "intents": [
+        "audit",
+        "budget",
+        "context",
+        "slice",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/audit-context-budget.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/audit-mcp-templates",
+      "intents": [
+        "audit",
+        "spec",
+        "templates"
+      ],
+      "kind": "script",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/audit-mcp-templates.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/audit-receipts",
+      "intents": [
+        "audit",
+        "decision",
+        "ledger",
+        "metadata",
+        "only"
+      ],
+      "kind": "script",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/audit-receipts.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/audit-test-quality",
+      "intents": [
+        "audit",
+        "classifies",
+        "level",
+        "quality",
+        "scripts"
+      ],
+      "kind": "script",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/audit-test-quality.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/compliance-check",
+      "intents": [
+        "compliance",
+        "ejecuta",
+        "reglas",
+        "verificaciones"
+      ],
+      "kind": "cmd",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/compliance-check.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/compliance-fix",
+      "intents": [
+        "aplicar",
+        "automática",
+        "compliance",
+        "corrección",
+        "hallazgos"
+      ],
+      "kind": "cmd",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/compliance-fix.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/compliance-judge",
+      "intents": [
+        "confidentiality",
+        "format",
+        "judge",
+        "levels",
+        "rules"
+      ],
+      "kind": "agent",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/compliance-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/compliance-report",
+      "intents": [
+        "compliance",
+        "ejecutivo",
+        "generar",
+        "informe",
+        "regulatorio"
+      ],
+      "kind": "cmd",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/compliance-report.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/compliance-scan",
+      "intents": [
+        "automática",
+        "contra",
+        "código",
+        "detección",
+        "escanear"
+      ],
+      "kind": "cmd",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/compliance-scan.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/corporate/engagement-evidence-package",
+      "intents": [
+        "client",
+        "compliance",
+        "engagement",
+        "evidence",
+        "package"
+      ],
+      "kind": "script",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/corporate/engagement-evidence-package.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/corporate/enterprise-compliance-wire",
+      "intents": [
+        "compliance",
+        "enterprise",
+        "existing",
+        "scripts",
+        "wire"
+      ],
+      "kind": "script",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/corporate/enterprise-compliance-wire.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/glm-validate",
+      "intents": [
+        "completeness",
+        "drift",
+        "governance",
+        "manifest",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/glm-validate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/governance-audit",
+      "intents": [
+        "acciones",
+        "auditoría",
+        "cumplimiento",
+        "permitidas",
+        "política"
+      ],
+      "kind": "cmd",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/governance-audit.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/governance-audit-log",
+      "intents": [
+        "append",
+        "audit",
+        "chain",
+        "governance",
+        "hash"
+      ],
+      "kind": "script",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/governance-audit-log.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/governance-enterprise",
+      "intents": [
+        "audit",
+        "certification",
+        "checks",
+        "compliance",
+        "decision"
+      ],
+      "kind": "cmd",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/governance-enterprise.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/governance-enterprise/SKILL",
+      "intents": [
+        "audita",
+        "certifican",
+        "compliance",
+        "decisiones",
+        "enterprise"
+      ],
+      "kind": "skill",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/governance-enterprise/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/governance-query",
+      "intents": [
+        "capa",
+        "consulta",
+        "gobernanza",
+        "governance",
+        "query"
+      ],
+      "kind": "script",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/governance-query.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/legal-compliance",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/legal-compliance.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/opus47-compliance-check",
+      "intents": [
+        "batches",
+        "check",
+        "compliance",
+        "migration",
+        "opus"
+      ],
+      "kind": "script",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/opus47-compliance-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/output-cleanup",
+      "intents": [
+        "cleanup",
+        "directory",
+        "output",
+        "policy",
+        "retention"
+      ],
+      "kind": "script",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/output-cleanup.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/policy-check",
+      "intents": [
+        "agente",
+        "mostrar",
+        "permisos",
+        "politicas",
+        "proyecto"
+      ],
+      "kind": "cmd",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/policy-check.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/regulatory-compliance/SKILL",
+      "intents": [
+        "cumplimiento",
+        "marcos",
+        "regulatorios",
+        "sectoriales",
+        "valida"
+      ],
+      "kind": "skill",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/regulatory-compliance/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/standards-compliance-gate",
+      "intents": [
+        "compliance",
+        "compuerta",
+        "determinista",
+        "estandares",
+        "gate"
+      ],
+      "kind": "script",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/standards-compliance-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/vertical-education",
+      "intents": [
+        "accesibilidad",
+        "compliance",
+        "coppa",
+        "educación",
+        "educativa"
+      ],
+      "kind": "cmd",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/vertical-education.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/vertical-finance",
+      "intents": [
+        "basel",
+        "compliance",
+        "extensión",
+        "finanzas",
+        "mifid"
+      ],
+      "kind": "cmd",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/vertical-finance.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/vertical-healthcare",
+      "intents": [
+        "compliance",
+        "extensión",
+        "fhir",
+        "healthcare",
+        "hipaa"
+      ],
+      "kind": "cmd",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/vertical-healthcare.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/vertical-legal",
+      "intents": [
+        "compliance",
+        "contract",
+        "ediscovery",
+        "extensión",
+        "gdpr"
+      ],
+      "kind": "cmd",
+      "owner_domain": "governance",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/vertical-legal.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/auto-compact",
+      "intents": [
+        "auto",
+        "automáticamente",
+        "compact",
+        "contexto",
+        "disparado"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/auto-compact.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/cache-analytics",
+      "intents": [
+        "ahorrados",
+        "ahorro",
+        "costes",
+        "latencia",
+        "métricas"
+      ],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/cache-analytics.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/cache-hygiene",
+      "intents": [
+        "cache",
+        "caching",
+        "disciplina",
+        "hygiene",
+        "prefijo"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/cache-hygiene.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/cache-metrics",
+      "intents": [
+        "cache",
+        "ledger",
+        "local",
+        "metrics",
+        "métricas"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/cache-metrics.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/changelog-consolidate",
+      "intents": [
+        "changelog",
+        "consolidate",
+        "fragments"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/changelog-consolidate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/changelog-consolidate-if-needed",
+      "intents": [
+        "automation",
+        "changelog",
+        "consolidate",
+        "merge",
+        "needed"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/changelog-consolidate-if-needed.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/coherence-court-orchestrator",
+      "intents": [
+        "applies",
+        "coherence",
+        "consolidates",
+        "convenes",
+        "court"
+      ],
+      "kind": "agent",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/coherence-court-orchestrator.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/company-show",
+      "intents": [
+        "consolidado",
+        "contexto",
+        "ejecutivo",
+        "empresa",
+        "mostrar"
+      ],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/company-show.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/configurator",
+      "intents": [
+        "agents",
+        "centralizes",
+        "consume",
+        "decisions",
+        "dispatch"
+      ],
+      "kind": "agent",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/configurator.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/content-fingerprint",
+      "intents": [
+        "consolidation",
+        "content",
+        "fingerprint",
+        "skill"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/content-fingerprint.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-aging",
+      "intents": [
+        "aging",
+        "context"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-aging.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/context-budget",
+      "intents": [
+        "capa",
+        "contexto",
+        "disponibles",
+        "distribución",
+        "optimización"
+      ],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/context-budget.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-budget-check",
+      "intents": [
+        "budget",
+        "check",
+        "context"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-budget-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/context-caching/SKILL",
+      "intents": [
+        "cache",
+        "carga",
+        "contexto",
+        "hits",
+        "maximizar"
+      ],
+      "kind": "skill",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/context-caching/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-calibration-measure",
+      "intents": [
+        "calibration",
+        "context",
+        "measure",
+        "patterns",
+        "usage"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-calibration-measure.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-capability-check",
+      "intents": [
+        "capability",
+        "check",
+        "context",
+        "metadata",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-capability-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-compaction-policy",
+      "intents": [
+        "compaction",
+        "context",
+        "declared",
+        "policy",
+        "survival"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-compaction-policy.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-condenser",
+      "intents": [
+        "compression",
+        "condenser",
+        "context",
+        "rolling",
+        "window"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-condenser.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-distortion-measure",
+      "intents": [
+        "context",
+        "distortion",
+        "measure"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-distortion-measure.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/context-dome/SKILL",
+      "intents": [],
+      "kind": "skill",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/context-dome/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-dome-generate",
+      "intents": [
+        "bajo",
+        "context",
+        "dome",
+        "generate",
+        "modulo"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-dome-generate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/context-dome-manager",
+      "intents": [
+        "arquitecto",
+        "audita",
+        "clasificacion",
+        "confidencialidad",
+        "conocimiento"
+      ],
+      "kind": "agent",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/context-dome-manager.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-drop-after-use",
+      "intents": [
+        "context",
+        "decision",
+        "drop",
+        "engine",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-drop-after-use.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-drop-metrics",
+      "intents": [
+        "context",
+        "drop",
+        "metrics",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-drop-metrics.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-engineering-report",
+      "intents": [
+        "context",
+        "engineering",
+        "generator",
+        "report",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-engineering-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-erosion-detect",
+      "intents": [
+        "collapse",
+        "context",
+        "detect",
+        "erosion",
+        "volume"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-erosion-detect.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-frozen-check",
+      "intents": [
+        "check",
+        "context",
+        "frozen"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-frozen-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-greedy-budget",
+      "intents": [
+        "budget",
+        "context",
+        "greedy",
+        "selection",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-greedy-budget.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/context-interview",
+      "intents": [
+        "clientes",
+        "contexto",
+        "entrevista",
+        "estructurada",
+        "proyectos"
+      ],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/context-interview.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/context-interview-conductor/SKILL",
+      "intents": [
+        "contexto",
+        "entrevista",
+        "estructurado",
+        "guiada",
+        "mediante"
+      ],
+      "kind": "skill",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/context-interview-conductor/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-jit-lint",
+      "intents": [
+        "agent",
+        "context",
+        "lint",
+        "preloading",
+        "skill"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-jit-lint.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-meter",
+      "intents": [
+        "abtop",
+        "class",
+        "context",
+        "first",
+        "meter"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-meter.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/context-optimized-dev/SKILL",
+      "intents": [
+        "contexto",
+        "desarrolla",
+        "limitado",
+        "presupuesto"
+      ],
+      "kind": "skill",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/context-optimized-dev/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-origin-tag",
+      "intents": [
+        "context",
+        "origin",
+        "slice",
+        "tagging"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-origin-tag.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-preflight-check",
+      "intents": [],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-preflight-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-receipts-validate",
+      "intents": [
+        "context",
+        "receipts",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-receipts-validate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-restate-anchor",
+      "intents": [
+        "anchor",
+        "context",
+        "restate"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-restate-anchor.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/context-rot-strategy/SKILL",
+      "intents": [
+        "aproxima",
+        "compactar",
+        "contexto",
+        "decidir",
+        "larga"
+      ],
+      "kind": "skill",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/context-rot-strategy/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-rotation",
+      "intents": [
+        "automated",
+        "context",
+        "daily",
+        "monthly",
+        "rotation"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-rotation.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-snapshot",
+      "intents": [
+        "between",
+        "context",
+        "load",
+        "save",
+        "session"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-snapshot.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/context-status",
+      "intents": [
+        "context",
+        "model",
+        "optimization",
+        "recommendations",
+        "show"
+      ],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/context-status.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/context-task-classifier/SKILL",
+      "intents": [
+        "actual",
+        "clasificar",
+        "compactar",
+        "contexto",
+        "tarea"
+      ],
+      "kind": "skill",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/context-task-classifier/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-task-classifier",
+      "intents": [
+        "classifier",
+        "context",
+        "task"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-task-classifier.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-task-classify",
+      "intents": [
+        "class",
+        "classifier",
+        "classify",
+        "context",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-task-classify.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/context-tracker",
+      "intents": [
+        "context",
+        "tracker"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/context-tracker.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/digest-to-memory",
+      "intents": [
+        "agents",
+        "bridge",
+        "digest",
+        "graph",
+        "memory"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/digest-to-memory.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/engagement-rotate",
+      "intents": [
+        "client",
+        "context",
+        "engagement",
+        "rotate",
+        "seal"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/engagement-rotate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/entity-recall",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/entity-recall.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/focal-switch",
+      "intents": [
+        "cambiar",
+        "contexto",
+        "focal",
+        "load",
+        "nido"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/focal-switch.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/generate-blocklist",
+      "intents": [
+        "blocklist",
+        "context",
+        "dynamic",
+        "generate",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/generate-blocklist.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/generate-context-index",
+      "intents": [
+        "context",
+        "files",
+        "generate",
+        "index",
+        "projects"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/generate-context-index.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/generate-global-context",
+      "intents": [
+        "agent",
+        "compact",
+        "context",
+        "generate",
+        "global"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/generate-global-context.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/install-memory-deps",
+      "intents": [
+        "installs",
+        "isolated",
+        "memory",
+        "only",
+        "optional"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/install-memory-deps.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/iterative-compress",
+      "intents": [
+        "compress",
+        "compression",
+        "context",
+        "iterative",
+        "preservation"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/iterative-compress.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/learning-recall",
+      "intents": [
+        "authority",
+        "filtered",
+        "learning",
+        "recall",
+        "savialearning"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/learning-recall.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/lesson-search",
+      "intents": [
+        "cross",
+        "domain",
+        "keyword",
+        "lessons",
+        "project"
+      ],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/lesson-search.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-access",
+      "intents": [
+        "access",
+        "count",
+        "increment",
+        "last",
+        "memory"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-access.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/memory-agent",
+      "intents": [
+        "gestiona",
+        "lenguaje",
+        "memoria",
+        "natural",
+        "persistente"
+      ],
+      "kind": "agent",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/memory-agent.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-backup-pm",
+      "intents": [
+        "backup",
+        "indices",
+        "memory",
+        "privacy",
+        "repo"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-backup-pm.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-cache-rebuild",
+      "intents": [
+        "cache",
+        "files",
+        "memory",
+        "rebuild",
+        "sqlite"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-cache-rebuild.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-canary-check",
+      "intents": [
+        "canary",
+        "check",
+        "filtering",
+        "memory",
+        "output"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-canary-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/memory-check",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/memory-check.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-check",
+      "intents": [
+        "check",
+        "health",
+        "layers",
+        "memory",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-conflict-check",
+      "intents": [
+        "check",
+        "conflict",
+        "conflicting",
+        "detect",
+        "entries"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-conflict-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/memory-conflict-judge",
+      "intents": [
+        "active",
+        "auto",
+        "contradicts",
+        "detects",
+        "draft"
+      ],
+      "kind": "agent",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/memory-conflict-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/memory-consolidate",
+      "intents": [
+        "compress",
+        "consolidate",
+        "context",
+        "entries",
+        "memory"
+      ],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/memory-consolidate.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-consolidate",
+      "intents": [
+        "consolidate",
+        "knowledge",
+        "memory",
+        "pase",
+        "reflexión"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-consolidate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/memory-context",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/memory-context.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-feedback-post-merge",
+      "intents": [
+        "entry",
+        "feedback",
+        "memory",
+        "merge",
+        "merged"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-feedback-post-merge.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-hygiene",
+      "intents": [
+        "auto",
+        "automática",
+        "hygiene",
+        "limpieza",
+        "memory"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-hygiene.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-index-rebuild",
+      "intents": [
+        "auto",
+        "index",
+        "jsonl",
+        "memory",
+        "rebuild"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-index-rebuild.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-liveness-check",
+      "intents": [
+        "check",
+        "liveness",
+        "memory",
+        "scripts",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-liveness-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-prune",
+      "intents": [
+        "confidence",
+        "entries",
+        "memory",
+        "prune"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-prune.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/memory-recall",
+      "intents": [
+        "context",
+        "current",
+        "memories",
+        "relevant",
+        "retrieve"
+      ],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/memory-recall.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-recall-audit",
+      "intents": [
+        "audit",
+        "budget",
+        "measure",
+        "memory",
+        "recall"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-recall-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/memory-rotate",
+      "intents": [
+        "context",
+        "cycles",
+        "daily",
+        "execute",
+        "manually"
+      ],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/memory-rotate.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-save",
+      "intents": [
+        "entity",
+        "memory",
+        "save",
+        "session",
+        "sourced"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-save.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-search",
+      "intents": [
+        "context",
+        "memory",
+        "search",
+        "sourced",
+        "stats"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-search.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-stack-load",
+      "intents": [
+        "budgeted",
+        "load",
+        "loading",
+        "memory",
+        "progressive"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-stack-load.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-status-check",
+      "intents": [
+        "capas",
+        "check",
+        "estado",
+        "memoria",
+        "memory"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-status-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-store",
+      "intents": [
+        "jsonl",
+        "memory",
+        "persistent",
+        "store",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-store.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-sync-index",
+      "intents": [
+        "auto",
+        "index",
+        "jsonl",
+        "markdown",
+        "memory"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-sync-index.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-tier-rotate",
+      "intents": [
+        "auto",
+        "memory",
+        "rotate",
+        "rotation",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-tier-rotate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-verify",
+      "intents": [
+        "compression",
+        "gate",
+        "memory",
+        "quality",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-verify.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memory-write-gate",
+      "intents": [
+        "before",
+        "entries",
+        "gate",
+        "memory",
+        "validates"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memory-write-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/memvid-probe",
+      "intents": [
+        "memory",
+        "memvid",
+        "portable",
+        "probe",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/memvid-probe.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/mind-virus/scan-memory",
+      "intents": [
+        "auto",
+        "before",
+        "defense",
+        "load",
+        "memory"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/mind-virus/scan-memory.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/my-focus",
+      "intents": [
+        "carga",
+        "contexto",
+        "focus",
+        "identifica",
+        "item"
+      ],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/my-focus.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/nl-query",
+      "intents": [
+        "comandos",
+        "consultas",
+        "habla",
+        "lenguaje",
+        "memorizar"
+      ],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/nl-query.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/post-compaction",
+      "intents": [
+        "compactación",
+        "compaction",
+        "contexto",
+        "hook",
+        "inyecta"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/post-compaction.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/recursion-guard-export",
+      "intents": [
+        "context",
+        "export",
+        "guard",
+        "loop",
+        "prevention"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/recursion-guard-export.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/save-nudge",
+      "intents": [
+        "nudge",
+        "save",
+        "scripts",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/save-nudge.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/session-action-log",
+      "intents": [
+        "action",
+        "append",
+        "only",
+        "session",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/session-action-log.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/session-cleanup",
+      "intents": [
+        "abtop",
+        "cleanup",
+        "orphan",
+        "pattern",
+        "process"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/session-cleanup.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/session-event-log",
+      "intents": [
+        "agents",
+        "durable",
+        "event",
+        "managed",
+        "pattern"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/session-event-log.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/session-init-bootstrap",
+      "intents": [
+        "async",
+        "bootstrap",
+        "init",
+        "session",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/session-init-bootstrap.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/session-registry",
+      "intents": [
+        "coordination",
+        "registry",
+        "session",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/session-registry.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/session-resume-index",
+      "intents": [
+        "index",
+        "metadata",
+        "multica",
+        "pattern",
+        "resume"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/session-resume-index.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/session-state-machine",
+      "intents": [
+        "machine",
+        "phase",
+        "session",
+        "spec",
+        "state"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/session-state-machine.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/session-state-snapshot",
+      "intents": [
+        "estado",
+        "lección",
+        "sesión",
+        "session",
+        "snapshot"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/session-state-snapshot.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/session-status",
+      "intents": [
+        "abtop",
+        "consultable",
+        "pattern",
+        "session",
+        "snapshot"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/session-status.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/setup-memory",
+      "intents": [
+        "auto",
+        "estructura",
+        "inicializa",
+        "memory",
+        "proyecto"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/setup-memory.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/skill-optimize",
+      "intents": [
+        "agente",
+        "auto",
+        "autoresearch",
+        "bucle",
+        "optimizar"
+      ],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/skill-optimize.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slice-context-chain",
+      "intents": [
+        "between",
+        "chain",
+        "context",
+        "knowledge",
+        "session"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slice-context-chain.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/spill-save",
+      "intents": [
+        "fichero",
+        "output",
+        "oversized",
+        "persiste",
+        "privado"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/spill-save.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/tool-search",
+      "intents": [
+        "agentes",
+        "buscar",
+        "clave",
+        "comandos",
+        "palabra"
+      ],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/tool-search.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/ua-chat",
+      "intents": [
+        "graph",
+        "knowledge",
+        "language",
+        "natural",
+        "search"
+      ],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/ua-chat.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/ubiquitous-language/SKILL",
+      "intents": [
+        "consolidar",
+        "context",
+        "dice",
+        "dominio",
+        "extrae"
+      ],
+      "kind": "skill",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/ubiquitous-language/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/vaults-context-load",
+      "intents": [
+        "context",
+        "fallback",
+        "load",
+        "loading",
+        "saviavaults"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/vaults-context-load.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/vaults-freshness",
+      "intents": [
+        "check",
+        "context",
+        "dome",
+        "fresh",
+        "freshness"
+      ],
+      "kind": "script",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/vaults-freshness.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/web-research",
+      "intents": [
+        "auto",
+        "available",
+        "back",
+        "best",
+        "context"
+      ],
+      "kind": "cmd",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/web-research.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/web-research/SKILL",
+      "intents": [
+        "buscar",
+        "contexto",
+        "cves",
+        "docs",
+        "gaps"
+      ],
+      "kind": "skill",
+      "owner_domain": "memory",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/web-research/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/decide-architecture",
+      "intents": [
+        "accuracy",
+        "agent",
+        "anthropic",
+        "bias",
+        "clasifica"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/decide-architecture.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/_template/SKILL",
+      "intents": [
+        "carga",
+        "copia",
+        "crear",
+        "directorio",
+        "nueva"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/_template/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/_template_python/SKILL",
+      "intents": [
+        "backed",
+        "carga",
+        "copia",
+        "crear",
+        "directorio"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/_template_python/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/acceptance-cost",
+      "intents": [
+        "acceptance",
+        "aceptado",
+        "cambio",
+        "cost",
+        "costo"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/acceptance-cost.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/accessibility-mode",
+      "intents": [
+        "accesibilidad",
+        "activa",
+        "desactiva",
+        "estado",
+        "muestra"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/accessibility-mode.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/accessibility-setup",
+      "intents": [
+        "accesibilidad",
+        "adaptarse",
+        "configura",
+        "necesidades",
+        "preferencias"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/accessibility-setup.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/action-shape-classifier",
+      "intents": [
+        "acción",
+        "action",
+        "classifier",
+        "forma",
+        "guards"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/action-shape-classifier.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/adaptive-halting",
+      "intents": [
+        "adaptive",
+        "check",
+        "criterion",
+        "double",
+        "halting"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/adaptive-halting.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/adaptive-strategy-selector",
+      "intents": [
+        "adaptive",
+        "based",
+        "loading",
+        "model",
+        "select"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/adaptive-strategy-selector.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/adb-run",
+      "intents": [
+        "chains",
+        "compound",
+        "execute",
+        "functions",
+        "without"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/adb-run.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/add-maturity-levels",
+      "intents": [
+        "field",
+        "frontmatter",
+        "levels",
+        "maturity",
+        "skill"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/add-maturity-levels.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ado-bridge",
+      "intents": [
+        "azure",
+        "bridge",
+        "commands",
+        "devops",
+        "rest"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ado-bridge.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/advisor-config",
+      "intents": [
+        "advisor",
+        "anthropic",
+        "config",
+        "configuration",
+        "generate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/advisor-config.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agents-catalog-sync",
+      "intents": [
+        "agents",
+        "auto",
+        "catalog",
+        "slice",
+        "sync"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agents-catalog-sync.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agents-md-drift-check",
+      "intents": [
+        "agents",
+        "check",
+        "drift"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agents-md-drift-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agents-md-generate",
+      "intents": [
+        "agents",
+        "generate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agents-md-generate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/agents-size-checker",
+      "intents": [
+        "agents",
+        "checker",
+        "emit",
+        "fail",
+        "list"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/agents-size-checker.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/ai-labor-impact/SKILL",
+      "intents": [
+        "analiza",
+        "equipo",
+        "impacto",
+        "organización",
+        "trabajo"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/ai-labor-impact/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/ai-model-card",
+      "intents": [
+        "agentes",
+        "card",
+        "decisiones",
+        "documentando",
+        "model"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/ai-model-card.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/always-on-install-cron",
+      "intents": [
+        "always",
+        "cron",
+        "detectors",
+        "install",
+        "monitoring"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/always-on-install-cron.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/always-on-runner",
+      "intents": [
+        "always",
+        "detector",
+        "framework",
+        "monitoring",
+        "runner"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/always-on-runner.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/architect",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/architect.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/architecture-intelligence/SKILL",
+      "intents": [
+        "arquitectura",
+        "diseña",
+        "existente",
+        "nuevo",
+        "proyecto"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/architecture-intelligence/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ast-comprehend",
+      "intents": [
+        "comprehend",
+        "comprehension",
+        "estructural",
+        "extractor",
+        "lenguaje"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ast-comprehend.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/ast-comprehension/SKILL",
+      "intents": [
+        "comprensión",
+        "código",
+        "desconocido",
+        "enteros",
+        "estructural"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/ast-comprehension/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/ast-quality-gate/SKILL",
+      "intents": [
+        "calidad",
+        "código",
+        "generado",
+        "merge",
+        "verifica"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/ast-quality-gate/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/attack-surface-map",
+      "intents": [
+        "attack",
+        "mapping",
+        "surface"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/attack-surface-map.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/attack-surface-mapper/SKILL",
+      "intents": [
+        "ataque",
+        "dominio",
+        "mapear",
+        "osint",
+        "subdominios"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/attack-surface-mapper/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/auto-loop-gate",
+      "intents": [
+        "auto",
+        "clarify",
+        "classifies",
+        "gate",
+        "loop"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/auto-loop-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/azdevops-queries",
+      "intents": [],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/azdevops-queries.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/azure-devops-operator",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/azure-devops-operator.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/azure-devops-queries/SKILL",
+      "intents": [
+        "actualización",
+        "azure",
+        "consultas",
+        "datos",
+        "devops"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/azure-devops-queries/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/azure-pipelines/SKILL",
+      "intents": [
+        "azure",
+        "depura",
+        "gestiona",
+        "pipelines"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/azure-pipelines/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/backlog-capture",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/backlog-capture.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/backlog-git",
+      "intents": [
+        "backlogs",
+        "control",
+        "proyectos",
+        "versiones"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/backlog-git.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/backlog-git-tracker/SKILL",
+      "intents": [
+        "backlog",
+        "capturan",
+        "comparan",
+        "detectar",
+        "drift"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/backlog-git-tracker/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/backlog-groom",
+      "intents": [
+        "aceptación",
+        "asistido",
+        "criterios",
+        "detectar",
+        "duplicados"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/backlog-groom.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/backlog-init",
+      "intents": [
+        "backlog",
+        "init",
+        "initialize",
+        "local",
+        "project"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/backlog-init.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/backlog-patterns",
+      "intents": [
+        "detecta",
+        "duplicados",
+        "pbis",
+        "portfolio",
+        "proyectos"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/backlog-patterns.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/backlog-pbi-crud",
+      "intents": [
+        "archive",
+        "backlog",
+        "create",
+        "crud",
+        "local"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/backlog-pbi-crud.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/backlog-prioritize",
+      "intents": [
+        "automática",
+        "datos",
+        "esfuerzo",
+        "priorización",
+        "reales"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/backlog-prioritize.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/backlog-query",
+      "intents": [
+        "backlog",
+        "fields",
+        "frontmatter",
+        "local",
+        "pbis"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/backlog-query.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/backlog-resolver",
+      "intents": [
+        "backlog",
+        "data",
+        "fallback",
+        "first",
+        "local"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/backlog-resolver.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/backlog-sync",
+      "intents": [
+        "azure",
+        "backlog",
+        "devops",
+        "external",
+        "github"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/backlog-sync.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/backup",
+      "intents": [
+        "backup",
+        "cifrado",
+        "configuraciones",
+        "datos",
+        "drive"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/backup.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/backup",
+      "intents": [
+        "backup",
+        "cifrado",
+        "datos",
+        "gdrive",
+        "locales"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/backup.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/banking-architecture/SKILL",
+      "intents": [
+        "arquitectura",
+        "bancario",
+        "diseña",
+        "proyectos",
+        "revisa"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/banking-architecture/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/banking-bian",
+      "intents": [
+        "archimate",
+        "arquitectura",
+        "bian",
+        "contra",
+        "diagramas"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/banking-bian.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/banking-detect",
+      "intents": [
+        "auto",
+        "bancario",
+        "bian",
+        "detectar",
+        "entidades"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/banking-detect.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/banking-eda-validate",
+      "intents": [
+        "idempotencia",
+        "kafka",
+        "pipelines",
+        "saga",
+        "schemas"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/banking-eda-validate.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/baseline-tighten",
+      "intents": [
+        "auto",
+        "baseline",
+        "slice",
+        "tighten"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/baseline-tighten.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/benchmark-hook-dispatch",
+      "intents": [
+        "benchmark",
+        "dispatch",
+        "hook",
+        "scripts",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/benchmark-hook-dispatch.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/bertopic-probe",
+      "intents": [
+        "bertopic",
+        "probe",
+        "slice",
+        "viability"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/bertopic-probe.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/board-flow",
+      "intents": [
+        "actual",
+        "analiza",
+        "board",
+        "botella",
+        "cuellos"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/board-flow.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/bus-factor-analysis/SKILL",
+      "intents": [],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/bus-factor-analysis/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/bus-factor-distribute",
+      "intents": [
+        "developer",
+        "distribute",
+        "factor",
+        "knowledge",
+        "objetivo"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/bus-factor-distribute.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/bus-factor-scan",
+      "intents": [
+        "factor",
+        "orquestador",
+        "scan",
+        "wrapper"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/bus-factor-scan.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/business-analyst",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/business-analyst.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/calendar-deadlines",
+      "intents": [
+        "atras",
+        "deadlines",
+        "estado",
+        "nada",
+        "preparacion"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/calendar-deadlines.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/calendar-plan",
+      "intents": [
+        "automaticos",
+        "blocks",
+        "eisenhower",
+        "focus",
+        "planificar"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/calendar-plan.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/calendar-rebalance",
+      "intents": [
+        "blocks",
+        "calendario",
+        "cambio",
+        "focus",
+        "prioridades"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/calendar-rebalance.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/calendar-sync",
+      "intents": [
+        "calendario",
+        "graph",
+        "microsoft",
+        "outlook",
+        "sincronizar"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/calendar-sync.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/calendar-today",
+      "intents": [
+        "alertas",
+        "blocks",
+        "focus",
+        "recomendaciones",
+        "reuniones"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/calendar-today.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/calibration-judge",
+      "intents": [
+        "confidence",
+        "evidence",
+        "judge",
+        "match",
+        "statements"
+      ],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/calibration-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/capacity-forecast",
+      "intents": [
+        "capacidad",
+        "medio",
+        "planifica",
+        "plazo",
+        "previsión"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/capacity-forecast.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/capacity-planning/SKILL",
+      "intents": [
+        "calcula",
+        "capacidad",
+        "equipo",
+        "periodo",
+        "sprint"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/capacity-planning/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/capex-classify",
+      "intents": [
+        "capex",
+        "classification",
+        "classify",
+        "opex"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/capex-classify.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/capex-evidence-package",
+      "intents": [
+        "capex",
+        "evidence",
+        "generator",
+        "package"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/capex-evidence-package.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/capex-phase-gate",
+      "intents": [
+        "capex",
+        "gate",
+        "phase",
+        "recorder"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/capex-phase-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/case-init",
+      "intents": [
+        "business",
+        "case",
+        "data",
+        "pursuit",
+        "scaffold"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/case-init.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/case-kill-check",
+      "intents": [
+        "across",
+        "active",
+        "cases",
+        "kill",
+        "recommendations"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/case-kill-check.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/case-validate",
+      "intents": [
+        "business",
+        "case",
+        "directories",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/case-validate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/catalog",
+      "intents": [
+        "busca",
+        "catálogo",
+        "comandos",
+        "extendido",
+        "keyword"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/catalog.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/ceo-alerts",
+      "intents": [
+        "alertas",
+        "decisiones",
+        "dirección",
+        "estratégicas",
+        "nivel"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/ceo-alerts.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/ceremony-health",
+      "intents": [
+        "ceremonias",
+        "duración",
+        "métricas",
+        "participación",
+        "rate"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/ceremony-health.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/changelog-assemble",
+      "intents": [
+        "assemble",
+        "changelog",
+        "fragments"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/changelog-assemble.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/changelog-fragment",
+      "intents": [
+        "changelog",
+        "create",
+        "current",
+        "fragment"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/changelog-fragment.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/check-daemon-auth",
+      "intents": [
+        "auth",
+        "check",
+        "daemon"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/check-daemon-auth.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ci-duration",
+      "intents": [
+        "duración",
+        "duration",
+        "jobs",
+        "mide",
+        "wrapper"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ci-duration.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ci-failure-tracker",
+      "intents": [
+        "analysis",
+        "failure",
+        "failures",
+        "noise",
+        "pipeline"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ci-failure-tracker.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/ci-health",
+      "intents": [
+        "ejecuciones",
+        "fallo",
+        "local",
+        "muestra",
+        "partir"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/ci-health.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/classifier-corpus-run",
+      "intents": [
+        "clasificación",
+        "classifier",
+        "corpus",
+        "regresión"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/classifier-corpus-run.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/classify-execution-level",
+      "intents": [
+        "classify",
+        "execution",
+        "level",
+        "origin",
+        "script"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/classify-execution-level.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/claude-md-drift-check",
+      "intents": [
+        "check",
+        "claude",
+        "coincidan",
+        "conteos",
+        "drift"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/claude-md-drift-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/client-profile",
+      "intents": [
+        "cliente",
+        "gestión",
+        "perfiles",
+        "saviahub"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/client-profile.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/client-profile-manager/SKILL",
+      "intents": [
+        "actualizan",
+        "cliente",
+        "consultan",
+        "crean",
+        "perfiles"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/client-profile-manager/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/cobol-developer",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/cobol-developer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/coherence-court",
+      "intents": [
+        "coherence",
+        "consistencia",
+        "court",
+        "etapas",
+        "jueces"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/coherence-court.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/coherence-factual-judge",
+      "intents": [
+        "coherence",
+        "contradicts",
+        "court",
+        "earlier",
+        "facts"
+      ],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/coherence-factual-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/coherence-judge",
+      "intents": [
+        "consistency",
+        "dates",
+        "entities",
+        "internal",
+        "judge"
+      ],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/coherence-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/coherence-objectives-judge",
+      "intents": [
+        "coherence",
+        "contradicts",
+        "court",
+        "declared",
+        "flow"
+      ],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/coherence-objectives-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/coherence-premise-drift-judge",
+      "intents": [
+        "between",
+        "coherence",
+        "court",
+        "drift",
+        "flow"
+      ],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/coherence-premise-drift-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/coherence-scope-judge",
+      "intents": [
+        "coherence",
+        "constraints",
+        "court",
+        "earlier",
+        "fixed"
+      ],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/coherence-scope-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/coherence-validator",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/coherence-validator.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/commit-guardian",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/commit-guardian.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/company-messaging/SKILL",
+      "intents": [
+        "cifrados",
+        "company",
+        "envían",
+        "internos",
+        "mensajes"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/company-messaging/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/company-repo",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/company-repo.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/company-repo",
+      "intents": [
+        "company",
+        "lifecycle",
+        "operations",
+        "repo"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/company-repo.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/company-repo-ops",
+      "intents": [
+        "company",
+        "connect",
+        "operations",
+        "repo",
+        "status"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/company-repo-ops.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/company-repo-templates",
+      "intents": [
+        "company",
+        "heredoc",
+        "init",
+        "repo",
+        "templates"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/company-repo-templates.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/company-repo-templates-init",
+      "intents": [
+        "company",
+        "heredoc",
+        "init",
+        "initialization",
+        "repo"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/company-repo-templates-init.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/competence-score",
+      "intents": [
+        "calculate",
+        "competence",
+        "score",
+        "scores",
+        "tracking"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/competence-score.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/compile-agent-index",
+      "intents": [
+        "agent",
+        "compile",
+        "compiled",
+        "index",
+        "reference"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/compile-agent-index.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/compress-skip-frozen",
+      "intents": [
+        "advisory",
+        "compress",
+        "core",
+        "frozen",
+        "skip"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/compress-skip-frozen.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/confidence-calibrate",
+      "intents": [
+        "analytics",
+        "calibrate",
+        "calibration",
+        "confidence"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/confidence-calibrate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/confidentiality-check",
+      "intents": [
+        "check",
+        "comply",
+        "confidentiality",
+        "files",
+        "levels"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/confidentiality-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/confidentiality-scan",
+      "intents": [
+        "confidentiality",
+        "credentials",
+        "names",
+        "project",
+        "real"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/confidentiality-scan.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/consensus-validation/SKILL",
+      "intents": [
+        "decisión",
+        "jueces",
+        "panel",
+        "recomendación",
+        "técnica"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/consensus-validation/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/containment-check",
+      "intents": [
+        "available",
+        "check",
+        "containment",
+        "infrastructure",
+        "verify"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/containment-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/containment-run",
+      "intents": [
+        "command",
+        "containment",
+        "execute",
+        "level",
+        "proper"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/containment-run.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/content-fingerprint/SKILL",
+      "intents": [
+        "cache",
+        "cadena",
+        "contenido",
+        "corto",
+        "derivado"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/content-fingerprint/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/contribute",
+      "intents": [
+        "capa",
+        "comunidad",
+        "contribute",
+        "github",
+        "interacción"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/contribute.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/control-band-agent",
+      "intents": [
+        "agent",
+        "agente",
+        "band",
+        "control",
+        "invocación"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/control-band-agent.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/control-band-detect",
+      "intents": [
+        "band",
+        "bands",
+        "control",
+        "detección",
+        "detect"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/control-band-detect.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/corporate-adopt",
+      "intents": [
+        "adopt",
+        "corporate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/corporate-adopt.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/corporate-body-validate",
+      "intents": [
+        "body",
+        "corporate",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/corporate-body-validate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/corporate-ledger-verify",
+      "intents": [
+        "corporate",
+        "ledger",
+        "verify"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/corporate-ledger-verify.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/corporate-monotonicity-gate",
+      "intents": [
+        "corporate",
+        "gate",
+        "monotonicity"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/corporate-monotonicity-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/corporate-no-write-assert",
+      "intents": [
+        "assert",
+        "corp",
+        "corporate",
+        "input",
+        "instance"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/corporate-no-write-assert.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/corporate/corporate-disconnect-drill",
+      "intents": [
+        "corporate",
+        "disconnect",
+        "drill",
+        "simulation"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/corporate/corporate-disconnect-drill.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/corporate/corporate-resilience-check",
+      "intents": [
+        "assessment",
+        "check",
+        "corporate",
+        "local",
+        "resilience"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/corporate/corporate-resilience-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/cost-center",
+      "intents": [
+        "billing",
+        "budgets",
+        "cost",
+        "forecasting",
+        "invoicing"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/cost-center.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/cost-management/SKILL",
+      "intents": [
+        "costes",
+        "facturas",
+        "forecasting",
+        "gestionan",
+        "presupuestos"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/cost-management/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/count-commands",
+      "intents": [
+        "canonical",
+        "commands",
+        "count",
+        "counter",
+        "slash"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/count-commands.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/court-score-aggregator",
+      "intents": [
+        "aggregator",
+        "court",
+        "score"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/court-score-aggregator.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/credential-egress",
+      "intents": [
+        "credenciales",
+        "credential",
+        "egress",
+        "punto",
+        "resolución"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/credential-egress.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/credential-proxy",
+      "intents": [
+        "agents",
+        "credential",
+        "isolation",
+        "managed",
+        "pattern"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/credential-proxy.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/criterio-cite",
+      "intents": [
+        "cite",
+        "criterio",
+        "scripts",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/criterio-cite.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/criterio-init",
+      "intents": [
+        "criterio",
+        "init",
+        "scripts",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/criterio-init.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/criterio-validate",
+      "intents": [
+        "criterio",
+        "scripts",
+        "slice",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/criterio-validate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/criterion-simulation-judge",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/criterion-simulation-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/criticality",
+      "intents": [
+        "criticality",
+        "dispatcher",
+        "operations"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/criticality.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/criticality-assess",
+      "intents": [
+        "criticidad",
+        "desglose",
+        "dimensiones",
+        "evaluar",
+        "item"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/criticality-assess.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/criticality-dashboard",
+      "intents": [
+        "criticos",
+        "cross",
+        "equipo",
+        "heatmap",
+        "items"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/criticality-dashboard.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/criticality-engine",
+      "intents": [
+        "assess",
+        "criticality",
+        "dashboard",
+        "engine",
+        "operations"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/criticality-engine.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/criticality-rebalance",
+      "intents": [
+        "capacidad",
+        "carga",
+        "criticidad",
+        "equipo",
+        "redistribuir"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/criticality-rebalance.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/criticality-scoring",
+      "intents": [
+        "criticality",
+        "engine",
+        "functions",
+        "pure",
+        "scoring"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/criticality-scoring.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/daily-activation-plan",
+      "intents": [
+        "activation",
+        "agent",
+        "daily",
+        "plan"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/daily-activation-plan.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/daily-plan",
+      "intents": [
+        "activation",
+        "agent",
+        "budgets",
+        "generate",
+        "plan"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/daily-plan.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/daily-routine",
+      "intents": [
+        "adaptativa",
+        "comandos",
+        "diaria",
+        "jornada",
+        "relevantes"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/daily-routine.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/dependency-map",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/dependency-map.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/dependency-scan",
+      "intents": [
+        "dependency",
+        "scan",
+        "scanning",
+        "trivy",
+        "vulnerability"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/dependency-scan.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/dependency-scanner/SKILL",
+      "intents": [
+        "cyclonedx",
+        "dependencias",
+        "escanean",
+        "java",
+        "node"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/dependency-scanner/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/detect-token-exhaustion",
+      "intents": [
+        "agent",
+        "cause",
+        "classify",
+        "detect",
+        "exhaustion"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/detect-token-exhaustion.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/developer-experience/SKILL",
+      "intents": [
+        "desarrollo",
+        "equipo",
+        "experiencia",
+        "mejora",
+        "mide"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/developer-experience/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/devops-validation/SKILL",
+      "intents": [
+        "agile",
+        "azure",
+        "conecta",
+        "configuración",
+        "devops"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/devops-validation/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/diagram-architect",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/diagram-architect.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/diagram-generate",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/diagram-generate.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/diagram-generation/SKILL",
+      "intents": [
+        "arquitectura",
+        "código",
+        "diagramas",
+        "flujo",
+        "generar"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/diagram-generation/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/diagram-import",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/diagram-import.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/diagram-import/SKILL",
+      "intents": [
+        "crear",
+        "diagrama",
+        "entidades",
+        "existente",
+        "extraer"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/diagram-import/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/diagram-status",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/diagram-status.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/doc-counts-check",
+      "intents": [
+        "check",
+        "counts",
+        "scripts",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/doc-counts-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/doc-quality-feedback/SKILL",
+      "intents": [
+        "calidad",
+        "documentación",
+        "feedback",
+        "recopila",
+        "reglas"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/doc-quality-feedback/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/dotnet-developer",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/dotnet-developer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/dual-estimate",
+      "intents": [
+        "agent",
+        "dual",
+        "engine",
+        "estimate",
+        "estimation"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/dual-estimate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/ecosystem-watcher/SKILL",
+      "intents": [
+        "cambios",
+        "detectar",
+        "ecosistema",
+        "externas",
+        "herramientas"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/ecosystem-watcher/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/egress-gate",
+      "intents": [
+        "control",
+        "egress",
+        "gate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/egress-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/emergency-fallback",
+      "intents": [
+        "emergency",
+        "fallback",
+        "operaciones"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/emergency-fallback.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/emergency-mode",
+      "intents": [
+        "cloud",
+        "disponible",
+        "emergencia",
+        "está",
+        "gestionar"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/emergency-mode.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/emergency-mode/SKILL",
+      "intents": [
+        "anthropic",
+        "caída",
+        "continuar",
+        "está",
+        "localai"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/emergency-mode/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/emergency-plan",
+      "intents": [
+        "descarga",
+        "emergency",
+        "modelo",
+        "modo",
+        "offline"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/emergency-plan.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/emergency-setup",
+      "intents": [
+        "emergencia",
+        "emergency",
+        "local",
+        "modo",
+        "rápido"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/emergency-setup.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/emergency-status",
+      "intents": [
+        "emergencia",
+        "emergency",
+        "estado",
+        "sistema",
+        "status"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/emergency-status.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/emotional-state-tracker",
+      "intents": [
+        "emotional",
+        "savia",
+        "session",
+        "state",
+        "stress"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/emotional-state-tracker.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/engagement-capacity-check",
+      "intents": [
+        "capacity",
+        "check",
+        "enforcement",
+        "engagement"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/engagement-capacity-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/engagement-init",
+      "intents": [
+        "client",
+        "engagement",
+        "ethical",
+        "init",
+        "initialize"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/engagement-init.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/engagement-separation-proof",
+      "intents": [
+        "engagement",
+        "generates",
+        "proof",
+        "separation",
+        "verifiable"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/engagement-separation-proof.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/engagement-wall-check",
+      "intents": [
+        "check",
+        "client",
+        "cross",
+        "engagement",
+        "isolation"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/engagement-wall-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ensure-daemons-auth",
+      "intents": [
+        "auth",
+        "daemons",
+        "ensure"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ensure-daemons-auth.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/enterprise-analytics/SKILL",
+      "intents": [
+        "aggregación",
+        "empresarial",
+        "forecasting",
+        "métricas",
+        "necesitan"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/enterprise-analytics/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/enterprise-onboarding/SKILL",
+      "intents": [
+        "forma",
+        "incorporan",
+        "masiva",
+        "múltiples",
+        "organización"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/enterprise-onboarding/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise-reconcile",
+      "intents": [
+        "adapted",
+        "archived",
+        "classify",
+        "enterprise",
+        "reconcile"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise-reconcile.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/bench-match",
+      "intents": [
+        "bench",
+        "management",
+        "match",
+        "resource"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/bench-match.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/bench-register",
+      "intents": [
+        "bench",
+        "management",
+        "register",
+        "resource"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/bench-register.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/billing-milestone",
+      "intents": [
+        "billing",
+        "ifrs",
+        "milestone",
+        "project"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/billing-milestone.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/client-health-score",
+      "intents": [
+        "client",
+        "health",
+        "intelligence",
+        "score"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/client-health-score.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/daily-activation-plan",
+      "intents": [
+        "activation",
+        "agent",
+        "daily",
+        "plan"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/daily-activation-plan.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/dep-graph",
+      "intents": [
+        "cross",
+        "dependencies",
+        "graph",
+        "project"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/dep-graph.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/enterprise-migrate",
+      "intents": [
+        "command",
+        "core",
+        "enterprise",
+        "migrate",
+        "migration"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/enterprise-migrate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/expertise-directory",
+      "intents": [
+        "directory",
+        "expertise",
+        "federation",
+        "knowledge"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/expertise-directory.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/knowledge-federator",
+      "intents": [
+        "federation",
+        "federator",
+        "knowledge"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/knowledge-federator.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/lessons-collector",
+      "intents": [
+        "collector",
+        "cross",
+        "lessons",
+        "pipeline",
+        "project"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/lessons-collector.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/lessons-promote",
+      "intents": [
+        "cross",
+        "lessons",
+        "pipeline",
+        "project",
+        "promote"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/lessons-promote.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/rbac-bulk-assign",
+      "intents": [
+        "assign",
+        "bulk",
+        "file",
+        "rbac",
+        "roles"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/rbac-bulk-assign.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/rbac-check",
+      "intents": [
+        "check",
+        "command",
+        "permission",
+        "rbac",
+        "tenant"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/rbac-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/release-create",
+      "intents": [
+        "create",
+        "orchestration",
+        "release"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/release-create.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/release-gate-check",
+      "intents": [
+        "check",
+        "gate",
+        "orchestration",
+        "release"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/release-gate-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/rollback-module",
+      "intents": [
+        "activation",
+        "enterprise",
+        "module",
+        "revert",
+        "rollback"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/rollback-module.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/tenant-activate",
+      "intents": [
+        "activate",
+        "mode",
+        "multi",
+        "tenant",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/tenant-activate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/tenant-create",
+      "intents": [
+        "create",
+        "enterprise",
+        "savia",
+        "tenant"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/tenant-create.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/env-scrub",
+      "intents": [
+        "entorno",
+        "sanitiza",
+        "scrub",
+        "spawn"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/env-scrub.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/eras-timeline-generate",
+      "intents": [
+        "docs",
+        "eras",
+        "generate",
+        "roadmap",
+        "timeline"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/eras-timeline-generate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/estimate-calibrate",
+      "intents": [
+        "actuals",
+        "agent",
+        "calibrate",
+        "empirical",
+        "estimate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/estimate-calibrate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/estimate-convert",
+      "intents": [
+        "agent",
+        "convert",
+        "days",
+        "dual",
+        "estimate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/estimate-convert.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/eval-ablation-run",
+      "intents": [
+        "ablation",
+        "eval"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/eval-ablation-run.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/eval-output",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/eval-output.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/eval-workspace",
+      "intents": [
+        "contra",
+        "eval",
+        "evaluación",
+        "integral",
+        "reservas"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/eval-workspace.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/evaluate-repo",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/evaluate-repo.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/evaluations-framework/SKILL",
+      "intents": [
+        "agentes",
+        "calidad",
+        "diseñan",
+        "ejecutan",
+        "evaluaciones"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/evaluations-framework/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/evidence-capture",
+      "intents": [
+        "bucle",
+        "capture",
+        "evidence",
+        "evidencia",
+        "wrapper"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/evidence-capture.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/exchange-ledger",
+      "intents": [
+        "exchange",
+        "federation",
+        "ledger"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/exchange-ledger.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/execution-level-inventory",
+      "intents": [
+        "execution",
+        "full",
+        "hooks",
+        "inventory",
+        "level"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/execution-level-inventory.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/exit",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/exit.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/exit-dependencies-declare",
+      "intents": [
+        "declare",
+        "dependencies",
+        "exit",
+        "package",
+        "tool"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/exit-dependencies-declare.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/exit-drill-execute",
+      "intents": [
+        "drill",
+        "execute",
+        "exit",
+        "full",
+        "simulation"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/exit-drill-execute.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/exit-independence-verify",
+      "intents": [
+        "exit",
+        "independence",
+        "package",
+        "verify"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/exit-independence-verify.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/exit-package-generate",
+      "intents": [
+        "engagement",
+        "exit",
+        "generate",
+        "generation",
+        "package"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/exit-package-generate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/exit-purge-verify",
+      "intents": [
+        "engagement",
+        "exit",
+        "forget",
+        "purge",
+        "verify"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/exit-purge-verify.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ext-platform-card-validate",
+      "intents": [
+        "card",
+        "external",
+        "platform",
+        "slice",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ext-platform-card-validate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ext-platform-export-gate",
+      "intents": [
+        "export",
+        "external",
+        "gate",
+        "platform",
+        "platforms"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ext-platform-export-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ext-platform-gate",
+      "intents": [
+        "asymmetry",
+        "enforce",
+        "external",
+        "gate",
+        "platform"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ext-platform-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ext-platform-resilience",
+      "intents": [
+        "external",
+        "platform",
+        "platforms",
+        "resilience",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ext-platform-resilience.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/factuality-judge",
+      "intents": [
+        "accuracy",
+        "against",
+        "claims",
+        "factual",
+        "judge"
+      ],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/factuality-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/federation-discover",
+      "intents": [
+        "auto",
+        "descubrimiento",
+        "discover",
+        "federadas",
+        "federation"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/federation-discover.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/federation-drill",
+      "intents": [
+        "compromised",
+        "drill",
+        "federation",
+        "instance"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/federation-drill.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/flow-backlog-groom",
+      "intents": [
+        "backlog",
+        "items",
+        "prioritize",
+        "review"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/flow-backlog-groom.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/flow-burndown",
+      "intents": [
+        "burndown",
+        "chart",
+        "data",
+        "show",
+        "sprint"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/flow-burndown.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/flow-metrics",
+      "intents": [
+        "cycle",
+        "dashboard",
+        "flow",
+        "flujo",
+        "lead"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/flow-metrics.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/flow-spec-create",
+      "intents": [
+        "create",
+        "document",
+        "specification"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/flow-spec-create.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/flow-sprint-board",
+      "intents": [
+        "board",
+        "column",
+        "counts",
+        "display",
+        "sprint"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/flow-sprint-board.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/flow-sprint-close",
+      "intents": [
+        "backlog",
+        "close",
+        "generate",
+        "move",
+        "pending"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/flow-sprint-close.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/flow-sprint-create",
+      "intents": [
+        "create",
+        "dates",
+        "goal",
+        "sprint"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/flow-sprint-create.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/flow-task-assign",
+      "intents": [
+        "assign",
+        "member",
+        "task",
+        "team"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/flow-task-assign.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/flow-task-create",
+      "intents": [
+        "create",
+        "flow",
+        "frontmatter",
+        "metadata",
+        "savia"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/flow-task-create.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/flow-task-move",
+      "intents": [
+        "between",
+        "board",
+        "columns",
+        "done",
+        "move"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/flow-task-move.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/flow-timesheet",
+      "intents": [
+        "hours",
+        "spent",
+        "task"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/flow-timesheet.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/flow-timesheet-report",
+      "intents": [
+        "date",
+        "generate",
+        "range",
+        "report",
+        "timesheet"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/flow-timesheet-report.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/flow-velocity",
+      "intents": [
+        "historical",
+        "metrics",
+        "show",
+        "velocity"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/flow-velocity.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/focal-checkin",
+      "intents": [
+        "carga",
+        "check",
+        "checkin",
+        "cognitiva",
+        "focal"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/focal-checkin.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/focal-dispatch",
+      "intents": [
+        "crítica",
+        "decisión",
+        "dispatch",
+        "focal",
+        "humana"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/focal-dispatch.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/focal-status",
+      "intents": [
+        "activos",
+        "agregada",
+        "focal",
+        "nidos",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/focal-status.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/focus-mode",
+      "intents": [
+        "carga",
+        "distracciones",
+        "modo",
+        "oculta",
+        "single"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/focus-mode.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/forge-idea",
+      "intents": [
+        "clara",
+        "endurecida",
+        "forja",
+        "idea",
+        "interrogatorio"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/forge-idea.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/forge-idea",
+      "intents": [
+        "forge",
+        "idea",
+        "presion",
+        "socratica",
+        "ternario"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/forge-idea.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/fork-agents",
+      "intents": [
+        "agents",
+        "cacheable",
+        "claude",
+        "fork",
+        "invocaciones"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/fork-agents.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/frontend-developer",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/frontend-developer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/frontier-strategy",
+      "intents": [
+        "frontier",
+        "selection",
+        "slice",
+        "strategies",
+        "strategy"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/frontier-strategy.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/gate-init",
+      "intents": [
+        "gate",
+        "init",
+        "scripts"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/gate-init.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/gate-post-receive",
+      "intents": [
+        "gate",
+        "post",
+        "receive",
+        "scripts"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/gate-post-receive.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/gate-teardown",
+      "intents": [
+        "gate",
+        "scripts",
+        "teardown"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/gate-teardown.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/generate-capability-map",
+      "intents": [
+        "around",
+        "capability",
+        "generate",
+        "generator",
+        "python"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/generate-capability-map.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/generate-critical-facts",
+      "intents": [
+        "critical",
+        "facts",
+        "generate",
+        "scripts"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/generate-critical-facts.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/generate-github-hooks",
+      "intents": [
+        "generate",
+        "github",
+        "hooks"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/generate-github-hooks.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/generate-index",
+      "intents": [
+        "components",
+        "discoverable",
+        "generate",
+        "index",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/generate-index.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/git-history-secret-remediate",
+      "intents": [
+        "helper",
+        "history",
+        "remediation",
+        "secret"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/git-history-secret-remediate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/git-history-secret-scan",
+      "intents": [
+        "history",
+        "scanning",
+        "secret"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/git-history-secret-scan.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/git-secret-scanner/SKILL",
+      "intents": [
+        "buscando",
+        "commits",
+        "escanea",
+        "gitleaks",
+        "historial"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/git-secret-scanner/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/go-developer",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/go-developer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/goal-service",
+      "intents": [
+        "durable",
+        "goal",
+        "service",
+        "sesión",
+        "wrapper"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/goal-service.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/graph-query",
+      "intents": [
+        "conocimiento",
+        "consulta",
+        "grafo",
+        "lenguaje",
+        "natural"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/graph-query.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/graphrag-quality-gate",
+      "intents": [
+        "gate",
+        "graphrag",
+        "quality"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/graphrag-quality-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/graphrag-quality-gates",
+      "intents": [
+        "gates",
+        "graphrag",
+        "quality"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/graphrag-quality-gates.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/guided-work",
+      "intents": [
+        "acompaña",
+        "adaptando",
+        "guiado",
+        "necesidades",
+        "paso"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/guided-work.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/hallucination-fast-judge",
+      "intents": [
+        "actually",
+        "calls",
+        "cited",
+        "commands",
+        "draft"
+      ],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/hallucination-fast-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/hallucination-judge",
+      "intents": [
+        "consistency",
+        "detects",
+        "facts",
+        "invented",
+        "judge"
+      ],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/hallucination-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/handback-resolve",
+      "intents": [
+        "handback",
+        "obligation",
+        "resolve"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/handback-resolve.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hashline-edit",
+      "intents": [
+        "edit",
+        "file",
+        "hashline",
+        "protection",
+        "safe"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hashline-edit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hashline-guard",
+      "intents": [
+        "agent",
+        "edits",
+        "file",
+        "guard",
+        "hashline"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hashline-guard.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/health-dashboard",
+      "intents": [
+        "adaptada",
+        "dashboard",
+        "muestra",
+        "proyecto",
+        "rápida"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/health-dashboard.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/heat-scheduler",
+      "intents": [
+        "based",
+        "heat",
+        "lightweight",
+        "parallelism",
+        "scheduler"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/heat-scheduler.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/help",
+      "intents": [
+        "catálogo",
+        "comandos",
+        "pasos",
+        "pendientes",
+        "primeros"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/help.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hook-assignment-rule",
+      "intents": [
+        "assignment",
+        "documentation",
+        "hook",
+        "rule",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hook-assignment-rule.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hook-bench-all",
+      "intents": [
+        "bench",
+        "hook",
+        "hooks",
+        "latency",
+        "measure"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hook-bench-all.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hook-latency-bench",
+      "intents": [
+        "bench",
+        "hook",
+        "latencia",
+        "latency",
+        "media"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hook-latency-bench.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hook-latency-budget",
+      "intents": [
+        "budget",
+        "enforcement",
+        "hook",
+        "latency",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hook-latency-budget.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hook-pii-gate",
+      "intents": [
+        "commit",
+        "gate",
+        "hook",
+        "quality"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hook-pii-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/hook-profile",
+      "intents": [
+        "active",
+        "change",
+        "hook",
+        "minimal",
+        "profile"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/hook-profile.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hook-profile",
+      "intents": [
+        "active",
+        "hook",
+        "profile",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hook-profile.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hooks-integrity-check",
+      "intents": [
+        "check",
+        "detect",
+        "hooks",
+        "integrity",
+        "orphan"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hooks-integrity-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/import-sprint-story",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/import-sprint-story.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/incident-postmortem",
+      "intents": [
+        "incident",
+        "plantilla",
+        "postmortem",
+        "rellena"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/incident-postmortem.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/incident-rca",
+      "intents": [
+        "harness",
+        "incident",
+        "incidentes",
+        "investigación"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/incident-rca.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/index-compact",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/index-compact.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/index-status",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/index-status.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/infrastructure-agent",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/infrastructure-agent.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/install-prepush-hook",
+      "intents": [
+        "actual",
+        "dado",
+        "hook",
+        "instala",
+        "push"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/install-prepush-hook.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/install-savia-bridge-system",
+      "intents": [
+        "bridge",
+        "install",
+        "promote",
+        "savia",
+        "system"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/install-savia-bridge-system.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/install-watchdog",
+      "intents": [
+        "install",
+        "installs",
+        "savia",
+        "service",
+        "systemd"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/install-watchdog.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/instance-card",
+      "intents": [
+        "card",
+        "cards",
+        "identity",
+        "instance",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/instance-card.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/integration-status",
+      "intents": [
+        "apis",
+        "conectividad",
+        "dashboard",
+        "estado",
+        "integraciones"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/integration-status.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/java-developer",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/java-developer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/judge-anti-fatigue",
+      "intents": [
+        "anti",
+        "fatigue",
+        "judge",
+        "tracking",
+        "verdict"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/judge-anti-fatigue.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/judge-calibration",
+      "intents": [
+        "adversariales",
+        "calibration",
+        "judge",
+        "jueces",
+        "tracking"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/judge-calibration.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/judge-routing-verify",
+      "intents": [
+        "check",
+        "judge",
+        "parity",
+        "routing",
+        "verify"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/judge-routing-verify.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/judge-trigger-detector",
+      "intents": [
+        "detection",
+        "detector",
+        "deterministic",
+        "judge",
+        "trigger"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/judge-trigger-detector.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/kg-cleanup",
+      "intents": [
+        "archive",
+        "cleanup",
+        "entities",
+        "expired",
+        "orphaned"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/kg-cleanup.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/kg-link-prediction",
+      "intents": [
+        "link",
+        "prediction",
+        "wrapper"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/kg-link-prediction.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/kg-query",
+      "intents": [
+        "names",
+        "qualified",
+        "query"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/kg-query.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/kg-topology-analysis",
+      "intents": [
+        "analysis",
+        "topology",
+        "wrapper"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/kg-topology-analysis.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/knowledge-graph/SKILL",
+      "intents": [
+        "conocimiento",
+        "construye",
+        "consulta",
+        "entidades",
+        "grafo"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/knowledge-graph/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/knowledge-graph",
+      "intents": [
+        "graph",
+        "knowledge",
+        "shell",
+        "wrapper"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/knowledge-graph.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/l13-meta-pruebas",
+      "intents": [
+        "determinista",
+        "harness",
+        "meta",
+        "pruebas"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/l13-meta-pruebas.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/l28-ablation",
+      "intents": [
+        "ablacion",
+        "ablation",
+        "harness",
+        "prueba",
+        "sandbox"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/l28-ablation.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/labs-preregister",
+      "intents": [
+        "hipotesis",
+        "labs",
+        "preregister",
+        "preregistro",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/labs-preregister.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/language-boundary-check",
+      "intents": [
+        "boundary",
+        "check",
+        "language",
+        "scripts",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/language-boundary-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/learning-autonomy",
+      "intents": [
+        "autonomy",
+        "autonomía",
+        "consistent",
+        "graduada",
+        "learning"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/learning-autonomy.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/learning-divergence",
+      "intents": [
+        "divergence",
+        "divergencia",
+        "grafo",
+        "instrumento",
+        "learning"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/learning-divergence.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/learning-federate",
+      "intents": [
+        "aprendidas",
+        "comparte",
+        "consume",
+        "federate",
+        "learning"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/learning-federate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/learning-guard",
+      "intents": [
+        "agnosticismo",
+        "aprendizaje",
+        "bucle",
+        "guard",
+        "learning"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/learning-guard.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/learning-lifecycle",
+      "intents": [
+        "artefacto",
+        "despliegue",
+        "learning",
+        "lifecycle",
+        "sustrato"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/learning-lifecycle.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/learning-persist",
+      "intents": [
+        "cúpula",
+        "learning",
+        "persist",
+        "persiste",
+        "proposal"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/learning-persist.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/learning-proposal",
+      "intents": [
+        "canonical",
+        "capture",
+        "learning",
+        "proposal"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/learning-proposal.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/learning-reconcile",
+      "intents": [
+        "conflictivas",
+        "duplicadas",
+        "learning",
+        "lecciones",
+        "reconcile"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/learning-reconcile.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/learning-rollback",
+      "intents": [
+        "entrada",
+        "instantáneo",
+        "learning",
+        "rollback",
+        "sustrato"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/learning-rollback.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/legacy-assess",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/legacy-assess.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/legalize-es",
+      "intents": [
+        "corpus",
+        "español",
+        "gestión",
+        "legalize",
+        "legislativo"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/legalize-es.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/lesson-extract",
+      "intents": [
+        "cross",
+        "current",
+        "extract",
+        "lesson",
+        "project"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/lesson-extract.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/lesson-pipeline",
+      "intents": [
+        "cross",
+        "lesson",
+        "lessons",
+        "pipeline",
+        "project"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/lesson-pipeline.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/lib/adb-wrapper",
+      "intents": [],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/lib/adb-wrapper.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/lib/concurrent-executor",
+      "intents": [
+        "bounded",
+        "concurrent",
+        "execution",
+        "executor",
+        "parallel"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/lib/concurrent-executor.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/lib/enterprise-helpers",
+      "intents": [
+        "checks",
+        "enterprise",
+        "helpers",
+        "module",
+        "sourceable"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/lib/enterprise-helpers.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/lib/llm-healer",
+      "intents": [
+        "healer",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/lib/llm-healer.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/lib/mock-env",
+      "intents": [
+        "environment",
+        "library",
+        "mock",
+        "reusable",
+        "scripts"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/lib/mock-env.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/lib/os-detect",
+      "intents": [
+        "defaults",
+        "detect",
+        "detection",
+        "path",
+        "portable"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/lib/os-detect.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/lib/slm-common",
+      "intents": [
+        "common",
+        "helpers",
+        "shared",
+        "slice",
+        "subcommands"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/lib/slm-common.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/lightpanda-browser/SKILL",
+      "intents": [
+        "agpl",
+        "apache",
+        "browser",
+        "casos",
+        "cero"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/lightpanda-browser/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/llms-txt-generate",
+      "intents": [
+        "docs",
+        "full",
+        "generate",
+        "llms"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/llms-txt-generate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/loop-budget-check",
+      "intents": [
+        "budget",
+        "check",
+        "loop",
+        "scripts"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/loop-budget-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/loop-run-log",
+      "intents": [
+        "append",
+        "autónomas",
+        "gestión",
+        "loop",
+        "only"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/loop-run-log.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/loop-state-init",
+      "intents": [
+        "autónomo",
+        "canónico",
+        "inicializa",
+        "init",
+        "loop"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/loop-state-init.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/loop-state-prune",
+      "intents": [
+        "archiva",
+        "cerrados",
+        "loop",
+        "prune",
+        "recently"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/loop-state-prune.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/loop-verify",
+      "intents": [
+        "adversarial",
+        "agente",
+        "loop",
+        "prompt",
+        "verificador"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/loop-verify.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/managed-content/SKILL",
+      "intents": [
+        "auto",
+        "documentos",
+        "generadas",
+        "marcadores",
+        "regeneran"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/managed-content/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/managed-scan",
+      "intents": [
+        "content",
+        "managed",
+        "outdated",
+        "scan",
+        "sections"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/managed-scan.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/managed-sync",
+      "intents": [
+        "content",
+        "managed",
+        "markers",
+        "regenerate",
+        "synchronize"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/managed-sync.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/marketplace-publish",
+      "intents": [
+        "components",
+        "marketplace",
+        "publish",
+        "registry"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/marketplace-publish.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/mask-reversible",
+      "intents": [
+        "identifier",
+        "mask",
+        "masking",
+        "reversible"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/mask-reversible.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/masked-unmask",
+      "intents": [
+        "back",
+        "claude",
+        "entities",
+        "masked",
+        "real"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/masked-unmask.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/mcp-recommend",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/mcp-recommend.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/measure-reliability",
+      "intents": [
+        "across",
+        "capability",
+        "consistency",
+        "measure",
+        "reliability"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/measure-reliability.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/memvid-backup/SKILL",
+      "intents": [
+        "backup",
+        "crea",
+        "externa",
+        "memoria",
+        "portable"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/memvid-backup/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/meta-control",
+      "intents": [
+        "control",
+        "meta",
+        "metacognitivo",
+        "orquestador",
+        "sagi"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/meta-control.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/meta-monitor",
+      "intents": [
+        "juicio",
+        "meta",
+        "metacognitivo",
+        "monitor",
+        "monitoreo"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/meta-monitor.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/meta-recalibra-ledger",
+      "intents": [
+        "ledger",
+        "meta",
+        "real",
+        "recalibra",
+        "recalibración"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/meta-recalibra-ledger.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/meta-recalibrate",
+      "intents": [
+        "juicio",
+        "meta",
+        "metacognitivo",
+        "recalibración",
+        "recalibrate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/meta-recalibrate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/mind-virus/quarantine",
+      "intents": [
+        "defense",
+        "explicit",
+        "file",
+        "flag",
+        "malicious"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/mind-virus/quarantine.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/mobile-developer",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/mobile-developer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/model-capability-resolver",
+      "intents": [
+        "capabilities",
+        "capability",
+        "model",
+        "registry",
+        "resolve"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/model-capability-resolver.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/my-sprint",
+      "intents": [
+        "asignados",
+        "cycle",
+        "items",
+        "pendientes",
+        "personal"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/my-sprint.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/network-recon/SKILL",
+      "intents": [
+        "detection",
+        "http",
+        "httpx",
+        "nmap",
+        "port"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/network-recon/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/network-recon",
+      "intents": [
+        "network",
+        "recon",
+        "reconnaissance"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/network-recon.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/nidos",
+      "intents": [
+        "isolation",
+        "manage",
+        "named",
+        "nidos",
+        "parallel"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/nidos.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/nidos",
+      "intents": [
+        "isolation",
+        "named",
+        "nidos",
+        "parallel",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/nidos.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/nidos-lib",
+      "intents": [
+        "nidos",
+        "savia",
+        "shared",
+        "utilities"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/nidos-lib.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/nuclei-scanning/SKILL",
+      "intents": [
+        "conocidas",
+        "cves",
+        "escanean",
+        "misconfigs",
+        "nuclei"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/nuclei-scanning/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/objective-contract",
+      "intents": [
+        "antagonista",
+        "contract",
+        "delegado",
+        "objective",
+        "objetivo"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/objective-contract.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/obs-status",
+      "intents": [
+        "check",
+        "conectadas",
+        "fuentes",
+        "health",
+        "observabilidad"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/obs-status.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/obscura-browser/SKILL",
+      "intents": [
+        "chromium",
+        "contenido",
+        "extrae",
+        "fetch",
+        "headless"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/obscura-browser/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ollama-classify",
+      "intents": [
+        "clasificacion",
+        "classify",
+        "local",
+        "ollama",
+        "texto"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ollama-classify.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ollama-hardware-check",
+      "intents": [
+        "check",
+        "hardware",
+        "ollama"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ollama-hardware-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/onboard",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/onboard.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/onboard-enterprise",
+      "intents": [
+        "batch",
+        "checklists",
+        "enterprise",
+        "import",
+        "knowledge"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/onboard-enterprise.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/onboarding-dev",
+      "intents": [
+        "agent",
+        "auto",
+        "buddy",
+        "docs",
+        "generates"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/onboarding-dev.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/onboarding-dev/SKILL",
+      "intents": [
+        "buddy",
+        "desarrollador",
+        "incorpora",
+        "nuevo",
+        "proyecto"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/onboarding-dev/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/operational-point-selector",
+      "intents": [
+        "operational",
+        "point",
+        "selector",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/operational-point-selector.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/operator-grant",
+      "intents": [
+        "deterministic",
+        "grant",
+        "ledger",
+        "operator"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/operator-grant.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/opus47-calibration-scorecard",
+      "intents": [
+        "calibration",
+        "opus",
+        "scorecard",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/opus47-calibration-scorecard.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/orchestration-protocol",
+      "intents": [
+        "agent",
+        "inter",
+        "messaging",
+        "orchestration",
+        "protocol"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/orchestration-protocol.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/org-political-landscape/SKILL",
+      "intents": [
+        "alianzas",
+        "análisis",
+        "centros",
+        "detecta",
+        "interno"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/org-political-landscape/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/org-registrar",
+      "intents": [
+        "grafo",
+        "organizacional",
+        "registrar",
+        "wrapper"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/org-registrar.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/org-stakeholder-mapper/SKILL",
+      "intents": [
+        "alianzas",
+        "decisores",
+        "extrae",
+        "formales",
+        "mapeador"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/org-stakeholder-mapper/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/orgchart-import",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/orgchart-import.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/orgchart-import/SKILL",
+      "intents": [
+        "equipo",
+        "estructura",
+        "extraer",
+        "importa",
+        "organigrama"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/orgchart-import/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/otel-emit",
+      "intents": [
+        "emisor",
+        "emit",
+        "estándar",
+        "eventos",
+        "otel"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/otel-emit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/oumi-probe",
+      "intents": [
+        "integration",
+        "oumi",
+        "probe",
+        "slice",
+        "viability"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/oumi-probe.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/output-compress",
+      "intents": [
+        "compress",
+        "output",
+        "stdin",
+        "stdout",
+        "tool"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/output-compress.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/overnight-roadmap-runner",
+      "intents": [
+        "loop",
+        "overnight",
+        "roadmap",
+        "runner",
+        "sprint"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/overnight-roadmap-runner.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/overnight-sprint/SKILL",
+      "intents": [
+        "autónoma",
+        "bajo",
+        "durante",
+        "ejecutar",
+        "forma"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/overnight-sprint/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/overnight-sprint-loop",
+      "intents": [
+        "loop",
+        "orchestrator",
+        "overnight",
+        "scripts",
+        "sprint"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/overnight-sprint-loop.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/overnight-sprint-state",
+      "intents": [
+        "loop",
+        "management",
+        "overnight",
+        "scripts",
+        "session"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/overnight-sprint-state.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/parallel-dispatch/SKILL",
+      "intents": [
+        "admission",
+        "background",
+        "bloquear",
+        "después",
+        "esto"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/parallel-dispatch/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/parallel-dispatch",
+      "intents": [
+        "admission",
+        "despacho",
+        "dispatch",
+        "handle",
+        "lección"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/parallel-dispatch.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/path-redact",
+      "intents": [
+        "absolute",
+        "containing",
+        "home",
+        "path",
+        "paths"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/path-redact.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pbi-decompose",
+      "intents": [
+        "decompose",
+        "granular",
+        "tasks",
+        "technical"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pbi-decompose.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/pbi-decomposition/SKILL",
+      "intents": [
+        "descompone",
+        "estiman",
+        "horas",
+        "tasks"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/pbi-decomposition/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pbi-jtbd",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pbi-jtbd.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pbi-prd",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pbi-prd.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/personal-vault/SKILL",
+      "intents": [
+        "escribe",
+        "memoria",
+        "perfil",
+        "personal",
+        "preferencias"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/personal-vault/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/php-developer",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/php-developer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/plan-diff-check",
+      "intents": [
+        "check",
+        "diff",
+        "plan",
+        "respeta",
+        "verifica"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/plan-diff-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/plugin-export",
+      "intents": [
+        "distributable",
+        "empaquetar",
+        "estructura",
+        "plugin",
+        "validación"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/plugin-export.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/plugin-validate",
+      "intents": [
+        "agents",
+        "commands",
+        "estructura",
+        "integridad",
+        "plugin"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/plugin-validate.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pm-backend-health",
+      "intents": [
+        "backend",
+        "configuration",
+        "detect",
+        "health"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pm-backend-health.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/poc-verify",
+      "intents": [
+        "binario",
+        "cybergym",
+        "lección",
+        "pocs",
+        "verificador"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/poc-verify.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pre-commit-sovereignty",
+      "intents": [
+        "grep",
+        "intentionally",
+        "match",
+        "note",
+        "omitted"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pre-commit-sovereignty.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pre-output-validator",
+      "intents": [
+        "inspired",
+        "output",
+        "rule",
+        "ttsr",
+        "validator"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pre-output-validator.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pre-tribunal-gates",
+      "intents": [
+        "deterministic",
+        "gates",
+        "tribunal"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pre-tribunal-gates.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/prime-agent-eval-gate",
+      "intents": [
+        "agent",
+        "arranque",
+        "crit",
+        "eval",
+        "gate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/prime-agent-eval-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/privacy-check-company",
+      "intents": [
+        "check",
+        "company",
+        "content",
+        "filter",
+        "privacy"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/privacy-check-company.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/probe-devops",
+      "intents": [
+        "acceso",
+        "azure",
+        "devops",
+        "diagnóstico",
+        "probe"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/probe-devops.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/product-discovery/SKILL",
+      "intents": [
+        "análisis",
+        "descomponer",
+        "jtbd",
+        "pbis",
+        "producto"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/product-discovery/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/professional-domain/SKILL",
+      "intents": [
+        "controlling",
+        "domain",
+        "family",
+        "finance",
+        "index"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/professional-domain/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/profile-discover",
+      "intents": [
+        "abtop",
+        "auto",
+        "discover",
+        "discovery",
+        "multi"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/profile-discover.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/profile-setup",
+      "intents": [
+        "configuración",
+        "conoce",
+        "conversación",
+        "natural",
+        "perfil"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/profile-setup.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/profile-show",
+      "intents": [
+        "actual",
+        "muestra",
+        "perfil",
+        "savia"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/profile-show.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/profile-switch",
+      "intents": [
+        "activo",
+        "cambia",
+        "cambiar",
+        "perfil",
+        "savia"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/profile-switch.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/project-activate",
+      "intents": [
+        "activa",
+        "active",
+        "activo",
+        "actualiza",
+        "contexto"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/project-activate.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/project-assign",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/project-assign.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/project-audit",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/project-audit.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/project-context",
+      "intents": [
+        "context",
+        "isolation",
+        "project",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/project-context.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/project-isolation-check",
+      "intents": [
+        "aislamiento",
+        "check",
+        "contexto",
+        "isolation",
+        "leak"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/project-isolation-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/project-new",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/project-new.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/project-release-plan",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/project-release-plan.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/project-roadmap",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/project-roadmap.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/project-switch",
+      "intents": [
+        "activo",
+        "aislamiento",
+        "cambia",
+        "contexto",
+        "proyecto"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/project-switch.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/project-update/SKILL",
+      "intents": [
+        "activo",
+        "actualización",
+        "fuentes",
+        "integral",
+        "proyecto"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/project-update/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/project-update-devops",
+      "intents": [
+        "config",
+        "devops",
+        "project",
+        "real",
+        "resuelve"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/project-update-devops.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/prompt-optimizer/SKILL",
+      "intents": [
+        "agente",
+        "efectividad",
+        "mejorar",
+        "optimiza",
+        "prompt"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/prompt-optimizer/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/propuestas-index-gen",
+      "intents": [
+        "auto",
+        "docs",
+        "generate",
+        "index",
+        "propuestas"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/propuestas-index-gen.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/protect-project-privacy",
+      "intents": [
+        "accidental",
+        "barrera",
+        "contra",
+        "privacy",
+        "project"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/protect-project-privacy.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pursuit-bid",
+      "intents": [
+        "decision",
+        "pursuit",
+        "qualified",
+        "record"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pursuit-bid.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pursuit-close",
+      "intents": [
+        "analysis",
+        "close",
+        "lost",
+        "mortem",
+        "post"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pursuit-close.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pursuit-draft",
+      "intents": [
+        "assets",
+        "generate",
+        "library",
+        "proposal",
+        "pursuit"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pursuit-draft.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pursuit-handoff",
+      "intents": [
+        "delivery",
+        "generate",
+        "handoff",
+        "package",
+        "pursuit"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pursuit-handoff.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pursuit-init",
+      "intents": [
+        "directory",
+        "files",
+        "opportunity",
+        "pursuit",
+        "scaffold"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pursuit-init.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pursuit-qualify",
+      "intents": [
+        "bant",
+        "meddic",
+        "pursuit",
+        "qualification",
+        "scoring"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pursuit-qualify.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pursuit-validate",
+      "intents": [
+        "directories",
+        "pursuit",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pursuit-validate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/push-pr",
+      "intents": [
+        "commits",
+        "create",
+        "push",
+        "release",
+        "sign"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/push-pr.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/python-developer",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/python-developer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/query-lib-index",
+      "intents": [
+        "index",
+        "query"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/query-lib-index.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/query-lib-nl",
+      "intents": [
+        "query",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/query-lib-nl.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/query-lib-resolve",
+      "intents": [
+        "query",
+        "resolve"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/query-lib-resolve.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/rbac-manager",
+      "intents": [
+        "backend",
+        "enterprise",
+        "manager",
+        "multi",
+        "rbac"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/rbac-manager.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/rca-eval-runner",
+      "intents": [
+        "eval",
+        "puntúa",
+        "runner",
+        "sintética",
+        "suite"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/rca-eval-runner.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/readiness-check",
+      "intents": [
+        "capability",
+        "check",
+        "checklist",
+        "deterministic",
+        "readiness"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/readiness-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/recommendation-tribunal-orchestrator",
+      "intents": [
+        "aggregates",
+        "applies",
+        "banner",
+        "fast",
+        "judges"
+      ],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/recommendation-tribunal-orchestrator.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/recover-savia",
+      "intents": [
+        "claude",
+        "clean",
+        "launch",
+        "outside",
+        "recover"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/recover-savia.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/reflection-validation/SKILL",
+      "intents": [
+        "decisión",
+        "importante",
+        "metacognitiva",
+        "respuesta",
+        "system"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/reflection-validation/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/reflection-validator",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/reflection-validator.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/refresh-agent-maps",
+      "intents": [
+        "agent",
+        "maps",
+        "refresh"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/refresh-agent-maps.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/relacion-capture",
+      "intents": [
+        "capture",
+        "relacion",
+        "scripts",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/relacion-capture.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/relacion-detect-conflicts",
+      "intents": [
+        "conflicts",
+        "detect",
+        "relacion",
+        "scripts",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/relacion-detect-conflicts.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/release-backfill",
+      "intents": [
+        "backfill",
+        "create",
+        "github",
+        "missing",
+        "release"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/release-backfill.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/release-invariants",
+      "intents": [
+        "básicas",
+        "hace",
+        "imposibles",
+        "inconsistencias",
+        "invariants"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/release-invariants.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/repos-list",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/repos-list.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/reranker/SKILL",
+      "intents": [
+        "búsqueda",
+        "memoria",
+        "recibe",
+        "relevancia",
+        "reordenar"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/reranker/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/reranker-probe",
+      "intents": [
+        "probe",
+        "reranker",
+        "slice",
+        "viability"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/reranker-probe.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/resolve-all-open-prs",
+      "intents": [
+        "conflicts",
+        "helper",
+        "open",
+        "resolve",
+        "runs"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/resolve-all-open-prs.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/resolve-pr-conflicts",
+      "intents": [
+        "auto",
+        "conflicts",
+        "recurring",
+        "resolve",
+        "resolver"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/resolve-pr-conflicts.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/resolver-md-generate",
+      "intents": [
+        "generate",
+        "resolver"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/resolver-md-generate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/resource-references/SKILL",
+      "intents": [
+        "necesitan",
+        "plantillas",
+        "recursos",
+        "referencias",
+        "workspace"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/resource-references/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/restore-checkpoint",
+      "intents": [
+        "checkpoint",
+        "high",
+        "operations",
+        "radius",
+        "restore"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/restore-checkpoint.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/restore-drill",
+      "intents": [
+        "drill",
+        "restore",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/restore-drill.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/robotica-diseno/SKILL",
+      "intents": [
+        "agente",
+        "artificial",
+        "automatización",
+        "celda",
+        "conecta"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/robotica-diseno/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/rpi-start",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/rpi-start.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/ruby-developer",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/ruby-developer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/rule-manifest-generate",
+      "intents": [
+        "determinista",
+        "generador",
+        "generate",
+        "manifest",
+        "rule"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/rule-manifest-generate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/rule-manifest-integrity",
+      "intents": [
+        "index",
+        "integrity",
+        "manifest",
+        "rule",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/rule-manifest-integrity.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/rule-usage-analyzer",
+      "intents": [
+        "across",
+        "analyze",
+        "analyzer",
+        "domain",
+        "rule"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/rule-usage-analyzer.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/rule-violation-judge",
+      "intents": [
+        "autonomous",
+        "canonical",
+        "claude",
+        "detects",
+        "domain"
+      ],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/rule-violation-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/rules-index-generate",
+      "intents": [
+        "generate",
+        "index",
+        "rules"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/rules-index-generate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/run-adversarial-evals",
+      "intents": [
+        "adversarial",
+        "evals",
+        "scripts",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/run-adversarial-evals.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/run-agent-evals",
+      "intents": [
+        "agent",
+        "agents",
+        "critical",
+        "evals",
+        "evaluation"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/run-agent-evals.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/rust-developer",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/rust-developer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sagi-e2e",
+      "intents": [
+        "flujo",
+        "multi",
+        "objetivo",
+        "paso",
+        "sagi"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sagi-e2e.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sagi-pruebas",
+      "intents": [
+        "harness",
+        "orquestador",
+        "pruebas",
+        "sagi"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sagi-pruebas.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/scale-optimizer",
+      "intents": [
+        "analyze",
+        "benchmark",
+        "growing",
+        "improvements",
+        "optimization"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/scale-optimizer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/scaling-operations/SKILL",
+      "intents": [
+        "analiza",
+        "capacidad",
+        "escala",
+        "necesitan",
+        "optimizaciones"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/scaling-operations/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/scheduled-messaging/SKILL",
+      "intents": [
+        "automáticos",
+        "comunicación",
+        "configuran",
+        "mensajes",
+        "plataformas"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/scheduled-messaging/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/school-analytics",
+      "intents": [
+        "analytics",
+        "class",
+        "dashboard",
+        "progress",
+        "teacher"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/school-analytics.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/school-diary",
+      "intents": [
+        "diary",
+        "journal",
+        "learning",
+        "reflection",
+        "student"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/school-diary.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/school-enroll",
+      "intents": [
+        "alias",
+        "enroll",
+        "first",
+        "names",
+        "privacy"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/school-enroll.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/school-evaluate",
+      "intents": [
+        "encrypted",
+        "evaluates",
+        "project",
+        "rubric",
+        "student"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/school-evaluate.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/school-export",
+      "intents": [
+        "article",
+        "data",
+        "export",
+        "format",
+        "gdpr"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/school-export.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/school-forget",
+      "intents": [
+        "article",
+        "complete",
+        "data",
+        "deletion",
+        "erasure"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/school-forget.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/school-portfolio",
+      "intents": [
+        "journey",
+        "learning",
+        "portfolio",
+        "showcase",
+        "student"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/school-portfolio.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/school-progress",
+      "intents": [
+        "portfolio",
+        "progress",
+        "student",
+        "view"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/school-progress.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/school-project",
+      "intents": [
+        "creates",
+        "project",
+        "student",
+        "template"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/school-project.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/school-rubric",
+      "intents": [
+        "create",
+        "edit",
+        "evaluation",
+        "grading",
+        "rubrics"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/school-rubric.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/school-setup",
+      "intents": [
+        "classroom",
+        "configure",
+        "initialize",
+        "savia",
+        "school"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/school-setup.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/school-submit",
+      "intents": [
+        "completed",
+        "evaluation",
+        "project",
+        "student",
+        "submits"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/school-submit.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/score-diff",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/score-diff.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/scrapling-fetch",
+      "intents": [
+        "adaptive",
+        "fetch",
+        "scrapling",
+        "slice",
+        "wrapper"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/scrapling-fetch.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/scrapling-probe",
+      "intents": [
+        "probe",
+        "scrapling",
+        "slice",
+        "viability"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/scrapling-probe.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/setup-merge-drivers",
+      "intents": [
+        "configure",
+        "custom",
+        "drivers",
+        "local",
+        "merge"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/setup-merge-drivers.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/setup-savia-dual",
+      "intents": [
+        "dual",
+        "installer",
+        "linux",
+        "macos",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/setup-savia-dual.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/setup-savia-remote",
+      "intents": [
+        "once",
+        "remote",
+        "root",
+        "savia",
+        "server"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/setup-savia-remote.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/shield-ner-hook",
+      "intents": [
+        "capa",
+        "daemon",
+        "fast",
+        "hook",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/shield-ner-hook.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skill-creator",
+      "intents": [
+        "creator",
+        "interactive",
+        "scaffolding",
+        "skill",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skill-creator.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/skill-detect",
+      "intents": [
+        "automatically",
+        "detect",
+        "patterns",
+        "propose",
+        "repeated"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/skill-detect.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skill-detect",
+      "intents": [
+        "detect",
+        "improvement",
+        "pipeline",
+        "self",
+        "skill"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skill-detect.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/skill-eval",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/skill-eval.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/skill-evaluation/SKILL",
+      "intents": [
+        "apropiado",
+        "dada",
+        "seleccionar",
+        "skill",
+        "tarea"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/skill-evaluation/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skill-feedback-log",
+      "intents": [
+        "append",
+        "feedback",
+        "invocation",
+        "jsonl",
+        "skill"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skill-feedback-log.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skill-feedback-rank",
+      "intents": [
+        "compute",
+        "effectiveness",
+        "feedback",
+        "generate",
+        "rank"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skill-feedback-rank.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skill-keyword-detector",
+      "intents": [
+        "auto",
+        "based",
+        "detect",
+        "detector",
+        "keyword"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skill-keyword-detector.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skill-layer-check",
+      "intents": [
+        "capas",
+        "check",
+        "core",
+        "layer",
+        "peripheral"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skill-layer-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/skill-propose",
+      "intents": [
+        "auto",
+        "nuevo",
+        "observaciones",
+        "proponer",
+        "repetitivo"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/skill-propose.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skill-quality-eval",
+      "intents": [
+        "eval",
+        "evaluation",
+        "judge",
+        "quality",
+        "semantic"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skill-quality-eval.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skill-quality-eval-all",
+      "intents": [
+        "batch",
+        "eval",
+        "evaluation",
+        "quality",
+        "skill"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skill-quality-eval-all.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/skill-rank",
+      "intents": [
+        "based",
+        "data",
+        "effectiveness",
+        "invocation",
+        "ranking"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/skill-rank.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/skill-read",
+      "intents": [
+        "bajo",
+        "carga",
+        "completo",
+        "contenido",
+        "demanda"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/skill-read.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skill-routing-index",
+      "intents": [
+        "index",
+        "routing",
+        "skill"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skill-routing-index.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skill-suggest",
+      "intents": [
+        "hook",
+        "proactive",
+        "skill",
+        "suggest",
+        "suggestion"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skill-suggest.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skills-collision-detect",
+      "intents": [
+        "collision",
+        "description",
+        "detect",
+        "detection",
+        "skill"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skills-collision-detect.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skills-lock",
+      "intents": [
+        "integrity",
+        "lock",
+        "skills",
+        "verification"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skills-lock.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skills-md-generate",
+      "intents": [
+        "across",
+        "deterministic",
+        "force",
+        "handling",
+        "locale"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skills-md-generate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skills-schema-generate",
+      "intents": [
+        "generate",
+        "schema",
+        "skills"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skills-schema-generate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skillssh-adapter",
+      "intents": [
+        "adapter",
+        "paquetes",
+        "publicables",
+        "skills"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skillssh-adapter.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm",
+      "intents": [
+        "dispatcher",
+        "language",
+        "model",
+        "small",
+        "toolchain"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm-data-collect",
+      "intents": [
+        "artifacts",
+        "collect",
+        "data",
+        "training",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm-data-collect.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm-data-prep",
+      "intents": [
+        "data",
+        "fine",
+        "prep",
+        "prepare",
+        "project"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm-data-prep.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm-dataset-prep",
+      "intents": [
+        "dataset",
+        "phase",
+        "pipeline",
+        "prep",
+        "scaffolding"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm-dataset-prep.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm-dataset-validate",
+      "intents": [
+        "before",
+        "dataset",
+        "jsonl",
+        "training",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm-dataset-validate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm-eval-compare",
+      "intents": [
+        "between",
+        "compare",
+        "eval",
+        "results",
+        "versions"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm-eval-compare.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm-eval-harness-setup",
+      "intents": [
+        "config",
+        "emission",
+        "eval",
+        "harness",
+        "phase"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm-eval-harness-setup.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm-export-gguf",
+      "intents": [
+        "adapter",
+        "conversion",
+        "export",
+        "generate",
+        "gguf"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm-export-gguf.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm-modelfile-gen",
+      "intents": [
+        "generate",
+        "modelfile",
+        "ollama",
+        "trained"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm-modelfile-gen.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm-pipeline-validate",
+      "intents": [
+        "directory",
+        "meta",
+        "pipeline",
+        "project",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm-pipeline-validate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm-project-init",
+      "intents": [
+        "bootstrap",
+        "canonical",
+        "init",
+        "layout",
+        "project"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm-project-init.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm-synth",
+      "intents": [
+        "slice",
+        "synth"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm-synth.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm-synth-recipe",
+      "intents": [
+        "emit",
+        "oumi",
+        "recipe",
+        "scaffolding",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm-synth-recipe.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm-train",
+      "intents": [
+        "export",
+        "fine",
+        "locally",
+        "ollama",
+        "slms"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm-train.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/slm-train-config",
+      "intents": [
+        "config",
+        "emit",
+        "phase",
+        "scaffolding",
+        "train"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/slm-train-config.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/smart-calendar/SKILL",
+      "intents": [
+        "agenda",
+        "gestiona",
+        "inteligente",
+        "outlook",
+        "sincronización"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/smart-calendar/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/source-corroborator",
+      "intents": [
+        "corroboración",
+        "corroborator",
+        "externas",
+        "fuentes",
+        "source"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/source-corroborator.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sovereignty-benchmark",
+      "intents": [
+        "benchmark",
+        "local",
+        "prompts",
+        "sovereignty",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sovereignty-benchmark.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sovereignty-classify",
+      "intents": [
+        "clasificador",
+        "classify",
+        "datos",
+        "determinista",
+        "soberanía"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sovereignty-classify.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sovereignty-decide",
+      "intents": [
+        "decide",
+        "decisión",
+        "política",
+        "sovereignty",
+        "umbral"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sovereignty-decide.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sovereignty-mask",
+      "intents": [
+        "data",
+        "mask",
+        "masking",
+        "reversible",
+        "sovereignty"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sovereignty-mask.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sovereignty-ops",
+      "intents": [
+        "download",
+        "operations",
+        "pack",
+        "sovereignty"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sovereignty-ops.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sovereignty-switch",
+      "intents": [
+        "between",
+        "providers",
+        "sovereignty",
+        "switch",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sovereignty-switch.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/sprint-autoplan",
+      "intents": [
+        "backlog",
+        "capacidad",
+        "composición",
+        "inteligente",
+        "planificación"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/sprint-autoplan.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/sprint-forecast",
+      "intents": [
+        "basada",
+        "completitud",
+        "histórica",
+        "predicción",
+        "sprint"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/sprint-forecast.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/sprint-management/SKILL",
+      "intents": [
+        "actualizan",
+        "consulta",
+        "estado",
+        "items",
+        "resumen"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/sprint-management/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/sprint-plan",
+      "intents": [
+        "asiste",
+        "calculando",
+        "capacity",
+        "carga",
+        "disponible"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/sprint-plan.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/sprint-release-notes",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/sprint-release-notes.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/sprint-retro",
+      "intents": [
+        "ceremonia",
+        "datos",
+        "facilitar",
+        "plantilla",
+        "retrospectiva"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/sprint-retro.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/sprint-review",
+      "intents": [
+        "cerrado",
+        "datos",
+        "resumen",
+        "review",
+        "sprint"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/sprint-review.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/sprint-status",
+      "intents": [
+        "actual",
+        "alertas",
+        "burndown",
+        "estado",
+        "progreso"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/sprint-status.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/start-bridge",
+      "intents": [
+        "bridge",
+        "claw",
+        "host",
+        "invoked",
+        "remote"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/start-bridge.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/structural-framing-judge",
+      "intents": [
+        "cbrn",
+        "detects",
+        "domain",
+        "form",
+        "judge"
+      ],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/structural-framing-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/subagent-dispatch-gate",
+      "intents": [
+        "dispatch",
+        "gate",
+        "resolución",
+        "subagent",
+        "telemetría"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/subagent-dispatch-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/surface-map-authorize",
+      "intents": [
+        "authorization",
+        "authorize",
+        "helper",
+        "surface"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/surface-map-authorize.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/surrogate/router-check",
+      "intents": [
+        "check",
+        "only",
+        "python",
+        "read",
+        "router"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/surrogate/router-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sync-adapters/adapter-interface",
+      "intents": [
+        "adapter",
+        "adapters",
+        "backlog",
+        "common",
+        "interface"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sync-adapters/adapter-interface.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sync-adapters/azure-devops-adapter",
+      "intents": [
+        "adapter",
+        "azure",
+        "backlog",
+        "devops",
+        "local"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sync-adapters/azure-devops-adapter.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sync-adapters/github-issues-adapter",
+      "intents": [
+        "adapter",
+        "backlog",
+        "github",
+        "issues",
+        "local"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sync-adapters/github-issues-adapter.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sync-adapters/jira-adapter",
+      "intents": [
+        "adapter",
+        "backlog",
+        "cloud",
+        "jira",
+        "local"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sync-adapters/jira-adapter.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/sync-calendars",
+      "intents": [
+        "calendarios",
+        "disponibilidad",
+        "microsoft",
+        "sincronizar",
+        "tenants"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/sync-calendars.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sync-github-metadata",
+      "intents": [
+        "github",
+        "metadata",
+        "repo",
+        "sync",
+        "update"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sync-github-metadata.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sync-model-tiers",
+      "intents": [
+        "abstract",
+        "fast",
+        "heavy",
+        "model",
+        "provider"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sync-model-tiers.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sync-tags-from-changelog",
+      "intents": [
+        "changelog",
+        "create",
+        "missing",
+        "sync",
+        "tags"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sync-tags-from-changelog.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/tabular-analyst",
+      "intents": [
+        "analisis",
+        "arrays",
+        "datos",
+        "estadistico",
+        "excel"
+      ],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/tabular-analyst.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/tabular-intelligence/SKILL",
+      "intents": [
+        "analiza",
+        "analizan",
+        "correlacion",
+        "datos",
+        "distribucion"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/tabular-intelligence/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/tabular-mcp-tool",
+      "intents": [
+        "data",
+        "language",
+        "natural",
+        "query",
+        "tabular"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/tabular-mcp-tool.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/tabular-summarize",
+      "intents": [
+        "data",
+        "detect",
+        "extract",
+        "summarize",
+        "tabular"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/tabular-summarize.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/task-create",
+      "intents": [
+        "create",
+        "investigate",
+        "list",
+        "savia",
+        "site"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/task-create.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/task-decomposer",
+      "intents": [
+        "atomic",
+        "classify",
+        "composite",
+        "decompose",
+        "decomposer"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/task-decomposer.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/team-coordination/SKILL",
+      "intents": [
+        "asignan",
+        "bloqueantes",
+        "coordinan",
+        "cross",
+        "detectan"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/team-coordination/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/team-evaluate",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/team-evaluate.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/team-onboarding",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/team-onboarding.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/team-onboarding/SKILL",
+      "intents": [
+        "competencias",
+        "equipo",
+        "evalúan",
+        "incorpora",
+        "miembro"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/team-onboarding/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/team-orchestrator",
+      "intents": [
+        "assign",
+        "blockers",
+        "coordination",
+        "create",
+        "cross"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/team-orchestrator.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/team-privacy-notice",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/team-privacy-notice.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/team-workload",
+      "intents": [
+        "asignados",
+        "balance",
+        "carga",
+        "equipo",
+        "horas"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/team-workload.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/tech-radar",
+      "intents": [
+        "adopt",
+        "hold",
+        "librerías",
+        "proyecto",
+        "radar"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/tech-radar.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/tech-writer",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/tech-writer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/telemetry-alert",
+      "intents": [
+        "alert",
+        "cruza",
+        "emite",
+        "issue",
+        "telemetry"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/telemetry-alert.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/telemetry-issues",
+      "intents": [
+        "agrupa",
+        "eventos",
+        "fingerprint",
+        "issues",
+        "telemetry"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/telemetry-issues.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/telemetry-tail-sample",
+      "intents": [
+        "retención",
+        "rotación",
+        "sample",
+        "sampling",
+        "tail"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/telemetry-tail-sample.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/terminal-state-emit",
+      "intents": [
+        "agent",
+        "emit",
+        "emits",
+        "loop",
+        "reason"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/terminal-state-emit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/terminal-state-read",
+      "intents": [
+        "agent",
+        "last",
+        "loop",
+        "read",
+        "reads"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/terminal-state-read.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ternary-verdict",
+      "intents": [
+        "contract",
+        "data",
+        "ternary",
+        "unified",
+        "verdict"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ternary-verdict.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/terraform-developer",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/terraform-developer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/tier3-probes/SKILL",
+      "intents": [
+        "adoptarlas",
+        "herramientas",
+        "tier",
+        "valida",
+        "viabilidad"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/tier3-probes/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/timeline-query",
+      "intents": [
+        "field",
+        "historical",
+        "query",
+        "temporal",
+        "timeline"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/timeline-query.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/token-estimator",
+      "intents": [
+        "before",
+        "cost",
+        "estimate",
+        "estimator",
+        "execution"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/token-estimator.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/token-meter",
+      "intents": [
+        "baseline",
+        "determinista",
+        "heurísticos",
+        "inmutable",
+        "medición"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/token-meter.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/tool-catalog",
+      "intents": [
+        "categorizado",
+        "catálogo",
+        "comandos",
+        "herramientas"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/tool-catalog.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/tool-result-trim",
+      "intents": [
+        "deterministic",
+        "hard",
+        "output",
+        "result",
+        "tool"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/tool-result-trim.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/topic-cluster/SKILL",
+      "intents": [
+        "agrupan",
+        "detectar",
+        "incidentes",
+        "patrones",
+        "pbis"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/topic-cluster/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/tracked-vs-nivel",
+      "intents": [
+        "nivel",
+        "slice",
+        "tracked"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/tracked-vs-nivel.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/trajectory-detector",
+      "intents": [
+        "desviación",
+        "detección",
+        "detector",
+        "minutos",
+        "trajectory"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/trajectory-detector.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/transcriptor",
+      "intents": [
+        "capturadas",
+        "capturas",
+        "digeridas",
+        "digerir",
+        "escanear"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/transcriptor.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/transcriptor-scan",
+      "intents": [
+        "digerir",
+        "listar",
+        "reuniones",
+        "savia",
+        "scan"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/transcriptor-scan.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/tribunal-critic",
+      "intents": [
+        "critic",
+        "quantitative",
+        "scoring",
+        "tribunal",
+        "verdicts"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/tribunal-critic.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/tribunal-status",
+      "intents": [
+        "depth",
+        "evaluations",
+        "pending",
+        "queue",
+        "recent"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/tribunal-status.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/tribunal-tiered-runner",
+      "intents": [
+        "execution",
+        "runner",
+        "tiered",
+        "tribunal"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/tribunal-tiered-runner.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/truth-tribunal-orchestrator",
+      "intents": [
+        "aggregates",
+        "applies",
+        "convenes",
+        "drives",
+        "iteration"
+      ],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/truth-tribunal-orchestrator.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/truth-tribunal-worker",
+      "intents": [
+        "consume",
+        "queued",
+        "tribunal",
+        "truth",
+        "verification"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/truth-tribunal-worker.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/twin-decay-check",
+      "intents": [
+        "check",
+        "days",
+        "decay",
+        "escanea",
+        "marca"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/twin-decay-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/typescript-developer",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/typescript-developer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ua-bridge",
+      "intents": [
+        "anything",
+        "between",
+        "bridge",
+        "savia",
+        "understand"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ua-bridge.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/ua-dashboard",
+      "intents": [
+        "browser",
+        "dashboard",
+        "graph",
+        "interactive",
+        "knowledge"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/ua-dashboard.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/ua-install",
+      "intents": [
+        "anything",
+        "graph",
+        "install",
+        "knowledge",
+        "plugin"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/ua-install.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ua-install",
+      "intents": [
+        "anything",
+        "install",
+        "plugin",
+        "savia",
+        "understand"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ua-install.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/unlimited-auth-detector",
+      "intents": [
+        "auth",
+        "delegación",
+        "detecta",
+        "detector",
+        "límite"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/unlimited-auth-detector.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/update",
+      "intents": [
+        "actualizaciones",
+        "aplicar",
+        "comprobar",
+        "datos",
+        "github"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/update.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/update",
+      "intents": [
+        "actualización",
+        "sistema",
+        "update",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/update.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/user-profile",
+      "intents": [
+        "crear",
+        "editar",
+        "equipo",
+        "gestiona",
+        "miembros"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/user-profile.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/validate-agent-permissions",
+      "intents": [
+        "agent",
+        "level",
+        "matches",
+        "permission",
+        "permissions"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/validate-agent-permissions.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/validate-changelog-links",
+      "intents": [
+        "changelog",
+        "enlace",
+        "links",
+        "validate",
+        "verifica"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/validate-changelog-links.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/validate-ci-local",
+      "intents": [
+        "local",
+        "parallel",
+        "validate",
+        "validation"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/validate-ci-local.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/validate-commands",
+      "intents": [],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/validate-commands.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/validate-critical-facts-cap",
+      "intents": [
+        "critical",
+        "facts",
+        "scripts",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/validate-critical-facts-cap.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/validate-devops",
+      "intents": [],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/validate-devops.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/validate-devops-checks",
+      "intents": [
+        "bash",
+        "shell",
+        "shellcheck"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/validate-devops-checks.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/validate-filesize",
+      "intents": [
+        "cumplen",
+        "ficheros",
+        "líneas",
+        "validar",
+        "workspace"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/validate-filesize.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/validate-handoff",
+      "intents": [
+        "handoff",
+        "reason",
+        "structure",
+        "termination",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/validate-handoff.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/validate-layer-contract",
+      "intents": [
+        "contract",
+        "layer",
+        "validate",
+        "validator"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/validate-layer-contract.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/validate-schema",
+      "intents": [
+        "frontmatter",
+        "json",
+        "schema",
+        "settings",
+        "validar"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/validate-schema.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/validate-settings-local",
+      "intents": [
+        "data",
+        "detect",
+        "json",
+        "local",
+        "private"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/validate-settings-local.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/vault",
+      "intents": [
+        "dispatcher",
+        "personal",
+        "vault"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/vault.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/vault-graph",
+      "intents": [
+        "adyacencia",
+        "extract",
+        "graph",
+        "inline",
+        "knowledge"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/vault-graph.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/vault-links",
+      "intents": [
+        "adyacencia",
+        "inline",
+        "links",
+        "relaciones",
+        "saviavaults"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/vault-links.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/vault-ops",
+      "intents": [
+        "library",
+        "operations",
+        "personal",
+        "sourced",
+        "vault"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/vault-ops.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/vaults-backup-cron",
+      "intents": [
+        "automático",
+        "backup",
+        "crit",
+        "cron",
+        "cúpulas"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/vaults-backup-cron.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/vaults-export",
+      "intents": [
+        "confidentiality",
+        "export",
+        "filtering",
+        "signing",
+        "vault"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/vaults-export.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/vaults-graph-query",
+      "intents": [
+        "graph",
+        "knowledge",
+        "queries",
+        "query",
+        "saviavaults"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/vaults-graph-query.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/vaults-nextcloud-setup",
+      "intents": [
+        "backups",
+        "configurar",
+        "credenciales",
+        "nextcloud",
+        "setup"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/vaults-nextcloud-setup.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/vaults-validate",
+      "intents": [
+        "against",
+        "documents",
+        "entity",
+        "schemas",
+        "validate"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/vaults-validate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/velocity-trend",
+      "intents": [
+        "anomalías",
+        "detección",
+        "explicativos",
+        "factores",
+        "media"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/velocity-trend.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/verdict-path",
+      "intents": [
+        "attach",
+        "expand",
+        "path",
+        "verdict",
+        "wrapper"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/verdict-path.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/verify-ledger-chain",
+      "intents": [
+        "chain",
+        "ledger",
+        "slice",
+        "verify"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/verify-ledger-chain.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/verify-principal",
+      "intents": [
+        "principal",
+        "scripts",
+        "slice",
+        "verify"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/verify-principal.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/vuln-scan",
+      "intents": [
+        "scan",
+        "scanner",
+        "scripts",
+        "vuln",
+        "vulnerability"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/vuln-scan.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/wave-executor",
+      "intents": [
+        "engine",
+        "execution",
+        "executor",
+        "generic",
+        "graphs"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/wave-executor.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/wave-executor-lib",
+      "intents": [
+        "executor",
+        "functions",
+        "helper",
+        "wave"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/wave-executor-lib.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/wellbeing-guardian",
+      "intents": [
+        "alerts",
+        "balance",
+        "break",
+        "hours",
+        "individual"
+      ],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/wellbeing-guardian.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/wellbeing-guardian/SKILL",
+      "intents": [
+        "bienestar",
+        "equipo",
+        "individual",
+        "monitorizan",
+        "señales"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/wellbeing-guardian/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/workspace-doctor",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/workspace-doctor.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/workspace-health",
+      "intents": [
+        "comprehensive",
+        "dashboard",
+        "health",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/workspace-health.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/write-a-skill/SKILL",
+      "intents": [
+        "correctamente",
+        "crear",
+        "guia",
+        "nueva",
+        "repite"
+      ],
+      "kind": "skill",
+      "owner_domain": "planning",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/write-a-skill/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/speckit.analyze",
+      "intents": [
+        "alias",
+        "compatible",
+        "consensus",
+        "cruzado",
+        "github"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/speckit.analyze.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/coherence-court",
+      "intents": [
+        "against",
+        "audit",
+        "consistency",
+        "earlier",
+        "fixed"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/coherence-court.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/court-review",
+      "intents": [
+        "across",
+        "code",
+        "convene",
+        "court",
+        "evaluate"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/court-review.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/failure-patterns",
+      "intents": [
+        "agent",
+        "analysis",
+        "before",
+        "checking",
+        "error"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/failure-patterns.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/adversarial-containment",
+      "intents": [
+        "adversarial",
+        "containment",
+        "suite",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/adversarial-containment.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/adversarial-security/SKILL",
+      "intents": [
+        "auditar",
+        "blue",
+        "pipeline",
+        "proyecto",
+        "seguridad"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/adversarial-security/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/ai-exposure-audit",
+      "intents": [
+        "auditoría",
+        "desplazamiento",
+        "exposición",
+        "exposure",
+        "observed"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/ai-exposure-audit.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/android-autonomous-debugger/SKILL",
+      "intents": [
+        "android",
+        "apps",
+        "contra",
+        "depuran",
+        "dispositivos"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/android-autonomous-debugger/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/android-manifest-audit",
+      "intents": [
+        "android",
+        "audit",
+        "manifest"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/android-manifest-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/architectural-vocabulary-audit",
+      "intents": [
+        "architectural",
+        "audit",
+        "slice",
+        "vocabulary",
+        "única"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/architectural-vocabulary-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/architecture-judge",
+      "intents": [
+        "boundaries",
+        "code",
+        "coupling",
+        "court",
+        "judge"
+      ],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/architecture-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/attention-anchor-check",
+      "intents": [
+        "anchor",
+        "attention",
+        "check",
+        "coverage",
+        "pattern"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/attention-anchor-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/audit",
+      "intents": [
+        "assessment",
+        "audit",
+        "executive",
+        "generate",
+        "professional"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/audit.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/automation-scheduler/SKILL",
+      "intents": [
+        "audits",
+        "automati",
+        "automatiza",
+        "automatizaciones",
+        "briefs"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/automation-scheduler/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/banking-data-governance",
+      "intents": [
+        "auditar",
+        "clasificación",
+        "datos",
+        "feature",
+        "gdpr"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/banking-data-governance.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/banking-mlops-audit",
+      "intents": [
+        "architectures",
+        "auditar",
+        "drift",
+        "mlops",
+        "model"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/banking-mlops-audit.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/case-review",
+      "intents": [
+        "benefit",
+        "days",
+        "generate",
+        "realization",
+        "review"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/case-review.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ci-bats-deps",
+      "intents": [
+        "bats",
+        "dependency",
+        "deps",
+        "dynamic",
+        "generate"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ci-bats-deps.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ci-select-bats",
+      "intents": [
+        "based",
+        "bats",
+        "changed",
+        "dynamic",
+        "files"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ci-select-bats.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/ci-test-quality-gate",
+      "intents": [
+        "coverage",
+        "gate",
+        "quality",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/ci-test-quality-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/cognitive-judge",
+      "intents": [
+        "code",
+        "complexity",
+        "court",
+        "debuggability",
+        "judge"
+      ],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/cognitive-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/command-tier-audit",
+      "intents": [
+        "audit",
+        "command",
+        "scripts",
+        "slice",
+        "tier"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/command-tier-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/comprehension-audit",
+      "intents": [
+        "comprehension",
+        "coverage",
+        "identify",
+        "implementations",
+        "lack"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/comprehension-audit.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/confidentiality-auditor",
+      "intents": [
+        "audita",
+        "blocked",
+        "clean",
+        "confidencialidad",
+        "cumplimiento"
+      ],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/confidentiality-auditor.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/confidentiality-sign",
+      "intents": [
+        "audit",
+        "confidentiality",
+        "cryptographic",
+        "sign",
+        "signature"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/confidentiality-sign.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/corporate-attest",
+      "intents": [
+        "attest",
+        "attestation",
+        "corporate",
+        "generate",
+        "signed"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/corporate-attest.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/corporate-fleet-dashboard",
+      "intents": [
+        "attestations",
+        "corporate",
+        "dashboard",
+        "derive",
+        "fleet"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/corporate-fleet-dashboard.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/corporate/corporate-attestation-queue",
+      "intents": [
+        "attestation",
+        "corporate",
+        "offline",
+        "online",
+        "queue"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/corporate/corporate-attestation-queue.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/corporate/engagement-audit-answer",
+      "intents": [
+        "answer",
+        "audit",
+        "auditor",
+        "canonical",
+        "engagement"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/corporate/engagement-audit-answer.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/correctness-judge",
+      "intents": [
+        "cases",
+        "code",
+        "court",
+        "edge",
+        "error"
+      ],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/correctness-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/court-orchestrator",
+      "intents": [
+        "code",
+        "convenes",
+        "court",
+        "cycles",
+        "manages"
+      ],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/court-orchestrator.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/court-review",
+      "intents": [
+        "code",
+        "court",
+        "helper",
+        "orchestration",
+        "review"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/court-review.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/court-turn-router",
+      "intents": [
+        "adaptive",
+        "code",
+        "court",
+        "review",
+        "router"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/court-turn-router.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/coverage-report",
+      "intents": [
+        "coverage",
+        "generate",
+        "report",
+        "test",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/coverage-report.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/decide-architecture-corpus-test",
+      "intents": [
+        "architecture",
+        "corpus",
+        "decide",
+        "spec",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/decide-architecture-corpus-test.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/doc-health-audit",
+      "intents": [
+        "audit",
+        "auditor",
+        "documentation",
+        "health"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/doc-health-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/docs-audit",
+      "intents": [
+        "actual",
+        "audit",
+        "audita",
+        "docs",
+        "estructura"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/docs-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/docs-lint",
+      "intents": [
+        "bash",
+        "docs",
+        "lint",
+        "slice",
+        "wrapper"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/docs-lint.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/docs-quality-audit",
+      "intents": [
+        "agentes",
+        "auditar",
+        "basada",
+        "calidad",
+        "documentacion"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/docs-quality-audit.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/drift-auditor",
+      "intents": [
+        "auditoría",
+        "cambios",
+        "config",
+        "convergencia",
+        "código"
+      ],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/drift-auditor.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/dynamic-web-security-test",
+      "intents": [
+        "dynamic",
+        "security",
+        "test",
+        "testing"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/dynamic-web-security-test.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/dynamic-web-tester/SKILL",
+      "intents": [
+        "dalfox",
+        "dinámico",
+        "endpoints",
+        "nuclei",
+        "sqli"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/dynamic-web-tester/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/activation-plan-review",
+      "intents": [
+        "activation",
+        "agent",
+        "plan",
+        "review"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/activation-plan-review.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/audit-purge",
+      "intents": [
+        "audit",
+        "purge",
+        "retention",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/audit-purge.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/audit-search",
+      "intents": [
+        "audit",
+        "inspector",
+        "search",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/audit-search.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/enterprise/governance-audit-trail",
+      "intents": [
+        "audit",
+        "compliance",
+        "governance",
+        "signed",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/enterprise/governance-audit-trail.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/eval-lint",
+      "intents": [
+        "eval",
+        "golden",
+        "lint",
+        "sets",
+        "tribunales"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/eval-lint.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/evidence-first-development/SKILL",
+      "intents": [
+        "alta",
+        "aprobado",
+        "código",
+        "desarrollo",
+        "dominios"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/evidence-first-development/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/executive-audit",
+      "intents": [
+        "audit",
+        "executive",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/executive-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/expertise-asymmetry-judge",
+      "intents": [
+        "active",
+        "alternatives",
+        "audit",
+        "blind",
+        "domain"
+      ],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/expertise-asymmetry-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/fix-assigner",
+      "intents": [
+        "agents",
+        "assigns",
+        "court",
+        "creates",
+        "findings"
+      ],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/fix-assigner.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/fix-survival-check",
+      "intents": [
+        "audit",
+        "check",
+        "spec",
+        "survival",
+        "weekly"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/fix-survival-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/focal-decisions-log",
+      "intents": [
+        "append",
+        "audit",
+        "decisiones",
+        "decisions",
+        "director"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/focal-decisions-log.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/frontend-test-runner",
+      "intents": [
+        "commit",
+        "component",
+        "coverage",
+        "execution",
+        "frontend"
+      ],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/frontend-test-runner.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/grill-me/SKILL",
+      "intents": [
+        "adversarial",
+        "assumption",
+        "before",
+        "break",
+        "breaks"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/grill-me/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/guardrail-audit",
+      "intents": [
+        "audit",
+        "auditoría",
+        "cumplimiento",
+        "guardrail",
+        "principio"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/guardrail-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hook-event-gap-audit",
+      "intents": [
+        "audit",
+        "audita",
+        "cubiertos",
+        "event",
+        "eventos"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hook-event-gap-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hook-injection-audit",
+      "intents": [
+        "audit",
+        "hook",
+        "injection",
+        "patterns",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hook-injection-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hook-latency-audit",
+      "intents": [
+        "audit",
+        "enforcement",
+        "hook",
+        "latency",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hook-latency-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hook-matcher-audit",
+      "intents": [
+        "audit",
+        "hook",
+        "matcher",
+        "slice",
+        "specificity"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hook-matcher-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hook-test-coverage-audit",
+      "intents": [
+        "audit",
+        "bats",
+        "coverage",
+        "detect",
+        "hook"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hook-test-coverage-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hook-type-audit",
+      "intents": [
+        "audit",
+        "handler",
+        "hook",
+        "slice",
+        "type"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hook-type-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/hooks-coverage-matrix",
+      "intents": [
+        "coverage",
+        "hooks",
+        "matrix",
+        "scripts",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/hooks-coverage-matrix.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/hub-audit",
+      "intents": [
+        "agentes",
+        "auditar",
+        "comandos",
+        "dependencias",
+        "dominio"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/hub-audit.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/iac-security-baseline",
+      "intents": [
+        "baseline",
+        "inicial",
+        "legacy",
+        "proyecto",
+        "security"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/iac-security-baseline.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/iac-security-scan",
+      "intents": [
+        "scan",
+        "scanning",
+        "security",
+        "trivy"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/iac-security-scan.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/iac-security-scanner/SKILL",
+      "intents": [
+        "bicep",
+        "compose",
+        "config",
+        "detectar",
+        "docker"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/iac-security-scanner/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/knowledge-lint",
+      "intents": [
+        "base",
+        "check",
+        "detect",
+        "evidence",
+        "health"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/knowledge-lint.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/knowledge-lint",
+      "intents": [
+        "base",
+        "check",
+        "health",
+        "knowledge",
+        "lint"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/knowledge-lint.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/labs-self-audit",
+      "intents": [
+        "audit",
+        "comprobaciones",
+        "disciplina",
+        "labs",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/labs-self-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/layer-baseline-test",
+      "intents": [
+        "baseline",
+        "coordination",
+        "criterion",
+        "falsability",
+        "layer"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/layer-baseline-test.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/legal-audit",
+      "intents": [
+        "auditoría",
+        "compliance",
+        "contra",
+        "española",
+        "legal"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/legal-audit.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/legal-compliance/SKILL",
+      "intents": [
+        "audita",
+        "compliance",
+        "consolidada",
+        "contra",
+        "española"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/legal-compliance/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/loop-phasing-audit",
+      "intents": [
+        "audit",
+        "audita",
+        "declarado",
+        "inferido",
+        "level"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/loop-phasing-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/markdownlint",
+      "intents": [
+        "dependency",
+        "markdownlint",
+        "native",
+        "wrapper"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/markdownlint.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/mcp-audit",
+      "intents": [
+        "across",
+        "audit",
+        "configs",
+        "overhead",
+        "server"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/mcp-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/mcp-security-audit",
+      "intents": [
+        "audit",
+        "chain",
+        "config",
+        "security",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/mcp-security-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/mobile-security-scan",
+      "intents": [
+        "mobile",
+        "scan",
+        "security"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/mobile-security-scan.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/mobile-security-scanner/SKILL",
+      "intents": [
+        "android",
+        "análisis",
+        "busca",
+        "básico",
+        "docker"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/mobile-security-scanner/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/model-upgrade-audit",
+      "intents": [
+        "audit",
+        "components",
+        "debt",
+        "models",
+        "need"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/model-upgrade-audit.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/model-upgrade-audit/SKILL",
+      "intents": [
+        "debt",
+        "detectar",
+        "disponible",
+        "modelo",
+        "nuevo"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/model-upgrade-audit/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/model-upgrade-auditor",
+      "intents": [
+        "agents",
+        "audits",
+        "backed",
+        "eval",
+        "evidence"
+      ],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/model-upgrade-auditor.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/mutation-audit/SKILL",
+      "intents": [
+        "calidad",
+        "mediante",
+        "medir",
+        "mutation",
+        "quiere"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/mutation-audit/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/mutation-audit",
+      "intents": [
+        "audit",
+        "mutation",
+        "testing"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/mutation-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/opencode-cross-audit",
+      "intents": [
+        "audit",
+        "cross",
+        "opencode",
+        "scripts"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/opencode-cross-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/opencode-parity-audit",
+      "intents": [
+        "audit",
+        "opencode",
+        "parity",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/opencode-parity-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/overnight-sprint",
+      "intents": [
+        "autonomous",
+        "creates",
+        "executes",
+        "human",
+        "launch"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/overnight-sprint.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/pentester",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/pentester.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/pentesting/SKILL",
+      "intents": [
+        "aplicación",
+        "contra",
+        "ejecuta",
+        "infraestructura",
+        "pentest"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/pentesting/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/perf-audit",
+      "intents": [
+        "anti",
+        "async",
+        "auditoría",
+        "detecta",
+        "estática"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/perf-audit.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/perf-fix",
+      "intents": [
+        "aplica",
+        "crea",
+        "existen",
+        "first",
+        "hallazgos"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/perf-fix.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/perf-report",
+      "intents": [
+        "async",
+        "ejecutivo",
+        "hotspots",
+        "informe",
+        "issues"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/perf-report.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/performance-audit/SKILL",
+      "intents": [
+        "audita",
+        "código",
+        "detectar",
+        "estático",
+        "hotspots"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/performance-audit/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/permissions-wildcard-audit",
+      "intents": [
+        "audit",
+        "permissions",
+        "slice",
+        "wildcard"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/permissions-wildcard-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/pr-agent-judge/SKILL",
+      "intents": [
+        "agent",
+        "añade",
+        "code",
+        "court",
+        "externo"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/pr-agent-judge/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/pr-agent-judge",
+      "intents": [
+        "agent",
+        "code",
+        "court",
+        "external",
+        "include"
+      ],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/pr-agent-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pr-agent-run",
+      "intents": [
+        "agent",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pr-agent-run.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pr-context-loader",
+      "intents": [
+        "before",
+        "context",
+        "creation",
+        "load",
+        "loader"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pr-context-loader.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pr-digest",
+      "intents": [
+        "analiza",
+        "contextual",
+        "digestión",
+        "ejecutivo",
+        "español"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pr-digest.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pr-pending",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pr-pending.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pr-plan",
+      "intents": [
+        "before",
+        "checklist",
+        "failures",
+        "flight",
+        "gates"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pr-plan.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pr-plan",
+      "intents": [
+        "flight",
+        "gate",
+        "plan",
+        "push",
+        "sign"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pr-plan.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pr-plan-gates",
+      "intents": [
+        "executed",
+        "functions",
+        "gate",
+        "gates",
+        "plan"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pr-plan-gates.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pr-plan-queue-check",
+      "intents": [
+        "check",
+        "module",
+        "plan",
+        "queue",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pr-plan-queue-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pr-rebase",
+      "intents": [
+        "branch",
+        "current",
+        "main",
+        "onto",
+        "origin"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pr-rebase.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/pr-review",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/pr-review.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pr-thermal-receipt",
+      "intents": [
+        "codeflow",
+        "inspired",
+        "receipt",
+        "thermal"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pr-thermal-receipt.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/pre-push-security-gate",
+      "intents": [
+        "gate",
+        "push",
+        "security"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/pre-push-security-gate.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/prompt-security-scan",
+      "intents": [
+        "analyzer",
+        "injection",
+        "leakage",
+        "prompt",
+        "scan"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/prompt-security-scan.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/python-sbom",
+      "intents": [
+        "audit",
+        "python",
+        "requirements",
+        "sbom",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/python-sbom.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/rbac-management/SKILL",
+      "intents": [
+        "acceso",
+        "audita",
+        "gestionan",
+        "permisos",
+        "roles"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/rbac-management/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/rbac-manager",
+      "intents": [
+        "access",
+        "audit",
+        "based",
+        "control",
+        "grant"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/rbac-manager.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/receipt-v2",
+      "intents": [
+        "bound",
+        "content",
+        "receipt",
+        "receipts",
+        "review"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/receipt-v2.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/recommendation-tribunal-search",
+      "intents": [
+        "audit",
+        "inspection",
+        "recommendation",
+        "search",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/recommendation-tribunal-search.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/reconciler",
+      "intents": [
+        "auditor",
+        "auto",
+        "buckets",
+        "classifies",
+        "conflict"
+      ],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/reconciler.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/review-cache",
+      "intents": [
+        "cache",
+        "caché",
+        "code",
+        "gestión",
+        "review"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/review-cache.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/review-cache-stats",
+      "intents": [
+        "caché",
+        "code",
+        "estadísticas",
+        "review"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/review-cache-stats.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/review-checkpoint",
+      "intents": [
+        "cambio",
+        "cierre",
+        "hallazgos",
+        "humana",
+        "lectura"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/review-checkpoint.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/review-checkpoint",
+      "intents": [
+        "checkpoint",
+        "humana",
+        "paquete",
+        "review",
+        "revision"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/review-checkpoint.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/review-community",
+      "intents": [
+        "community",
+        "comunidad",
+        "issues",
+        "local",
+        "only"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/review-community.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/review-depth-selector",
+      "intents": [
+        "based",
+        "depth",
+        "review",
+        "risk",
+        "score"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/review-depth-selector.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/rule-orphan-detector",
+      "intents": [
+        "audit",
+        "detector",
+        "orphan",
+        "rule",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/rule-orphan-detector.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/sdd-research-lane",
+      "intents": [
+        "auditable",
+        "investigación",
+        "lane",
+        "research"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/sdd-research-lane.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/security-attacker",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/security-attacker.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/security-audit-all",
+      "intents": [
+        "audit",
+        "runner",
+        "scanners",
+        "security",
+        "unified"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/security-audit-all.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/security-auditor",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/security-auditor.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/security-auto-remediation",
+      "intents": [
+        "auto",
+        "remediation",
+        "security",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/security-auto-remediation.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/security-benchmark-runner",
+      "intents": [
+        "benchmark",
+        "runner",
+        "security",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/security-benchmark-runner.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/security-defender",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/security-defender.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/security-guardian",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/security-guardian.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/security-judge",
+      "intents": [
+        "auth",
+        "code",
+        "court",
+        "credentials",
+        "injection"
+      ],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/security-judge.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/security-review",
+      "intents": [],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/security-review.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/security-scan",
+      "intents": [
+        "audit",
+        "scan",
+        "security",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/security-scan.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/self-audit",
+      "intents": [
+        "audit",
+        "self",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/self-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skill-audit",
+      "intents": [
+        "audit",
+        "auditor",
+        "baseline",
+        "catalog",
+        "quality"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skill-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skill-catalog-audit",
+      "intents": [
+        "audit",
+        "catalog",
+        "skill",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skill-catalog-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skill-catalog-auditor",
+      "intents": [
+        "auditor",
+        "catalog",
+        "quality",
+        "skill",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skill-catalog-auditor.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skill-maturity-audit",
+      "intents": [
+        "audit",
+        "kanban",
+        "maturity",
+        "skill"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skill-maturity-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skills-depth-lint",
+      "intents": [
+        "depth",
+        "enforcement",
+        "level",
+        "lint",
+        "single"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skills-depth-lint.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skills-lint",
+      "intents": [
+        "description",
+        "lint",
+        "routing",
+        "rule",
+        "skill"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skills-lint.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skills-overlap-audit",
+      "intents": [
+        "audit",
+        "description",
+        "matrix",
+        "overlap",
+        "similarity"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skills-overlap-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skills-tier-audit",
+      "intents": [
+        "assignment",
+        "audit",
+        "skill",
+        "skills",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skills-tier-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/skills-usage-audit",
+      "intents": [
+        "audit",
+        "audita",
+        "skills",
+        "usage",
+        "workspace"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/skills-usage-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/sovereignty-audit",
+      "intents": [
+        "audit",
+        "cognitive",
+        "data",
+        "diagnose",
+        "lock"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/sovereignty-audit.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/sovereignty-auditor/SKILL",
+      "intents": [
+        "audita",
+        "cognitiva",
+        "dependencia",
+        "equipo",
+        "grado"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/sovereignty-auditor/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/spellcheck-docs",
+      "intents": [
+        "accent",
+        "dictionaries",
+        "docs",
+        "orthographic",
+        "review"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/spellcheck-docs.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/tabular-self-audit",
+      "intents": [
+        "audit",
+        "needed",
+        "post",
+        "self",
+        "tabular"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/tabular-self-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/tdd-vertical-slices/SKILL",
+      "intents": [
+        "applying",
+        "avoids",
+        "cycles",
+        "development",
+        "driven"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/tdd-vertical-slices/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-accessibility",
+      "intents": [
+        "accessibility",
+        "feature",
+        "files",
+        "test",
+        "universal"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-accessibility.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-ai-adoption",
+      "intents": [
+        "adoption",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-ai-adoption.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-ai-governance",
+      "intents": [
+        "governance",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-ai-governance.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-ai-labor-impact",
+      "intents": [
+        "analysis",
+        "impact",
+        "labor",
+        "test",
+        "tests"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-ai-labor-impact.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-ai-planning",
+      "intents": [
+        "planning",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-ai-planning.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-ai-safety",
+      "intents": [
+        "safety",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-ai-safety.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/test-architect/SKILL",
+      "intents": [
+        "alta",
+        "calidad",
+        "diseñan",
+        "generan",
+        "lenguaje"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/test-architect/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/test-architect",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/test-architect.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-architecture-debt",
+      "intents": [
+        "architecture",
+        "debt",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-architecture-debt.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-auditor",
+      "intents": [
+        "auditor",
+        "bats",
+        "certify",
+        "files",
+        "score"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-auditor.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-auditor-sweep",
+      "intents": [
+        "audit",
+        "auditor",
+        "bats",
+        "global",
+        "slice"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-auditor-sweep.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-backlog-git",
+      "intents": [
+        "backlog",
+        "backloggit",
+        "structural",
+        "test",
+        "tests"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-backlog-git.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-backlog-intelligence",
+      "intents": [
+        "backlog",
+        "intelligence",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-backlog-intelligence.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-backup",
+      "intents": [
+        "backup",
+        "cifrado",
+        "sistema",
+        "test",
+        "tests"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-backup.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-banking-vertical",
+      "intents": [
+        "banking",
+        "test",
+        "vertical"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-banking-vertical.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-ceo-reports",
+      "intents": [
+        "reports",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-ceo-reports.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-ceremony-intelligence",
+      "intents": [
+        "ceremony",
+        "intelligence",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-ceremony-intelligence.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-client-profiles",
+      "intents": [
+        "client",
+        "profiles",
+        "structural",
+        "test",
+        "tests"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-client-profiles.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-coherence-validator",
+      "intents": [
+        "coherence",
+        "framework",
+        "output",
+        "quality",
+        "suite"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-coherence-validator.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-company-profile",
+      "intents": [
+        "company",
+        "profile",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-company-profile.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-company-repo",
+      "intents": [
+        "architecture",
+        "based",
+        "branch",
+        "company",
+        "repo"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-company-repo.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-confidence-calibration",
+      "intents": [
+        "calibration",
+        "confidence",
+        "framework",
+        "quality",
+        "suite"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-confidence-calibration.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-consensus",
+      "intents": [
+        "consensus",
+        "framework",
+        "judge",
+        "multi",
+        "quality"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-consensus.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-context-aging",
+      "intents": [
+        "aging",
+        "context",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-context-aging.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-context-eng-improvements",
+      "intents": [
+        "context",
+        "engineering",
+        "improvements",
+        "test",
+        "tests"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-context-eng-improvements.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-context-engineering",
+      "intents": [
+        "commands",
+        "context",
+        "engineering",
+        "suite",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-context-engineering.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-context-interview",
+      "intents": [
+        "context",
+        "interview",
+        "structural",
+        "test",
+        "tests"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-context-interview.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-context-optimization",
+      "intents": [
+        "context",
+        "optimization",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-context-optimization.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-context-tracking",
+      "intents": [
+        "context",
+        "test",
+        "tracking"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-context-tracking.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-contribute",
+      "intents": [
+        "comunidad",
+        "contribución",
+        "contribute",
+        "sistema",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-contribute.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-cost-center",
+      "intents": [
+        "billing",
+        "center",
+        "cost",
+        "management",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-cost-center.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-coverage-checker",
+      "intents": [
+        "checker",
+        "corresponding",
+        "coverage",
+        "every",
+        "script"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-coverage-checker.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-coverage-ratchet",
+      "intents": [
+        "cobertura",
+        "coverage",
+        "decreciente",
+        "ratchet",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-coverage-ratchet.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-cross-project",
+      "intents": [
+        "cross",
+        "project",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-cross-project.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-dev-productivity",
+      "intents": [
+        "productivity",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-dev-productivity.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-docs-overhaul",
+      "intents": [
+        "docs",
+        "documentation",
+        "overhaul",
+        "savia",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-docs-overhaul.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/test-engineer",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/test-engineer.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-enterprise-dashboard",
+      "intents": [
+        "analytics",
+        "dashboard",
+        "enterprise",
+        "reporting",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-enterprise-dashboard.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-equality-shield",
+      "intents": [
+        "equality",
+        "shield",
+        "test",
+        "tests"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-equality-shield.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-era18-commands",
+      "intents": [
+        "command",
+        "commands",
+        "structure",
+        "test",
+        "validation"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-era18-commands.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-era18-formulas",
+      "intents": [
+        "correctness",
+        "formula",
+        "formulas",
+        "scoring",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-era18-formulas.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-era18-rules",
+      "intents": [
+        "config",
+        "rule",
+        "rules",
+        "test",
+        "validation"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-era18-rules.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-evolving-playbooks",
+      "intents": [
+        "evolving",
+        "playbooks",
+        "suite",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-evolving-playbooks.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-frontend-testing",
+      "intents": [
+        "frontend",
+        "nueva",
+        "test",
+        "testing",
+        "tests"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-frontend-testing.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-governance",
+      "intents": [
+        "governance",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-governance.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-governance-enterprise",
+      "intents": [
+        "audit",
+        "enterprise",
+        "governance",
+        "test",
+        "trail"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-governance-enterprise.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-hub-audit",
+      "intents": [
+        "audit",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-hub-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-install",
+      "intents": [
+        "install",
+        "installers",
+        "structural",
+        "test",
+        "validation"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-install.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-integration-company",
+      "intents": [
+        "company",
+        "integration",
+        "orchestrator",
+        "savia",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-integration-company.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-integration-hub",
+      "intents": [
+        "integration",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-integration-hub.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-integrations-external",
+      "intents": [
+        "external",
+        "integrations",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-integrations-external.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-memory-improvements",
+      "intents": [
+        "improvements",
+        "memory",
+        "store",
+        "suite",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-memory-improvements.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-multi-layer-caching",
+      "intents": [
+        "caching",
+        "layer",
+        "multi",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-multi-layer-caching.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-multi-platform",
+      "intents": [
+        "multi",
+        "platform",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-multi-platform.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-multi-tenant",
+      "intents": [
+        "marketplace",
+        "multi",
+        "skills",
+        "suite",
+        "tenant"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-multi-tenant.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-nl-resolution",
+      "intents": [
+        "command",
+        "resolution",
+        "suite",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-nl-resolution.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-observability-core",
+      "intents": [
+        "core",
+        "observability",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-observability-core.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-okr-strategy",
+      "intents": [
+        "strategy",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-okr-strategy.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-onboard-enterprise",
+      "intents": [
+        "enterprise",
+        "onboard",
+        "onboarding",
+        "scale",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-onboard-enterprise.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-orgchart-diagrams",
+      "intents": [],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-orgchart-diagrams.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-pbi-history",
+      "intents": [
+        "field",
+        "history",
+        "implementation",
+        "level",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-pbi-history.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-pbi-spec-links",
+      "intents": [
+        "bidirectional",
+        "linkage",
+        "links",
+        "spec",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-pbi-spec-links.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-performance-quality",
+      "intents": [
+        "performance",
+        "quality",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-performance-quality.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-pipeline-devops",
+      "intents": [
+        "devops",
+        "pipeline",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-pipeline-devops.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-playbooks",
+      "intents": [
+        "playbooks",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-playbooks.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-po-analytics",
+      "intents": [
+        "analytics",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-po-analytics.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-profile-system",
+      "intents": [
+        "profile",
+        "system",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-profile-system.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-project-management",
+      "intents": [
+        "management",
+        "project",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-project-management.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-qa-toolkit",
+      "intents": [
+        "test",
+        "toolkit"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-qa-toolkit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-rbac-manager",
+      "intents": [
+        "based",
+        "file",
+        "manager",
+        "rbac",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-rbac-manager.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-reflection-validator",
+      "intents": [
+        "agent",
+        "cognition",
+        "meta",
+        "reflection",
+        "suite"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-reflection-validator.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-repo-management",
+      "intents": [
+        "management",
+        "repo",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-repo-management.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-review-community",
+      "intents": [
+        "community",
+        "comunitaria",
+        "protocolo",
+        "review",
+        "revisión"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-review-community.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/test-runner",
+      "intents": [],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/test-runner.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-savia-confidentiality",
+      "intents": [
+        "confidentiality",
+        "encrypted",
+        "messaging",
+        "savia",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-savia-confidentiality.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-savia-crypto",
+      "intents": [
+        "crypto",
+        "encryption",
+        "savia",
+        "test",
+        "tests"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-savia-crypto.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-savia-flow",
+      "intents": [
+        "architecture",
+        "based",
+        "branch",
+        "flow",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-savia-flow.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-savia-flow-tasks",
+      "intents": [
+        "branch",
+        "flow",
+        "native",
+        "savia",
+        "task"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-savia-flow-tasks.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-savia-hub",
+      "intents": [
+        "savia",
+        "saviahub",
+        "structural",
+        "test",
+        "tests"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-savia-hub.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-savia-index",
+      "intents": [
+        "architecture",
+        "based",
+        "branch",
+        "index",
+        "indexes"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-savia-index.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-savia-messaging",
+      "intents": [
+        "based",
+        "branch",
+        "infrastructure",
+        "messaging",
+        "savia"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-savia-messaging.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-savia-school",
+      "intents": [
+        "educational",
+        "savia",
+        "school",
+        "test",
+        "tests"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-savia-school.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-savia-travel",
+      "intents": [
+        "clean",
+        "mode",
+        "pack",
+        "savia",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-savia-travel.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-scale-optimizer",
+      "intents": [
+        "integration",
+        "optimizer",
+        "polish",
+        "scale",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-scale-optimizer.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-scoring-intelligence",
+      "intents": [
+        "intelligence",
+        "scoring",
+        "test",
+        "tests"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-scoring-intelligence.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-security-compliance",
+      "intents": [
+        "compliance",
+        "security",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-security-compliance.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-semantic-memory",
+      "intents": [
+        "memory",
+        "semantic",
+        "suite",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-semantic-memory.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-sovereignty-audit",
+      "intents": [
+        "audit",
+        "cognitive",
+        "sovereignty",
+        "structural",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-sovereignty-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-specs-sdd",
+      "intents": [
+        "specs",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-specs-sdd.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-stress-hooks",
+      "intents": [
+        "hooks",
+        "stress",
+        "test",
+        "tests"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-stress-hooks.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-stress-runner",
+      "intents": [
+        "orchestrator",
+        "runner",
+        "stress",
+        "test",
+        "tests"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-stress-runner.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-stress-scripts",
+      "intents": [
+        "robustness",
+        "scripts",
+        "stress",
+        "supporting",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-stress-scripts.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-stress-security",
+      "intents": [
+        "coverage",
+        "pattern",
+        "security",
+        "stress",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-stress-security.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-tasks-entities",
+      "intents": [
+        "class",
+        "entities",
+        "first",
+        "tasks",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-tasks-entities.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-team-orchestrator",
+      "intents": [
+        "coordination",
+        "multi",
+        "orchestrator",
+        "team",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-team-orchestrator.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-tech-lead",
+      "intents": [
+        "lead",
+        "tech",
+        "test"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-tech-lead.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-update-system",
+      "intents": [
+        "actualización",
+        "sistema",
+        "system",
+        "test",
+        "tests"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-update-system.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-utils",
+      "intents": [
+        "compartidas",
+        "funciones",
+        "scripts",
+        "test",
+        "utils"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-utils.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-vertical-compliance",
+      "intents": [
+        "compliance",
+        "test",
+        "vertical"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-vertical-compliance.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-vertical-detection",
+      "intents": [
+        "detección",
+        "detection",
+        "sistema",
+        "test",
+        "tests"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-vertical-detection.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-verticals",
+      "intents": [
+        "test",
+        "verticals"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-verticals.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-wellbeing-guardian",
+      "intents": [
+        "guardian",
+        "structural",
+        "test",
+        "tests",
+        "wellbeing"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-wellbeing-guardian.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/test-workspace",
+      "intents": [
+        "slice",
+        "test",
+        "workspace",
+        "wrapper"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/test-workspace.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/tests/test-adb-wrapper",
+      "intents": [],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/tests/test-adb-wrapper.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/tls-security-check",
+      "intents": [
+        "check",
+        "security"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/tls-security-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/tls-security-checker/SKILL",
+      "intents": [
+        "auditorías",
+        "deploy",
+        "headers",
+        "http",
+        "invocable"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/tls-security-checker/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/tool-ergonomics-audit",
+      "intents": [
+        "audit",
+        "auto",
+        "ergonomics",
+        "spec",
+        "tool"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/tool-ergonomics-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/turn-sdlc-audit",
+      "intents": [
+        "audit",
+        "auditor",
+        "sdlc",
+        "turn"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/turn-sdlc-audit.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/twin-linter",
+      "intents": [
+        "contra",
+        "linter",
+        "schema",
+        "spec",
+        "twin"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/twin-linter.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/verification-lattice/SKILL",
+      "intents": [
+        "allá",
+        "capa",
+        "code",
+        "estándar",
+        "multi"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/verification-lattice/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/visual-diff-merge-check",
+      "intents": [
+        "check",
+        "diff",
+        "merge",
+        "scripts",
+        "spec"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/visual-diff-merge-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/visual-digest",
+      "intents": [
+        "ambigüedades",
+        "capturas",
+        "contexto",
+        "contextual",
+        "detectan"
+      ],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/visual-digest.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/visual-qa-agent",
+      "intents": [
+        "analysis",
+        "cambios",
+        "comparison",
+        "componentes",
+        "detectan"
+      ],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/visual-qa-agent.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "agent:.opencode/agents/web-e2e-tester",
+      "intents": [
+        "against",
+        "android",
+        "apps",
+        "autonomous",
+        "changes"
+      ],
+      "kind": "agent",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".opencode/agents/web-e2e-tester.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "opencode"
+      ],
+      "id": "script:scripts/web-headers-check",
+      "intents": [
+        "check",
+        "headers",
+        "security"
+      ],
+      "kind": "script",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": "scripts/web-headers-check.sh",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude"
+      ],
+      "id": "skill:.claude/skills/workspace-integrity/SKILL",
+      "intents": [
+        "agentes",
+        "audita",
+        "baseline",
+        "drift",
+        "integridad"
+      ],
+      "kind": "skill",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/skills/workspace-integrity/SKILL.md",
+      "status": "active",
+      "tests": []
+    },
+    {
+      "depends_on": [],
+      "frontend_support": [
+        "claude",
+        "opencode"
+      ],
+      "id": "cmd:.claude/commands/zeroclaw",
+      "intents": [
+        "commands",
+        "firmware",
+        "flash",
+        "interface",
+        "send"
+      ],
+      "kind": "cmd",
+      "owner_domain": "quality",
+      "replaced_by": null,
+      "risk_level": null,
+      "source": ".claude/commands/zeroclaw.md",
+      "status": "active",
+      "tests": []
+    }
+  ],
+  "content_hash": "1629d582d2e8",
+  "deferred_kinds": [
+    "rule",
+    "hook"
+  ],
+  "kinds_included": [
+    "command",
+    "skill",
+    "agent",
+    "script"
+  ],
+  "registry_version": 1
+}

--- a/CHANGELOG.d/se375-registry.md
+++ b/CHANGELOG.d/se375-registry.md
@@ -1,0 +1,5 @@
+---
+version_bump: patch
+section: Added
+---
+- **SE-375 Canonical Capability Registry (S1)**: generate-capability-map.py emite `.scm/registry.json` (1446 capabilities, ids únicos, determinista) con campos id/kind/source/status/owner_domain/intents/risk_level/frontend_support/depends_on/tests/replaced_by. --check valida también el registry. Kinds rule/hook diferidos a S2 (documentado en deferred_kinds). Bats: RN-07, RN-09, campos mínimos. GENERATED_VIEW_DRIFT (SE-379) ahora compara también registry.json.

--- a/scripts/generate-capability-map.py
+++ b/scripts/generate-capability-map.py
@@ -323,6 +323,74 @@ def write_resources_json(json_path: Path, resources: list[ResourceEntry]) -> Non
     )
 
 
+def write_registry_json(scm_dir: Path, resources: list[ResourceEntry]) -> None:
+    """SE-375 — Canonical Capability Registry (machine-readable, deterministic).
+
+    Evoluciona .scm (no compite): mismo hash estable que resources.json.
+    Campos por capability: id, kind, source, status, owner_domain, intents,
+    risk_level, frontend_support, depends_on, tests, replaced_by.
+    Kinds diferidos (S2): rule, hook — documentados en deferred_kinds.
+    """
+    sorted_resources = sorted(resources, key=lambda r: (r.category, r.name))
+    content_hash = hashlib.sha256(
+        json.dumps([r.to_dict() for r in sorted_resources], ensure_ascii=False, sort_keys=True).encode("utf-8")
+    ).hexdigest()[:12]
+
+    capabilities = []
+    for r in sorted_resources:
+        risk = None
+        status = "active"
+        src = Path(r.rel_path)
+        if r.kind == "agent":
+            try:
+                text = src.read_text(encoding="utf-8", errors="replace")[:2000]
+                m = re.search(r"^permission:\s*(L[0-4])", text, re.MULTILINE)
+                risk = m.group(1) if m else None
+                if re.search(r"^deprecated:\s*true", text, re.MULTILINE):
+                    status = "deprecated"
+            except OSError:
+                pass
+        elif r.kind == "skill":
+            try:
+                text = src.read_text(encoding="utf-8", errors="replace")[:2000]
+                if re.search(r"^deprecated:\s*true", text, re.MULTILINE):
+                    status = "deprecated"
+            except OSError:
+                pass
+        if r.kind == "cmd":
+            frontend = ["claude", "opencode"]
+        elif str(src).startswith(".claude"):
+            frontend = ["claude"]
+        else:
+            frontend = ["opencode"]
+        stem = str(src)[:-len(src.suffix)] if src.suffix else str(src)
+        capabilities.append({
+            "id": f"{r.kind}:{stem}",
+            "kind": r.kind,
+            "source": str(src),
+            "status": status,
+            "owner_domain": r.category,
+            "intents": sorted(set(r.intents)),
+            "risk_level": risk,
+            "frontend_support": frontend,
+            "depends_on": [],
+            "tests": [],
+            "replaced_by": None,
+        })
+
+    payload = {
+        "registry_version": 1,
+        "content_hash": content_hash,
+        "kinds_included": ["command", "skill", "agent", "script"],
+        "deferred_kinds": ["rule", "hook"],
+        "capabilities": capabilities,
+    }
+    (scm_dir / "registry.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
 def main(argv: list[str]) -> int:
     # Parse flags
     check_mode = False
@@ -362,11 +430,18 @@ def main(argv: list[str]) -> int:
             write_index_file(tmp_scm / "INDEX.scm", resources)
             write_category_files(tmp_cat, resources)
             write_resources_json(tmp_scm / "resources.json", resources)
+            write_registry_json(tmp_scm, resources)
 
             real_hash = _read_index_hash(index_file)
             tmp_hash = _read_index_hash(tmp_scm / "INDEX.scm")
 
-            if real_hash == tmp_hash:
+            tmp_registry = tmp_scm / "registry.json"
+            real_registry = scm_dir / "registry.json"
+            registry_same = (
+                not real_registry.exists()
+                or (tmp_registry.exists() and tmp_registry.read_bytes() == real_registry.read_bytes())
+            )
+            if real_hash == tmp_hash and registry_same:
                 print(f"SCM: FRESH ({len(resources)} resources)")
                 return 0
             else:
@@ -382,6 +457,7 @@ def main(argv: list[str]) -> int:
     write_index_file(scm_dir / "INDEX.scm", resources)
     write_category_files(categories_dir, resources)
     write_resources_json(scm_dir / "resources.json", resources)
+    write_registry_json(scm_dir, resources)
 
     elapsed_seconds = time.monotonic() - start_time
     kind_totals = {k: sum(1 for r in resources if r.kind == k)

--- a/scripts/release-invariants.sh
+++ b/scripts/release-invariants.sh
@@ -99,10 +99,13 @@ if [[ -f "$idx" && -x "$ROOT/scripts/generate-capability-map.py" ]]; then
     cp -al "$ROOT/$d" "$SB_VIEW/$d" 2>/dev/null
   done
   ( cd "$SB_VIEW" && timeout 120 python3 "$SB_VIEW/scripts/generate-capability-map.py" >/dev/null 2>&1 )
+  REG="$ROOT/.scm/registry.json"
   if [[ ! -f "$SB_VIEW/.scm/INDEX.scm" ]]; then
     fail "GENERATED_VIEW_DRIFT: no se pudo regenerar en sandbox"
   elif ! cmp -s "$SB_VIEW/.scm/INDEX.scm" "$idx"; then
     fail "GENERATED_VIEW_DRIFT: .scm/INDEX.scm difiere de la regeneración (ejecutar generate-capability-map.py)"
+  elif [[ -f "$REG" ]] && ! cmp -s "$SB_VIEW/.scm/registry.json" "$REG"; then
+    fail "GENERATED_VIEW_DRIFT: .scm/registry.json difiere de la regeneración (ejecutar generate-capability-map.py)"
   else
     ok "GENERATED_VIEW_DRIFT"
   fi

--- a/tests/bats/capability-registry.bats
+++ b/tests/bats/capability-registry.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+# SE-375 — RN-07 (IDs únicos) y RN-09 (regeneración determinista)
+REG=".scm/registry.json"
+
+@test "SE-375 RN-07: ids únicos en registry" {
+  run bash -c "jq -r '.capabilities[].id' $REG | sort | uniq -d | wc -l"
+  [ "$output" -eq 0 ]
+}
+
+@test "SE-375 RN-09: regeneración determinista (byte-identical)" {
+  TMP=$(mktemp -d)
+  for d in .claude .opencode scripts docs; do cp -al "$d" "$TMP/$d"; done
+  ( cd "$TMP" && python3 "$TMP/scripts/generate-capability-map.py" >/dev/null 2>&1 )
+  cmp -s "$TMP/.scm/registry.json" "$REG"
+  cmp -s "$TMP/.scm/INDEX.scm" .scm/INDEX.scm
+  rm -rf "$TMP"
+}
+
+@test "SE-375: toda capability tiene campos mínimos no vacíos" {
+  run bash -c "jq -e '[.capabilities[] | select((.id|length)>0 and (.kind|length)>0 and (.source|length)>0)] | length == .capabilities | not' $REG >/dev/null 2>&1; jq '[.capabilities[] | select((.id|length)==0 or (.kind|length)==0 or (.source|length)==0)] | length' $REG"
+  [ "$output" -eq 0 ]
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Segunda tanda de las mejoras aprobadas: crea el "registro maestro" de todo lo que Savia puede hacer (agentes, skills, comandos, scripts). Hasta hoy esa información estaba repartida en ficheros que a veces no coincidían; ahora hay una única lista generada automáticamente, con identificador único y estable entre generaciones, de la que saldrán todos los contadores e índices públicos.

Scope-trace: skip — implementación de SE-375 APPROVED: trazabilidad en docs/specs/SE-375-canonical-capability-registry.spec.md

## Test plan

- [x] registry.json: 1446 capabilities, 1446 ids únicos (RN-07)
- [x] Regeneración byte-idéntica en sandbox + --check FRESH (RN-09)
- [x] GENERATED_VIEW_DRIFT compara INDEX.scm y registry.json
- [x] bats tests/bats/capability-registry.bats 3/3 PASS
- [x] Campos mínimos presentes en el 100% de entradas
## Summary
feat(scripts): SE-375 canonical capability registry (S1)
### Changes
- 4df07e6d feat(scripts): SE-375 canonical capability registry (S1)
### Stats
6 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed
