### PR TITLE
fix(harness): enforce fail-closed operational integrity

### DIFF
--- a/.claude/skills/agent-messaging/SKILL.md
+++ b/.claude/skills/agent-messaging/SKILL.md
@@ -1,14 +1,13 @@
 ---
 layer: peripheral
 name: agent-messaging
-description: Usar cuando un agente debe enviar un mensaje a otro agente con roles y receipts, sin pasar por el usuario. Triggers: mensaje a otro agente, agent-message, notify agent, inbox.
+description: "Usar cuando un agente debe enviar un mensaje a otro agente con roles y receipts, sin pasar por el usuario. Triggers: mensaje a otro agente, agent-message, notify agent, inbox."
 metadata:
   # --- metadata.savia.* (SE-333) ---
   savia.category: orchestration
   savia.maturity: stable
   savia.context: standalone
   savia.context_cost: low
-  savia.maturity: beta
   savia.priority: medium
   savia.tags: "messaging, agent-to-agent, a2a, receipts, orchestration"
   savia.trigger_keywords: "mensaje a agente, notify, inbox, agent-message"

--- a/.claude/skills/agent-runs-board/SKILL.md
+++ b/.claude/skills/agent-runs-board/SKILL.md
@@ -1,7 +1,7 @@
 ---
 layer: peripheral
 name: agent-runs-board
-description: Usar cuando se lanza, supervisa o consulta un run autónomo (overnight-sprint, code-improvement-loop, tech-research-agent, SDD) y se necesita el ledger operativo con estado derivado. Triggers: 'registra el run', 'board de runs', 'estado del run', 'savia-runs', '¿en qué columna está mi run?', 'ci_failed', 'needs_input', 'merge_conflict'.
+description: "Usar cuando se lanza, supervisa o consulta un run autónomo (overnight-sprint, code-improvement-loop, tech-research-agent, SDD) y se necesita el ledger operativo con estado derivado. Triggers: 'registra el run', 'board de runs', 'estado del run', 'savia-runs', '¿en qué columna está mi run?', 'ci_failed', 'needs_input', 'merge_conflict'."
 metadata:
   # --- metadata.savia.* (SE-333) ---
   savia.agent: dev-orchestrator

--- a/.claude/skills/code-improvement-loop/SKILL.md
+++ b/.claude/skills/code-improvement-loop/SKILL.md
@@ -8,8 +8,7 @@ metadata:
   savia.maturity: stable
   savia.category: sdd-framework
   savia.context: fork
-    savia.loop_level: L2  # L0=draft | L1=report-only | L2=assisted | L3=unattended — ver docs/rules/domain/loop-phasing.md
-  savia.maturity: experimental
+  savia.loop_level: L2  # L0=draft | L1=report-only | L2=assisted | L3=unattended — ver docs/rules/domain/loop-phasing.md
   savia.priority: medium
   savia.summary: "Bucle autonomo de mejora de codigo: detecta oportunidades (deuda, cobertura, performance), aplica mejoras y genera PRs Draft. Usa ramas agent/improve-*. Revision humana obligatoria."
   savia.tags: "autonomous, improvement, refactoring, pr-draft"

--- a/.claude/skills/overnight-sprint/SKILL.md
+++ b/.claude/skills/overnight-sprint/SKILL.md
@@ -8,8 +8,7 @@ metadata:
   savia.maturity: stable
   savia.category: sdd-framework
   savia.context: fork
-    savia.loop_level: L2  # L0=draft | L1=report-only | L2=assisted | L3=unattended — ver docs/rules/domain/loop-phasing.md
-  savia.maturity: experimental
+  savia.loop_level: L2  # L0=draft | L1=report-only | L2=assisted | L3=unattended — ver docs/rules/domain/loop-phasing.md
   savia.priority: medium
   savia.summary: "Sprint autonomo nocturno: ejecuta tareas de bajo riesgo en bucle. Genera PRs Draft en ramas agent/overnight-*. Revision humana obligatoria al dia siguiente."
   savia.tags: "autonomous, overnight, batch, low-risk"

--- a/.claude/skills/parallel-dispatch/SKILL.md
+++ b/.claude/skills/parallel-dispatch/SKILL.md
@@ -1,14 +1,13 @@
 ---
 layer: peripheral
 name: parallel-dispatch
-description: Usar cuando se necesitan subagentes en paralelo con admission-handle — lanza N tareas en background y recoge resultados después, sin bloquear el turno padre. Triggers: lanza subagentes en paralelo, paraleliza esto, admission-handle, recoge resultados.
+description: "Usar cuando se necesitan subagentes en paralelo con admission-handle — lanza N tareas en background y recoge resultados después, sin bloquear el turno padre. Triggers: lanza subagentes en paralelo, paraleliza esto, admission-handle, recoge resultados."
 metadata:
   # --- metadata.savia.* (SE-333) ---
   savia.category: orchestration
   savia.maturity: stable
   savia.context: standalone
   savia.context_cost: low
-  savia.maturity: beta
   savia.priority: medium
   savia.tags: "parallel, subagents, admission-handle, orchestration"
   savia.trigger_keywords: "paralelo, parallel, subagentes, lanza en background"

--- a/.claude/skills/tech-research-agent/SKILL.md
+++ b/.claude/skills/tech-research-agent/SKILL.md
@@ -8,8 +8,7 @@ metadata:
   savia.maturity: stable
   savia.category: sdd-framework
   savia.context: fork
-    savia.loop_level: L1  # L0=draft | L1=report-only | L2=assisted | L3=unattended — ver docs/rules/domain/loop-phasing.md
-  savia.maturity: experimental
+  savia.loop_level: L1  # L0=draft | L1=report-only | L2=assisted | L3=unattended — ver docs/rules/domain/loop-phasing.md
   savia.priority: low
   savia.summary: "Agente de investigacion tecnica autonoma: investiga temas, genera informes y notifica al humano designado. Output: informe en output/research-*. Rama agent/research-*."
   savia.tags: "research, autonomous, investigation, reports"

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=30c463e3261243c0c5e43b6af84be12f455e424bb2ec75be579b09dddd4e366c
-timestamp=2026-09-07T19:19:54Z
-branch=agent/se394-20260907-agnostic-remediation
-head_commit=fdbf58f6
-signature=188b751ce3f7c6eb32e7492f788b63911290bee334732db380f30de9966fde07
+diff_hash=d73ef784b3697333252d152df160f30ffdf540adba64d9d3be75e5d748ec218d
+timestamp=2026-09-08T16:21:43Z
+branch=agent/se396-finish-20260908
+head_commit=6dd0f5d6
+signature=8a46dabb63d28d03268e3d3b24b131be565590b7c061f6bdf44768b5f041e752

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=d73ef784b3697333252d152df160f30ffdf540adba64d9d3be75e5d748ec218d
-timestamp=2026-09-08T16:21:43Z
+diff_hash=328cb58911d2c66b4788c9327e31181bd0a296670f3cdf2b7a78e12ef10c81cf
+timestamp=2026-09-08T16:38:55Z
 branch=agent/se396-finish-20260908
-head_commit=6dd0f5d6
-signature=8a46dabb63d28d03268e3d3b24b131be565590b7c061f6bdf44768b5f041e752
+head_commit=67f7d2fd
+signature=0077570769623f6f095ea3601411376d0996f02d2daa1146ff48133db984eedd

--- a/CHANGELOG.d/se396-operational-integrity.md
+++ b/CHANGELOG.d/se396-operational-integrity.md
@@ -5,3 +5,4 @@ section: Fixed
 - **Era 250 · skill discovery**: corrige seis frontmatters YAML inválidos y añade validación global para impedir regresiones de carga.
 - **SE-396 I01**: reserva ejecuciones antes del efecto, evita reejecutar retries ambiguos y confirma journal/liberación en una sola transacción durable.
 - **OpenCode Shield**: ejecuta el gate HTTP local con autenticación, timeout y bloqueo fail-closed; una configuración asíncrona ya no puede degradar el control de autorización.
+- **PR preflight**: conserva el resumen efímero de la PR frente a efectos laterales de la suite Bats antes del gate que lo valida.

--- a/CHANGELOG.d/se396-operational-integrity.md
+++ b/CHANGELOG.d/se396-operational-integrity.md
@@ -1,0 +1,7 @@
+---
+version_bump: patch
+section: Fixed
+---
+- **Era 250 · skill discovery**: corrige seis frontmatters YAML inválidos y añade validación global para impedir regresiones de carga.
+- **SE-396 I01**: reserva ejecuciones antes del efecto, evita reejecutar retries ambiguos y confirma journal/liberación en una sola transacción durable.
+- **OpenCode Shield**: ejecuta el gate HTTP local con autenticación, timeout y bloqueo fail-closed; una configuración asíncrona ya no puede degradar el control de autorización.

--- a/README.en.md
+++ b/README.en.md
@@ -62,6 +62,8 @@ Govern (risk L0-L4, gates, receipts) · execute (agents, commands, skills, SDD) 
 
 Governance (Policy/Risk/Gates) + Execution (Agents/Skills/Tools) + Memory (Context/Knowledge/History) → Evidence/Evals → Frontends + Providers.
 
+CI parses the complete skill catalog as YAML so metadata migrations cannot silently make capabilities disappear at startup.
+
 ## Frontends and providers
 
 Claude Code (SUPPORTED) · OpenCode (SUPPORTED) · Codex (DEGRADED_SAFE, L2 ceiling). Model and provider independence by design.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Frontends (Claude Code, OpenCode, Codex), modelos y proveedores son interfaces e
 
 Savia evoluciona mediante mecanismos explícitos: propuesta/spec → implementación → evaluación → evidencia → enforcement. El cumplimiento de políticas es ejecutable: policy document → machine-readable rule → runtime enforcement → evidence.
 
+El catálogo de skills se valida como YAML completo en CI para impedir que una migración de metadatos deje capacidades invisibles al arrancar.
+
 ## Frontends y proveedores soportados
 
 | Frontend | Estado |

--- a/docs/specs/SE-395-396-luna-roadmap.md
+++ b/docs/specs/SE-395-396-luna-roadmap.md
@@ -1,0 +1,188 @@
+# Handoff Luna — arquitectura, Vaults y roadmap de investigación
+
+Fecha: 2026-09-07. Propuesta para revisión, no modificación de prioridades oficiales.
+Specs: SE-395 y SE-396, ambas PROPOSED. Ejecutor previsto: `gpt-5.6-luna`;
+esto no acredita capacidades del modelo. La instrucción posterior «Implementa»
+autoriza el desarrollo local dentro del alcance y gates establecidos.
+
+## Fuentes y límites
+
+Repositorio auditado: `0c7cd9d104134aab90d627bb9def38e2fd299d4d`.
+SaviaLabs consultado realmente por MCP stdio; servidor negoció versión 0.3.0.
+Lecturas: `INDEX.md`, `labs/ROADMAP.md`, roadmaps L28/L29/L30, resultados L1/L13,
+notebook de ciclo L1–L10, hipótesis L14 e investigaciones L26/L27.
+No se copia contenido privado del dome: sólo conclusiones técnicas minimizadas.
+L15/L16 no localizados en el inventario consultado; no inferir cancelación.
+Índices y roadmaps no están uniformemente actualizados. Esta revisión es una
+síntesis de las líneas disponibles, no validación de cada experimento original.
+
+L1–L10 contienen evaluaciones sintéticas deterministas: un resultado CONFIRMA
+allí no demuestra utilidad operacional general. L13 también requiere ampliar
+evidencia real. L14 identifica deuda estructural; L28 propone integridad,
+verificación y handoff que deben integrarse con SE-391–394, no reconstruirse.
+L17–L22 aparecen entregadas: priorizar mantenimiento/validación antes de rehacer.
+L23 dispone de taxonomías; verificar integración en vez de repetir diseño.
+L26 propone coste/calidad, gates y resiliencia: hipótesis a medir. L27 mantiene
+distancia entre prototipos sintéticos y piloto real autorizado.
+L30 ya tiene fixtures/herramientas: siguiente valor es backtest de decisión real.
+L29 depende de hardware/decisión humana; no compras ni flashing autónomos.
+
+## Orden propuesto por valor y dependencias
+
+| Orden | Trabajo | Justificación/gate |
+|---|---|---|
+| 1 | SE-396 integridad + L14/L28 | Evita duplicación de ejecución y falsa evidencia; desbloquea confianza en todo benchmark |
+| 2 | Fuente única de planning y receipts por AC | Cierre verificable y tareas ejecutables; no nuevo registry |
+| 3 | Sustitución real CLI/proveedor/modelo/dominio; SE-391 cold start | Demostrar rutas existentes L2 sin elevar autoridad |
+| 4 | SE-395 F0–F3 static/shadow/A-B | Ahorro plausible, condicionado a aislamiento y baseline válido |
+| 5 | L26 y evaluaciones reales L1/L4/L6/L13 | Medir coste/calidad utilizando corpus y receipts comunes |
+| 6 | L30 backtest; L27 piloto autorizado | Valor de decisión antes de expandir plataformas |
+| 7 | L24/L25, L12, L29/RBT según demanda; L9 diferida | Necesitan demanda/evidencia o hardware; no expandir por novedad |
+
+No se inventan scores: fórmula canónica V×U/E requiere entradas V/U/E validadas
+que esta auditoría no tiene. Orden cualitativo provisional, no ranking numérico.
+No cambiar prioridades canónicas sin revisión; dependencias de seguridad prevalecen.
+
+## Contrato para cada tarea Luna
+
+WIP=1. Equipo describe roles, no paralelismo obligatorio. Antes de empezar cargar
+spec aprobada, instrucciones del proyecto, estado limpio/propiedad de archivos y
+dependencias. Un slice debe caber normalmente en ≤3 archivos productivos más tests;
+dividir si excede, no recortar acceptance. No elegir arquitectura por conveniencia.
+Cada TASK fija objetivo, archivos permitidos, inputs, outputs, test rojo esperado,
+tests de regresión, criterio STOP, evidencia y rollback reversible.
+Flujo: SPEC/TASK → PLAN → EDIT → TEST → FIX → TEST → VERIFY → RECEIPT.
+Si no hay fallo que corregir, FIX=NOT_NEEDED con evidencia; no fabricar defectos.
+Human gates sólo por criterio/autoridad/scope/efecto externo/riesgo/UNKNOWN.
+No sustituir silenciosamente el modelo solicitado si no está disponible.
+
+## Cola inicial descompuesta
+
+| Slice | Dependencia | Entrega y prueba decisiva |
+|---|---|---|
+| I01 | aprobación SE-396 | Test replay/mismatch y reserva previa en runtime/store; contador execute=1 |
+| I02 | I01 | Refs/capabilities/result correlation; inválido execute=0 |
+| I03 | I01 | Deadline/cancel/crash; efecto ambiguo no se reejecuta automáticamente |
+| I04 | contrato de verificador existente | Observations/preflight estrictos; evidencia inventada/stale/strings rechazada |
+| I05 | I04 | Separación synthetic/operational doctor; `/bin/true` no certifica L2 |
+| I06 | I02/I04 | Receipts correlacionados e inmutables, sin sobrescritura |
+| I07 | aprobación | Validators enums/extensions/timestamps; errores estables |
+| I08 | aprobación | Corpus compartido gates Python/TS; deny/nonzero/malformed equivalentes |
+| I09 | I04/I06 | Manifest closure y digest portable; mutación relevante invalida |
+| V01 | aprobación | Aislamiento grafo MCP por dome; principal ajeno nunca ve nodos |
+| V02 | V01 | Cache policy/revisiones/provenance y límites; revoke invalida hit |
+| P01 | I06 | Planning existente reconoce YAML/omisiones/AC; no cierre por merge |
+| A01 | I01–I09 | Dos adapters reales mismo flujo L2; indisponibilidad NOT_VERIFIED |
+| A02 | A01 | Provider/model resolution explícita y revisión de modelo en evidence |
+| A03 | A01/V01 | Dos domain packs efectivos y aislados, sin dependencia PM global |
+| R00 | aprobación SE-395 | Inventario/research note y contrato preregistrado; sin router aún |
+| R01 | R00/V02 | Dataset etiquetado/congelado y baseline reproducible |
+| R02 | R01 | Guidance schema y selección pura determinista; policy antes de score |
+| R03 | R02/I06 | Shadow sólo baseline, cero llamadas adicionales; receipt contrafactual |
+| R04 | R03 | A/B aislado, adversarial y GO/NO-GO/NEEDS_MORE_EVIDENCE |
+
+Fases pioneer/plasticity/homeostasis/multihop offline no están listas para asignar:
+descomponer sólo si R04 justifica GO y los contratos están revisados. NO-GO detiene
+esa línea sin impedir reparar integridad. No simular PASS de fases diferidas.
+
+## Handoff y stop
+
+Receipt por slice: spec/AC, SHA, diff, comandos y exit codes, tests, tipo de
+evidencia, limitaciones, timestamp, siguiente dependencia. Sin datos privados.
+No confundir ejecución delegada con autoridad delegada. Push, merge, activación,
+datos reales sensibles y nuevos pilotos necesitan autoridad aplicable.
+Al cumplir el slice, persistir receipt y continuar con el siguiente desbloqueado.
+No expandir a L3/L4 ni convertir investigación en capacidad SUPPORTED.
+La siguiente sesión revalida baseline antes de editar.
+
+## Plan de ejecución hasta cierre — ampliación 2026-09-07
+
+Objetivo: completar SE-396 y resolver empíricamente SE-395 hasta su conclusión
+experimental permitida. Un NO-GO justificado cierra una hipótesis; no equivale a
+implementar las fases descartadas. NEEDS_MORE_EVIDENCE deja la fase abierta.
+Las líneas adicionales de Labs son prioridades futuras, fuera de esta ejecución.
+
+### Punto de partida comprobado
+
+I01 tiene un cambio local y dos regresiones nuevas. El turno anterior reportó
+78 tests verdes, pero no demuestra cierre: `Store.acquire()` devuelve el token
+de una reserva existente para la misma sesión/call, por lo que un retry tras
+fallo puede ejecutar de nuevo. Lookup y acquire son transacciones separadas.
+Record y release también: una caída entre ambas puede dejar reserva retenida
+aunque exista resultado. Añadir pruebas de esos límites antes de completar I01.
+No existe evidencia registrada de test rojo previo a ese cambio; la afirmación
+anterior «con TDD» no está sustentada por la secuencia de herramientas.
+
+### Etapas y salidas verificables
+
+| Etapa | Trabajo | Condición para avanzar |
+|---|---|---|
+| E0 Preparar | Preservar cambios y archivos ajenos; aislar rama/worktree; reconciliar instrucciones, lifecycle y mapa AC→task→test | Baseline y propiedad de archivos registrados; ninguna tarea omite aceptación |
+| E1 Integridad | Completar I01–I03: admisión exclusiva durable, identidad/digest, refs/capabilities, correlación, cancel/deadline y recuperación | Replay/concurrencia/crash no duplican ejecución; estado incierto se conserva y recuperación tiene contrato |
+| E2 Evidencia | I04–I09: verificador, doctor, receipts, validators, gates y manifest | Evidencia inventada/sintética/stale no certifica; paridad Python/TS; receipts inmutables |
+| E3 Vaults | V01–V02: grafo/cache por principal/dome, revocación, provenance y budgets | Tests cruzados no exponen datos; cache no pierde fuentes ni evade límites |
+| E4 Sustitución | P01/A01–A03: planning y rutas efectivas frontend/provider/model/domain | Flujos reales equivalentes y límites registrados; ninguna dependencia indisponible se sustituye por PASS simulado |
+| E5 Cold start | Nueva sesión, doctor real, C1–C14, dogfood L2, gates L3/L4 y receipts | Evidencia operacional separada; L2 sin aprobaciones mecánicas; L3 bloquea/pregunta y L4 deniega |
+| E6 Investigación | R00–R04: protocolo, baseline, schema, shadow y A/B | Dataset congelado, adversarial y métricas reproducibles; GO/NO-GO/NEEDS_MORE_EVIDENCE explícito |
+| E7 Experimentos posteriores | R05–R09 abajo, sólo tras GO aplicable | Beneficio incremental por mecanismo, sin violar invariantes |
+| E8 Integración/cierre | Regresión, revisión, PR/CI/merge con autoridad aplicable, comprobación posterior | AC cubiertos, evidence accesible, lifecycle correcto y conclusión experimental documentada |
+
+E1 y E2 pueden intercalar slices independientes; mantener un único escritor.
+E4/E5 bloqueados por herramientas externas no detienen E6 si E2/E3 y su baseline
+ya son válidos. No declarar cierre global mientras falte un gate obligatorio.
+
+### Pruebas decisivas de integridad
+
+Antes de ejecutar: mismo evento simultáneo en dos procesos; mismo event_id con
+payload distinto; distinto event_id con mismo call/request; capability denegada;
+refs ausentes/ajenas. El contador de efectos debe ser 0 o 1 según contrato.
+Durante/después: excepción, resultado inválido, mismatch, cancel, timeout y caída
+en cada frontera de persistencia. Reiniciar Store/runtime y repetir solicitud.
+No liberar reservas por mero paso del tiempo ni afirmar exactly-once ante efectos
+externos inciertos. Completar resultado y estado de reserva de manera coherente.
+Añadir control positivo a cada prueba de denegación: comando que falla por otro
+motivo no demuestra frontera de secretos. Usar datos protegidos de prueba sin
+exponer credenciales reales en logs ni evidence.
+
+### Extensión experimental condicionada
+
+| Slice | Dependencia | Implementar/probar/analizar |
+|---|---|---|
+| R05 Pioneer | R04 GO | Persistencia e invalidación; repeated-query holdout; comparar ahorro y calidad contra static |
+| R06 Branching | R04 GO | Triggers deterministas y budgets; ambiguas/conflictos; medir misses y coste incremental |
+| R07 Plasticidad | R05/R06 GO | Feedback verificable, pesos bounded y decay; poisoning y overfitting; evaluar por exposición |
+| R08 Homeostasis/pruning | R07 GO | Dry-run, dormancy recuperable y lifecycle; ataques de popularidad; comprobar diversidad sin desplazar mandato de policy |
+| R09 Multi-hop offline | Evidencia previa y simulación revisada | Grafo fixture sin red, 2–3 hops; ciclos/explosión/budgets/provenance; ninguna ruta de producción habilitada |
+
+Antes de cada R05–R09 redactar TASK con interfaces exactas, estados/transiciones,
+archivos, fixtures y umbral incremental preregistrado. Usar ablación: añadir un
+mecanismo cada vez. Ante NO-GO conservar la mejor variante anterior y documentar
+qué fases dependientes quedan descartadas. Cambiar umbrales tras ver holdout
+invalida esa evaluación y exige un nuevo holdout antes de afirmar mejora.
+
+### Disciplina de ejecución, análisis y continuidad
+
+Luna realiza una TASK por contexto manejable; no necesita permiso entre comandos
+L0–L2 autorizados. Probar fallo antes del fix cuando se trate de una regresión;
+ejecutar pruebas dirigidas y después las suites afectadas. Repetir sólo si hay
+cambio, fallo o incertidumbre nueva. Cada tarea termina con análisis de AC,
+riesgos residuales y receipt; después seleccionar siguiente dependencia lista.
+Si una tarea falla, diagnosticar y corregir dentro del alcance. Si necesita una
+decisión humana real, persistir diagnóstico y opciones concretas y avanzar trabajo
+independiente. No usar el gate como motivo genérico para abandonar el roadmap.
+Al cambiar de sesión guardar SHA/diff, archivos propios, comandos reproducibles,
+tests pendientes, próximo TASK y blockers; conservar las modificaciones ajenas.
+
+### Cierre operacional y autorización
+
+Preparar cambios revisables y descripciones de PR por bloque coherente; no mezclar
+graduación operacional con fixtures. La orden actual pide un plan: este documento
+no ejecuta publicación. Verificar autoridad aplicable al publicar/mergear.
+Tras merge, registrar SHA y CI del commit integrado. Terminar la sesión que causa
+el defer SE-371; reconciliar AGENTS desde fuente canónica y comprobar generación
+y drift cuando ya sea permitido. E5 debe usar una sesión nueva, nunca afirmar
+cold-start desde la sesión implementadora. Si la interfaz no permite crearlo,
+dejar un handoff ejecutable y marcar ese gate pendiente.
+Entrega final: matriz AC completa, tests/CI, receipts operacionales, benchmark,
+GO/NO-GO por experimento, limitaciones y lifecycle actualizado sin saltos.
+Codex mantiene DEGRADED_SAFE/L2; adaptive default-off y producción one-hop.

--- a/docs/specs/SE-395-vaults-adaptive-connectivity.spec.md
+++ b/docs/specs/SE-395-vaults-adaptive-connectivity.spec.md
@@ -1,0 +1,168 @@
+---
+status: PROPOSED
+priority: P1
+developer_type: agent-team
+created: 2026-09-07
+parent: SE-280
+related_specs: [SE-282, SE-309, SE-396]
+risk: L2
+type: research-and-experiment
+implementation_model: gpt-5.6-luna
+---
+
+# SE-395 — Savia Vaults Adaptive Connectivity
+
+## Estado y alcance
+
+Propuesta reconciliada del diseño aportado por la operadora. Esta entrega sólo
+persiste análisis y contrato; no implementa ni autoriza activación. ID comprobado
+libre en specs locales y planning al redactar; no implica reserva remota.
+Baseline inspeccionado: `0c7cd9d104134aab90d627bb9def38e2fd299d4d`.
+Referencias inequívocas: `projects/savia-vaults/specs/SE-280-savia-vaults.spec.md`,
+`SE-282-savia-federate.spec.md` y `SE-309-knowledge-governance.spec.md` en esa misma
+carpeta. No confundir SE-309 con otra spec homónima del workspace.
+
+Pregunta: ¿puede una topología de acceso adaptativa reducir coste y aumentar
+contexto útil sin degradar recall, provenance, seguridad ni autoridad humana?
+NO-GO es un resultado científico válido. Las mejoras propuestas no están medidas.
+
+## Reconciliación con implementación
+
+- `projects/savia-vaults/src/federation/search.ts`: búsqueda local y remotas
+  saludables en paralelo; merge/dedup/cache existentes. Reutilizar, no duplicar.
+- `src/federation/types.ts`: pesos, tags, salud y attribution existentes; no
+  presupone un contrato completo de policy por consulta.
+- `src/knowledge/{decision,decision-state,conflicts,provenance}.ts`: reutilizar
+  decisiones, estados, conflictos y provenance; no crear otro knowledge graph.
+- El cache observado no incorpora principal/policy/revisión de contenido en su
+  clave; cache hit pierde `sources`. `maxTotalResults` no limita el resultado.
+  Corregir/verificar en SE-396 antes de cualquier canary adaptativo.
+- `src/server/mcp.ts`: selección de instancia por dome y uso de grafo global
+  requieren prueba de aislamiento. Hallazgo estático, no filtración demostrada.
+- Estados documentales PARTIAL/PROPOSED antiguos no prueban ausencia de código
+  ni graduación operacional. Congelar inventario ejecutable en fase 0.
+
+## Contrato no negociable
+
+Policy se evalúa antes de selección observable, cache, scoring y traversal; se
+reevalúa al ejecutar ante cambios de policy. DENY nunca es un peso negativo.
+CAN_ROUTE != CAN_ACCESS != AUTHORITY. Popularidad, frecuencia, learned_weight y
+success no son trust ni verdad. Conflictos permanecen hasta resolución gobernada.
+No reescribir conocimiento, provenance, decision states, permisos o confidencialidad.
+Prune route != delete knowledge. No secretos en cues, métricas ni receipts.
+Producción conserva máximo un salto federado. Waypoints internos no autorizan
+relay remoto; simulación multi-hop usa únicamente fixtures offline.
+Fallo adaptativo vuelve a federación existente con policy y presupuesto restante;
+si no puede garantizar ambos, termina sin expansión, no hace broadcast ilimitado.
+
+## Modelo experimental
+
+Router deterministic-first, sin LLM obligatorio: intent explícito, metadata,
+BM25, relaciones existentes, freshness y utilidad observada. Embeddings sólo si
+ya existen. Desempate estable por ID; reloj y semilla inyectables en benchmark.
+Cues versionados: attracts/repels/specialties; schema acotado, finite scores,
+límites de tamaño y rechazo de campos desconocidos. Metadata remota es no confiable.
+Trust/confidentiality son referencias gobernadas, no autoafirmaciones del destino.
+
+KnowledgeEdge: source/target, intents, configured_weight, learned_weight,
+success/failure/useful/traversal counters, timestamps, state, evidenceRefs.
+Estados DISCOVERY/ACTIVE/WEAK/DORMANT/BLOCKED; BLOCKED sólo por policy autorizada.
+Learned weight acotado inicialmente a 0.30, separado de peso configurado; nunca
+reactiva BLOCKED. Decay sólo de evidencia operacional, no de autoridad/trust.
+Pruning ACTIVE→WEAK→DORMANT conserva historia y es dry-run por defecto.
+
+PioneerRoute guarda conectividad útil, no respuestas. KnowledgeTract añade
+intentPattern, orderedTargets, uses, successRate, evidenceRefs y estados
+CANDIDATE/CALIBRATING/STABLE/DEGRADED/DORMANT. STABLE requiere calidad verificada
+en holdout y diversidad de casos, no sólo usos; tampoco significa TRUSTED.
+Invalidar ante cambios de policy, trust, confidencialidad, targets, contenido,
+conflictos o versión del router. Claves incluyen revisiones relevantes.
+
+Branch por evidencia insuficiente, conflicto, consulta multidominio, provenance
+faltante o mandato de segunda fuente; suficiencia usa reglas congeladas y
+evidencia independiente, no confianza autorreportada de un LLM.
+Reforzar utilidad verificada, no consulta/citación por sí sola; feedback no
+autenticado no actualiza pesos. Conflicto encontrado no es fallo de ruta.
+Homeostasis mide concentración/diversidad/utilidad normalizada por exposición;
+explora sólo alternativas autorizadas, sin desplazar fuentes obligatorias.
+Lifecycle de nuevo vault DISCOVERY/CALIBRATING/STABLE separado del trust.
+Controller propone ajustes/poda/orphans/ciclos; nunca modifica policy.
+
+## Configuración y almacenamiento
+
+Flags adaptive, pioneer, plasticity y exploration: false. Nunca activar al merge.
+Perfil de benchmark inicial: maxVaults=3, maxRemoteCalls=3, maxBranches=2,
+maxLatencyMs=3000, maxContextTokens=4096; definir branches como destinos adicionales
+al primario. Producción maxHops=1; simulación maxHops=3. Exploración futura 0.05,
+desactivada; budgets cuentan intentos, retries y fallback conjuntamente.
+Terminations: ANSWER_SUFFICIENT/BUDGET_EXHAUSTED/POLICY_BLOCK/NO_ROUTE/CONFLICT/
+TIMEOUT/UNKNOWN. Cancelar trabajo pendiente al vencer presupuesto.
+Reutilizar storage local existente: grafo gobernado versionable separado de
+telemetría agregada; no commit por lookup. Si exige nuevo storage, human gate.
+Desactivar flag restaura baseline sin migración destructiva ni learned influence.
+
+## Experimentos y medición preregistrada
+
+F0 inventario + research note: patrón biológico → abstracción y límites. La
+analogía no está validada científicamente en esta entrega; contrastar fuentes
+primarias antes de atribuir mecanismos. No afirmar equivalencia cerebral.
+F1 baseline reproducible; F2 static guidance + shadow; F3 A/B independiente;
+F4 pioneer + branching; F5 bounded learning; F6 pruning/homeostasis/critical period;
+F7 simulación multi-hop. Cada fase termina GO/NO-GO/NEEDS_MORE_EVIDENCE.
+No avanzar por el mero hecho de haber implementado la anterior.
+
+Dataset inicial mínimo 180 consultas, ≥20 por estrato: monodominio, cross-domain,
+ambiguas, conflictivas, stale, restringidas, unhealthy, repetidas, nuevas.
+Añadir casos donde baseline gana y casos realistas sanitizados autorizados;
+fixtures favorables exclusivamente no bastan. Separar train/calibration/test por
+familia de intención; congelar hash, etiquetas y umbrales antes del test final.
+Relevancia, utilidad y provenance etiquetadas independientemente del router.
+Comparar mismo snapshot, k, tokenizer y condiciones cold/warm cache. Registrar
+recall@k, precision@k, MRR/NDCG, consultas/intentos, llamadas remotas, p50/p95,
+tokens, duplicados, conflictos y useful_context_tokens/retrieved_context_tokens.
+Denominador cero: N/A, no mejora ficticia. No mezclar tokens reales y proxies.
+
+Gate propuesto: ≥30% menos consultas remotas, ≥25% menos contexto irrelevante,
+recall delta ≥−0.02 absoluto, provenance ≥baseline, cero bypass/exposición,
+p95 ≤baseline y useful-context-density ≥1.20×baseline. Usar intervalo pareado
+95% para recall no inferior; muestra insuficiente → NEEDS_MORE_EVIDENCE.
+Documentar cualquier cambio de protocolo antes de consultar holdout.
+Shadow ejecuta sólo baseline: selección y coste contrafactual son estimaciones,
+no ahorro/latencia challenger demostrados. A/B real usa transporte local aislado
+y corpus congelado; canary con destinos reales requiere autorización aplicable.
+
+## Seguridad, explicabilidad y evidencia
+
+Suite adversarial: specialty=everything; trust bajo/peso alto; metadata falsa;
+BLOCKED con successes históricos; query sensible; ciclo; branch explosion;
+empates; ruta stale; conflicto oculto; popularity attack; unhealthy dominante;
+tags envenenados; elevación de confidencialidad; retrieval jamás utilizado.
+Además: aislamiento entre principales/domes en cache/grafo, cambio de policy
+entre selección y ejecución, fallos/timeouts y fallback con presupuesto agotado.
+Probar invariantes de autoridad, one-hop, provenance, apagado y no borrado.
+
+Receipt versionado, integrado con evidencia existente: opaque query_id, versión,
+config/dataset hashes, visited/skipped/reasons autorizados, presupuesto consumido,
+terminación, fuente original y tipo de evidencia. Hash de query NO anonimiza;
+preferir ID opaco, o HMAC mediante mecanismo existente aprobado. Nunca credenciales,
+query íntegra o nombres de vaults prohibidos en explicaciones al llamante.
+Métricas sin labels de alta cardinalidad ni contenido. Explain determinista
+"why this/why not" sujeto a permisos; inspección CLI es adaptador, no core.
+Prune CLI sólo dry-run; simulador incapaz de abrir red.
+
+## Acceptance y handoff Luna
+
+AC01–06: baseline/schema/policy-before-score/attraction-repulsion/subset/fallback.
+AC07–12: pioneer auditable sin respuesta obligatoria/pesos separados/no elevación/
+no borrado/dormancy con provenance. AC13–16: budgets/one-hop/receipts/explain.
+AC17–20: A/B reproducible/coste+calidad/adversarial/apagado sin regresión.
+Cada AC debe tener test y receipt; fases diferidas no se marcan PASS anticipadamente.
+Research DoD: F0–F3, dataset congelado, tests, benchmark, recomendación y revisión
+humana. Full experimental DoD añade F4–F7 y justificación complejidad/valor.
+Estado permanece PROPOSED; consultar lifecycle canónico antes de iniciar código.
+Paquete: SHA, timestamp, config, dataset hash, outputs sanitizados, métricas,
+distribuciones, receipts, tests, limitaciones y decisión humana.
+
+Luna ejecutará slices y gates de `SE-395-396-luna-roadmap.md`, WIP=1. Decisiones
+no determinadas, nuevo storage/cloud/LLM obligatorio, cambio de autoridad/trust,
+default-on, multihop real o efectos externos → NEEDS_HUMAN_DECISION.

--- a/docs/specs/SE-396-harness-operational-integrity.spec.md
+++ b/docs/specs/SE-396-harness-operational-integrity.spec.md
@@ -1,0 +1,97 @@
+---
+status: PROPOSED
+priority: P1
+developer_type: agent-team
+created: 2026-09-07
+related_specs: [SE-391, SE-393, SE-394, SE-395]
+risk: L2
+implementation_model: gpt-5.6-luna
+---
+
+# SE-396 — Harness agnóstico: integridad operacional y sustitución verificable
+
+## Auditoría y valoración
+
+Baseline: `0c7cd9d104134aab90d627bb9def38e2fd299d4d`, post-SE-394.
+Auditoría local de código, reproducciones acotadas y consulta MCP a SaviaLabs;
+no auditoría exhaustiva ni validación cold-start. No código cambiado aquí.
+Valoración: contratos de separación útiles, pero agnosticismo operacional parcial.
+Prioridad: ejecución/evidencia fiable antes de nuevas abstracciones o capacidades.
+No promover Codex de DEGRADED_SAFE ni superar L2 por esta spec.
+
+## Avance implementado
+
+Esta entrega cubre únicamente la base de H01 y la ruta HTTP local de H07. El
+runtime reserva antes de invocar el adapter, reproduce eventos ya confirmados,
+conserva como ambigua una ejecución interrumpida y confirma journal/liberación
+en una sola transacción. El bridge de OpenCode ejecuta el Shield HTTP local con
+token, timeout y semántica fail-closed, incluso si se configura como asíncrono.
+Los demás hallazgos continúan abiertos; este avance no completa ni aprueba la
+spec, no cambia el nivel de autonomía y requiere los gates y revisión habituales.
+
+Mejoras existentes que se conservan: puertos de adapter, filtrado de proveedor
+desconocido con prefijo, resolución de dependencias/ciclos de domain packs,
+manifest ampliado y bloqueo de configuración de hooks ausente/corrupta.
+
+## Hallazgos y aceptación requerida
+
+| ID | Evidencia y gap | Reparación/criterio de aceptación |
+|---|---|---|
+| H01 | `scripts/dual-cli/runtime.py:handle` ejecuta adapter antes de `Store.record`; no lease previo | Reservar/deduplicar antes de ejecutar. Replay idéntico no vuelve a invocar adapter; payload distinto con mismo ID rechaza. Crash no reejecuta efecto ambiguo automáticamente |
+| H02 | Mismo flujo omite refs/capabilities reales; acepta result request_id ajeno | Resolver refs autorizadas, intersectar capabilities, validar correlación y policy antes de execute; rechazo sin efectos |
+| H03 | `contracts.py:verify_observation` acepta lookup con verified=True; preflight permite observaciones vacías y truthiness de strings | Validación estricta de booleanos, procedencia, subject, versión, environment, digest y vigencia; ausencia/untrusted/stale nunca certifica |
+| H04 | `codex_profile.py` acepta SAVIA_CODEX_TEST_MODE y probes `/bin/true` como éxito L2 | Fixtures aisladas de graduación/configuración; receipts SYNTHETIC no pueden ser evidencia operacional; doctor real con controles positivos y negativos |
+| H05 | `autonomy.py:write_receipt` no correlaciona request/execution y sobrescribe destino | Validar y correlacionar antes de persistir; append/identidad inmutable, replay idempotente y mismatch rechazado |
+| H06 | `contracts.py` enums con listas lanzan TypeError; usage.extensions admitido y después rechazado | Todo input inválido produce ProtocolError estable; extensiones y timestamps cumplen contrato probado |
+| H07 | `scripts/opencode-plugin/savia-gates/lib/shell-bridge.ts` sólo bloquea exit2/decision:block | Paridad Python/TS en nonzero, malformed JSON, continue:false, deny/ask; hooks de seguridad no fire-and-forget |
+| H08 | `config.py:build_manifest` omite ejecutores/validators relevantes | Closure de archivos y policies efectiva; cambio relevante invalida evidencia; hash estable entre checkouts equivalentes |
+| H09 | `savia-bridge.py` exige Claude; gateway/resolver/routing aún separados | Cablear rutas existentes al contrato común, no otro gateway. Dos adapters reales prueban mismo flujo; sin CLI/proveedor forzado en core |
+| H10 | Domain packs resuelven pero no se observó consumidor productivo de composición | Composición/precedencia/aislamiento explícitos; pruebas de dos dominios independientes sin reglas PM globales forzadas |
+| H11 | planning-state omite specs recientes; validator PASS no detecta YAML/omisiones | Reconciliar autoridad SE-378 existente, validar status YAML y evidencia AC; merge no equivale a graduación |
+| H12 | Vaults cache sin principal/policy/revisión; grafo MCP global pese a selección de dome | Tests adversariales por dome/principal; cache con provenance y límites; condición previa a canary SE-395 |
+
+## Reproducciones de esta auditoría
+
+R1: adapter de fixture anuncia `read`; evento exige capability no anunciada y
+refs inexistentes. Dos dispatch iguales ejecutaron dos veces, sin lease; ambos
+aceptaron resultado con otro request_id. Es el camino Python con adapter inyectado:
+el daemon por defecto sin adapters registrados no demuestra explotación desplegada.
+R2: observation de 2000 con subject/environment ajenos y ref inventada aceptada
+mediante mapping verified=True. Preflight con strings `"false"` en checks,
+observaciones vacías y certified=True devolvió certified=True sin gaps.
+R3: `SAVIA_CODEX_TEST_MODE=1`, PATH mínimo y probes `/bin/true` devolvieron PASS/L2
+sin probar instalación/auth/sandbox reales. CI sintética no equivale a doctor real.
+R4: writer persistió request A/execution B y posterior llamada sobrescribió receipt.
+R5: enum lista provocó TypeError; usage.extensions objeto provocó rechazo.
+R6: manifest real no incluía codex_profile.py, autonomy.py, state.py, protocol.py,
+domain_packs.py ni config.py. H07/H09/H10/H12 son inspección estática: requieren
+regresión ejecutable antes de afirmar impacto real. No se intentó leer secretos.
+Los 9 tests de harness contracts ejecutados pasaron: cobertura existente no detecta
+estos casos. No se ejecutó CI completa ni doctor/canaries reales en esta auditoría.
+
+## Contrato de implementación
+
+Reutilizar Store/protocol/adapters/contracts/receipts/registry existentes. No crear
+segunda verdad, permisos nuevos ni sistema paralelo de evidencia. Runtime debe
+negociar schema, aplicar deadlines/cancel y no confundir cancel solicitado con
+efecto cancelado. No prometer exactly-once ante caída tras efecto externo: conservar
+estado incierto y exigir reconciliación humana cuando corresponda.
+Evidence distingue UNIT/SYNTHETIC/INTEGRATION/OPERATIONAL; flags del caller no
+conceden confianza. Elegir autoridad verificadora existente tras inventario;
+si no existe contrato autorizado suficiente, STOP y decisión humana.
+Pruebas de sustitución separan frontend, proveedor, modelo y dominio; ausencia
+de instalación/autorización → NOT_VERIFIED, nunca PASS con mocks.
+Manifest debe cubrir configuración efectiva sin copiar secretos a evidence.
+
+## Plan, límites y Definition of Done
+
+Orden H01–H08 y H12 → H11 → H09–H10 → evidencia operacional. Detalle de slices
+en `SE-395-396-luna-roadmap.md`. Cada slice: test rojo → mínimo cambio → tests
+dirigidos → regresión/lint → receipt. Revisor humano conserva decisiones.
+AC: todos los hallazgos cuentan con regresión; paridad de gates; replay/cancel/
+crash/mismatch seguros; evidencia no falsificable por self-assertion; aislamiento
+de dominio; sustitución real documentada o limitaciones explícitas sin cierre total.
+CI verde y revisión requerida antes del cierre; seguir lifecycle canónico.
+La spec por sí sola no autoriza publicación, push ni merge; esas operaciones
+requieren la autoridad externa correspondiente. AGENTS.md sigue protocolo
+SE-371; no regenerar durante una sesión que provoca defer.

--- a/scripts/dual-cli/runtime.py
+++ b/scripts/dual-cli/runtime.py
@@ -61,6 +61,11 @@ class Runtime:
         consumer = next(c for c in status["consumers"] if c["session_id"] == session)
         if event["revision"] != status["revision"] or consumer["revision"] != status["revision"]:
             raise ProtocolError("STALE_REVISION")
+        prior = self.store.prior_record(event)
+        if prior is not None:
+            sequence, decision = prior
+            decision["sequence"] = sequence
+            return decision
         payload = event.get("payload")
         if isinstance(payload, dict) and payload.get("schema") == 2:
             adapter = self.adapters.get(payload.get("adapter_id"))
@@ -70,8 +75,17 @@ class Runtime:
             context = {"request_id": request["request_id"], "capability_id": request["capability_id"]}
             if adapter.preflight(context).get("ok") is not True:
                 raise ProtocolError("UNSUPPORTED_CAPABILITY")
+            lease, replay = self.store.admit(
+                event, session, event["revision"], event["call_id"]
+            )
+            if replay is not None:
+                sequence, decision = replay
+                decision["sequence"] = sequence
+                return decision
             result = execution_result(adapter.execute(request))
-            result["sequence"] = self.store.record(event, result)
+            if result["request_id"] != request["request_id"]:
+                raise ProtocolError("INCONSISTENT_RESULT")
+            result["sequence"] = self.store.complete(event, result, session, lease)
             return result
         result = {"action": "deny", "reason": "UNSUPPORTED_CAPABILITY",
                   "revision": status["revision"], "context": None,

--- a/scripts/dual-cli/state.py
+++ b/scripts/dual-cli/state.py
@@ -5,6 +5,7 @@ all writers have finished before invoking it. It is not exposed over a socket.
 """
 from contextlib import contextmanager
 import hashlib
+import json
 import os
 from pathlib import Path
 import secrets
@@ -29,6 +30,11 @@ class Store:
             db.execute("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)")
             db.execute("CREATE TABLE IF NOT EXISTS consumers (session TEXT PRIMARY KEY, revision TEXT)")
             db.execute("CREATE TABLE IF NOT EXISTS lease (slot INTEGER PRIMARY KEY CHECK(slot=1), session TEXT, call TEXT, token TEXT)")
+            columns = {row[1] for row in db.execute("PRAGMA table_info(lease)")}
+            if "event_id" not in columns:
+                db.execute("ALTER TABLE lease ADD COLUMN event_id TEXT")
+            if "digest" not in columns:
+                db.execute("ALTER TABLE lease ADD COLUMN digest TEXT")
             db.execute("CREATE TABLE IF NOT EXISTS completed (session TEXT, call TEXT, PRIMARY KEY(session, call))")
             db.execute("CREATE TABLE IF NOT EXISTS journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT UNIQUE, digest TEXT, decision TEXT)")
             db.execute("INSERT OR IGNORE INTO meta VALUES ('repo', ?)", (self.repo_id,))
@@ -93,7 +99,10 @@ class Store:
                     return held[2]
                 raise ProtocolError("CONFLICT")
             token = secrets.token_hex(32)
-            db.execute("INSERT INTO lease VALUES (1, ?, ?, ?)", (session, call, token))
+            db.execute(
+                "INSERT INTO lease(slot, session, call, token) VALUES (1, ?, ?, ?)",
+                (session, call, token),
+            )
             return token
 
     def release(self, session, token):
@@ -103,6 +112,96 @@ class Store:
                 raise ProtocolError("CONFLICT")
             db.execute("INSERT INTO completed VALUES (?, ?)", (session, held[0]))
             db.execute("DELETE FROM lease WHERE session=? AND token=?", (session, token))
+
+    def admit(self, event, session, revision, call):
+        """Atomically replay a committed event or reserve a new execution.
+
+        A matching live reservation is deliberately not reusable: execution may
+        already have produced an external effect, so only explicit reconciliation
+        may clear it.
+        """
+        identifier(call)
+        if event["repo_id"] != self.repo_id:
+            raise ProtocolError("UNTRUSTED")
+        digest = hashlib.sha256(canonical(event).encode()).hexdigest()
+        with self.connection() as db:
+            consumer = db.execute(
+                "SELECT revision FROM consumers WHERE session=?", (session,)
+            ).fetchone()
+            if not consumer:
+                raise ProtocolError("UNTRUSTED")
+            if not revision or self.revision(db) != revision or consumer[0] != revision:
+                raise ProtocolError("STALE_REVISION")
+            old = db.execute(
+                "SELECT sequence, digest, decision FROM journal WHERE event_id=?",
+                (event["event_id"],),
+            ).fetchone()
+            if old:
+                if old[1] != digest:
+                    raise ProtocolError("CONFLICT")
+                return None, (old[0], json.loads(old[2]))
+            held = db.execute(
+                "SELECT session, call, event_id, digest FROM lease"
+            ).fetchone()
+            if held:
+                if held[2] == event["event_id"] and held[3] not in (None, digest):
+                    raise ProtocolError("CONFLICT")
+                raise ProtocolError("AMBIGUOUS_EXECUTION")
+            if db.execute(
+                "SELECT 1 FROM completed WHERE session=? AND call=?", (session, call)
+            ).fetchone():
+                raise ProtocolError("CONFLICT")
+            token = secrets.token_hex(32)
+            db.execute(
+                "INSERT INTO lease(slot, session, call, token, event_id, digest) "
+                "VALUES (1, ?, ?, ?, ?, ?)",
+                (session, call, token, event["event_id"], digest),
+            )
+            return token, None
+
+    def complete(self, event, decision, session, token):
+        """Commit the decision and release its reservation atomically."""
+        if event["repo_id"] != self.repo_id:
+            raise ProtocolError("UNTRUSTED")
+        digest = hashlib.sha256(canonical(event).encode()).hexdigest()
+        serialized = canonical(decision)
+        with self.connection() as db:
+            held = db.execute(
+                "SELECT call, event_id, digest FROM lease "
+                "WHERE session=? AND token=?", (session, token)
+            ).fetchone()
+            if not held or held[1:] != (event["event_id"], digest):
+                raise ProtocolError("CONFLICT")
+            old = db.execute(
+                "SELECT sequence, digest, decision FROM journal WHERE event_id=?",
+                (event["event_id"],),
+            ).fetchone()
+            if old:
+                if old[1:] != (digest, serialized):
+                    raise ProtocolError("CONFLICT")
+                sequence = old[0]
+            else:
+                sequence = db.execute(
+                    "INSERT INTO journal(event_id, digest, decision) VALUES (?, ?, ?)",
+                    (event["event_id"], digest, serialized),
+                ).lastrowid
+            db.execute("INSERT INTO completed VALUES (?, ?)", (session, held[0]))
+            db.execute("DELETE FROM lease WHERE session=? AND token=?", (session, token))
+            return sequence
+
+    def prior_record(self, event):
+        """Return a previously committed decision for an identical event."""
+        if event["repo_id"] != self.repo_id:
+            raise ProtocolError("UNTRUSTED")
+        digest = hashlib.sha256(canonical(event).encode()).hexdigest()
+        with self.connection() as db:
+            row = db.execute("SELECT sequence, digest, decision FROM journal WHERE event_id=?",
+                             (event["event_id"],)).fetchone()
+            if not row:
+                return None
+            if row[1] != digest:
+                raise ProtocolError("CONFLICT")
+            return row[0], json.loads(row[2])
 
     def close_session(self, session):
         with self.connection() as db:

--- a/scripts/opencode-plugin/savia-gates/__tests__/http-gate.test.ts
+++ b/scripts/opencode-plugin/savia-gates/__tests__/http-gate.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, expect, test } from "bun:test"
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createServer, type Server } from "node:http"
+import { loadHookMap, runHooksForEvent } from "../lib/shell-bridge"
+
+const roots: string[] = []
+const servers: Server[] = []
+const envNames: string[] = []
+
+afterEach(async () => {
+  for (const name of envNames.splice(0)) delete process.env[name]
+  for (const server of servers.splice(0)) {
+    server.closeAllConnections?.()
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function listen(
+  responder: (request: import("node:http").IncomingMessage, response: import("node:http").ServerResponse) => void,
+): Promise<{ server: Server; url: string }> {
+  const server = createServer(responder)
+  servers.push(server)
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const address = server.address()
+  if (!address || typeof address === "string") throw new Error("test server has no TCP address")
+  return { server, url: `http://127.0.0.1:${address.port}/gate` }
+}
+
+async function projectWithHook(hook: Record<string, unknown>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "savia-http-gate-test-"))
+  roots.push(root)
+  await mkdir(join(root, ".claude"))
+  await writeFile(join(root, ".claude", "settings.json"), JSON.stringify({
+    hooks: { PreToolUse: [{ matcher: "Edit|Write", hooks: [hook] }] },
+  }))
+  return root
+}
+
+function httpHook(url: string, tokenEnv: string, timeout = 1): Record<string, unknown> {
+  return {
+    type: "http",
+    url,
+    headers: { "X-Shield-Token": `$${tokenEnv}` },
+    allowedEnvVars: [tokenEnv],
+    timeout,
+  }
+}
+
+async function run(root: string) {
+  const hookMap = await loadHookMap(root)
+  const payload = JSON.stringify({
+    hook_event_name: "PreToolUse",
+    tool_name: "Edit",
+    tool_input: { file_path: "src/example.ts", new_string: "safe content" },
+  })
+  return {
+    hookMap,
+    payload,
+    result: await runHooksForEvent(root, hookMap, "PreToolUse", "Edit", payload),
+  }
+}
+
+function token(name: string): string {
+  const value = `secret-${name}`
+  process.env[name] = value
+  envNames.push(name)
+  return value
+}
+
+test("HTTP Shield ALLOW passes and receives the original hook_input with auth", async () => {
+  const expectedToken = token("P02_ALLOW_TOKEN")
+  let receivedBody = ""
+  let receivedToken: string | undefined
+  const { url } = await listen((request, response) => {
+    receivedToken = request.headers["x-shield-token"] as string | undefined
+    request.on("data", (chunk) => { receivedBody += chunk })
+    request.on("end", () => {
+      response.writeHead(200, { "Content-Type": "application/json" })
+      response.end(JSON.stringify({ verdict: "ALLOW" }))
+    })
+  })
+  const root = await projectWithHook(httpHook(url, "P02_ALLOW_TOKEN"))
+
+  const { hookMap, payload, result } = await run(root)
+
+  expect(hookMap.PreToolUse[0].type).toBe("http")
+  expect(result.blocked).toBe(false)
+  expect(receivedBody).toBe(payload)
+  expect(receivedToken).toBe(expectedToken)
+})
+
+test("HTTP Shield explicit BLOCK blocks", async () => {
+  token("P02_BLOCK_TOKEN")
+  const { url } = await listen((_request, response) => {
+    response.writeHead(200, { "Content-Type": "application/json" })
+    response.end(JSON.stringify({ verdict: "BLOCK" }))
+  })
+  const root = await projectWithHook(httpHook(url, "P02_BLOCK_TOKEN"))
+
+  expect((await run(root)).result).toMatchObject({ blocked: true, stderr: "HTTP_GATE_BLOCK" })
+})
+
+test("HTTP Shield cannot be downgraded to fire-and-forget", async () => {
+  token("P02_ASYNC_TOKEN")
+  const { url } = await listen((_request, response) => {
+    response.writeHead(200, { "Content-Type": "application/json" })
+    response.end(JSON.stringify({ verdict: "BLOCK" }))
+  })
+  const root = await projectWithHook({
+    ...httpHook(url, "P02_ASYNC_TOKEN"),
+    async: true,
+  })
+
+  const { hookMap, result } = await run(root)
+
+  expect(hookMap.PreToolUse[0].async).toBe(false)
+  expect(result).toMatchObject({ blocked: true, stderr: "HTTP_GATE_BLOCK" })
+})
+
+test("HTTP Shield daemon down blocks", async () => {
+  token("P02_DOWN_TOKEN")
+  const { server, url } = await listen(() => {})
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+  servers.splice(servers.indexOf(server), 1)
+  const root = await projectWithHook(httpHook(url, "P02_DOWN_TOKEN", 0.1))
+
+  expect((await run(root)).result).toMatchObject({ blocked: true, stderr: "HTTP_GATE_UNREACHABLE" })
+})
+
+test("HTTP Shield timeout blocks with a typed reason", async () => {
+  token("P02_TIMEOUT_TOKEN")
+  const { url } = await listen(() => {})
+  const root = await projectWithHook(httpHook(url, "P02_TIMEOUT_TOKEN", 0.02))
+
+  expect((await run(root)).result).toMatchObject({ blocked: true, stderr: "HTTP_GATE_TIMEOUT" })
+})
+
+for (const status of [403, 500]) {
+  test(`HTTP Shield status ${status} blocks`, async () => {
+    token(`P02_STATUS_${status}_TOKEN`)
+    const { url } = await listen((_request, response) => {
+      response.writeHead(status, { "Content-Type": "application/json" })
+      response.end(JSON.stringify({ verdict: "ALLOW" }))
+    })
+    const root = await projectWithHook(httpHook(url, `P02_STATUS_${status}_TOKEN`))
+
+    expect((await run(root)).result).toMatchObject({ blocked: true, stderr: `HTTP_GATE_STATUS_${status}` })
+  })
+}
+
+test("HTTP Shield invalid JSON blocks", async () => {
+  token("P02_INVALID_TOKEN")
+  const { url } = await listen((_request, response) => {
+    response.writeHead(200, { "Content-Type": "application/json" })
+    response.end("not-json")
+  })
+  const root = await projectWithHook(httpHook(url, "P02_INVALID_TOKEN"))
+
+  expect((await run(root)).result).toMatchObject({ blocked: true, stderr: "HTTP_GATE_INVALID_RESPONSE" })
+})
+
+test("HTTP Shield unknown verdict blocks", async () => {
+  token("P02_UNKNOWN_TOKEN")
+  const { url } = await listen((_request, response) => {
+    response.writeHead(200, { "Content-Type": "application/json" })
+    response.end(JSON.stringify({ verdict: "MAYBE" }))
+  })
+  const root = await projectWithHook(httpHook(url, "P02_UNKNOWN_TOKEN"))
+
+  expect((await run(root)).result).toMatchObject({ blocked: true, stderr: "HTTP_GATE_UNKNOWN_VERDICT" })
+})
+
+test("HTTP Shield redirect blocks without contacting the destination", async () => {
+  token("P02_REDIRECT_TOKEN")
+  let destinationRequests = 0
+  const destination = await listen((_request, response) => {
+    destinationRequests++
+    response.writeHead(200, { "Content-Type": "application/json" })
+    response.end(JSON.stringify({ verdict: "ALLOW" }))
+  })
+  const source = await listen((_request, response) => {
+    response.writeHead(302, { Location: destination.url })
+    response.end()
+  })
+  const root = await projectWithHook(httpHook(source.url, "P02_REDIRECT_TOKEN"))
+
+  const result = (await run(root)).result
+
+  expect(result.blocked).toBe(true)
+  expect(["HTTP_GATE_UNREACHABLE", "HTTP_GATE_STATUS_0"]).toContain(result.stderr)
+  expect(destinationRequests).toBe(0)
+})
+
+test("HTTP Shield missing token blocks before sending an invented credential", async () => {
+  let requests = 0
+  let receivedToken: string | undefined
+  const { url } = await listen((request, response) => {
+    requests++
+    receivedToken = request.headers["x-shield-token"] as string | undefined
+    response.writeHead(200, { "Content-Type": "application/json" })
+    response.end(JSON.stringify({ verdict: "ALLOW" }))
+  })
+  const root = await projectWithHook(httpHook(url, "P02_MISSING_TOKEN"))
+
+  const result = (await run(root)).result
+
+  expect(result).toMatchObject({ blocked: true, stderr: "HTTP_GATE_MISSING_TOKEN" })
+  expect(requests).toBe(0)
+  expect(receivedToken).toBeUndefined()
+})
+
+test("HTTP Shield token never appears in captured output or result", async () => {
+  const expectedToken = token("P02_LEAK_TOKEN")
+  const { url } = await listen((_request, response) => {
+    response.writeHead(403, { "Content-Type": "application/json" })
+    response.end(JSON.stringify({ error: expectedToken }))
+  })
+  const root = await projectWithHook(httpHook(url, "P02_LEAK_TOKEN"))
+  let capturedStdout = ""
+  let capturedStderr = ""
+  const stdoutWrite = process.stdout.write
+  const stderrWrite = process.stderr.write
+  process.stdout.write = ((chunk: unknown) => { capturedStdout += String(chunk); return true }) as typeof process.stdout.write
+  process.stderr.write = ((chunk: unknown) => { capturedStderr += String(chunk); return true }) as typeof process.stderr.write
+  let result
+  try {
+    result = (await run(root)).result
+  } finally {
+    process.stdout.write = stdoutWrite
+    process.stderr.write = stderrWrite
+  }
+
+  expect(`${capturedStdout}${capturedStderr}${JSON.stringify(result)}`).not.toContain(expectedToken)
+})
+
+test("unsupported synchronous hook remains fail-closed", async () => {
+  const root = await projectWithHook({ type: "unknown-critical-type" })
+
+  expect((await run(root)).result).toMatchObject({ blocked: true, stderr: "UNSUPPORTED_CRITICAL_HOOK" })
+})
+
+test("HTTP hooks outside the local Shield boundary remain unsupported and fail-closed", async () => {
+  const root = await projectWithHook(httpHook("http://example.invalid/gate", "P02_EXTERNAL_TOKEN"))
+
+  expect((await run(root)).result).toMatchObject({ blocked: true, stderr: "UNSUPPORTED_CRITICAL_HOOK" })
+})
+
+test("command hook exit 0 regression passes", async () => {
+  const root = await projectWithHook({ type: "command", command: "exit 0" })
+
+  expect((await run(root)).result.blocked).toBe(false)
+})
+
+test("command hook hard-block exit regression blocks", async () => {
+  const root = await projectWithHook({ type: "command", command: "exit 2" })
+
+  expect((await run(root)).result.blocked).toBe(true)
+})

--- a/scripts/opencode-plugin/savia-gates/lib/manifest.ts
+++ b/scripts/opencode-plugin/savia-gates/lib/manifest.ts
@@ -47,6 +47,9 @@ export async function writeManifest(hookMap: HookMap): Promise<void> {
     const eventHandlers = HANDLERS[event]
     if (!eventHandlers) continue
     for (const e of entries) {
+      // The parity inventory compares command hook basenames. HTTP Shield
+      // hooks have no command basename and are exercised by runtime tests.
+      if (e.type !== "command") continue
       // Extract the .sh basename the same way opencode-parity-audit.sh does
       // (regex over the command path), so manifest claudeHook matches the CC
       // binding even when the command carries args like "$CLAUDE_JSON_INPUT".

--- a/scripts/opencode-plugin/savia-gates/lib/shell-bridge.ts
+++ b/scripts/opencode-plugin/savia-gates/lib/shell-bridge.ts
@@ -1,4 +1,5 @@
-// shell-bridge.ts — runs Claude Code bash hooks from OpenCode plugin
+// shell-bridge.ts — runs Claude Code command hooks and the local HTTP Shield
+// gate from the OpenCode plugin
 //
 // Reads .claude/settings.json once, builds an event → hook[] map keyed by
 // the same matcher Claude Code uses (tool name regex / glob), then on each
@@ -10,14 +11,29 @@ import { readFile, readdir, readlink, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { auditLog } from "./audit"
 
-export interface HookEntry {
-  command: string         // resolved absolute path of the .sh
+interface HookEntryBase {
   matcher?: string         // optional matcher (tool name regex)
   timeout?: number
   async?: boolean
   declared_event: string  // SessionStart / PreToolUse / etc.
-  unsupported?: boolean   // a declared hook we cannot safely translate
 }
+
+export interface CommandHookEntry extends HookEntryBase {
+  type: "command"
+  command: string         // resolved absolute path of the .sh
+}
+
+export interface HttpHookEntry extends HookEntryBase {
+  type: "http"
+  url: string
+  tokenEnv?: string
+}
+
+export interface UnsupportedHookEntry extends HookEntryBase {
+  type: "unsupported"
+}
+
+export type HookEntry = CommandHookEntry | HttpHookEntry | UnsupportedHookEntry
 
 export type HookMap = Record<string, HookEntry[]>
 
@@ -29,15 +45,66 @@ export interface HookResult {
   injectedContext?: string
 }
 
+function unsupportedHook(eventName: string, matcher: string | undefined): UnsupportedHookEntry {
+  return { type: "unsupported", matcher, async: false, declared_event: eventName }
+}
+
+function loadHttpHook(
+  hook: Record<string, unknown>,
+  eventName: string,
+  matcher: string | undefined,
+): HttpHookEntry | null {
+  if (typeof hook.url !== "string") return null
+  let url: URL
+  try {
+    url = new URL(hook.url)
+  } catch {
+    return null
+  }
+  // This adapter is intentionally only a client for the local Shield gate.
+  if (url.protocol !== "http:" || url.hostname !== "127.0.0.1" || !url.port ||
+      url.pathname !== "/gate" || url.username || url.password || url.search || url.hash) {
+    return null
+  }
+
+  const headers = hook.headers
+  if (headers !== undefined && (typeof headers !== "object" || headers === null || Array.isArray(headers))) {
+    return null
+  }
+  const headerEntries = Object.entries(headers ?? {})
+  if (headerEntries.some(([name]) => name.toLowerCase() !== "x-shield-token")) return null
+  const tokenValue = headerEntries.find(([name]) => name.toLowerCase() === "x-shield-token")?.[1]
+  let tokenEnv: string | undefined
+  if (tokenValue !== undefined) {
+    if (typeof tokenValue !== "string") return null
+    const match = /^\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))$/.exec(tokenValue)
+    tokenEnv = match?.[1] ?? match?.[2]
+    if (!tokenEnv || !Array.isArray(hook.allowedEnvVars) || !hook.allowedEnvVars.includes(tokenEnv)) {
+      return null
+    }
+  }
+  return {
+    type: "http",
+    url: url.href,
+    tokenEnv,
+    matcher,
+    timeout: hook.timeout,
+    // Shield is an authorization gate. Treating it as telemetry would let the
+    // tool execute before a BLOCK verdict arrives.
+    async: false,
+    declared_event: eventName,
+  }
+}
+
 export async function loadHookMap(projectRoot: string): Promise<HookMap> {
   const settingsPath = `${projectRoot}/.claude/settings.json`
   const raw = await readFile(settingsPath, "utf-8").catch(() => "")
-  if (!raw) return { __configuration__: [{ command: "", declared_event: "configuration", unsupported: true }] }
+  if (!raw) return { __configuration__: [{ type: "unsupported", declared_event: "configuration" }] }
   let parsed: any = {}
   try {
     parsed = JSON.parse(raw)
   } catch {
-    return { __configuration__: [{ command: "", declared_event: "configuration", unsupported: true }] }
+    return { __configuration__: [{ type: "unsupported", declared_event: "configuration" }] }
   }
   const out: HookMap = {}
   const events = parsed.hooks || {}
@@ -48,12 +115,17 @@ export async function loadHookMap(projectRoot: string): Promise<HookMap> {
       const matcher = entry.matcher
       const hooks = entry.hooks || []
       for (const h of hooks) {
+        if (h.type === "http") {
+          const httpHook = loadHttpHook(h, eventName, matcher)
+          if (httpHook) out[eventName].push(httpHook)
+          else if (!h.async) out[eventName].push(unsupportedHook(eventName, matcher))
+          continue
+        }
         // A configured synchronous gate must never disappear merely because
         // this adapter cannot execute its hook type.  Async hooks are
         // telemetry by contract and remain non-blocking.
         if (h.type !== "command" || typeof h.command !== "string") {
-          if (!h.async) out[eventName].push({ command: "", matcher, async: false,
-            declared_event: eventName, unsupported: true })
+          if (!h.async) out[eventName].push(unsupportedHook(eventName, matcher))
           continue
         }
         const cmd = h.command
@@ -68,6 +140,7 @@ export async function loadHookMap(projectRoot: string): Promise<HookMap> {
           // `echo "…"`), or `bash -c` breaks on unbalanced quotes.
           .replace(/^"([^"]*)"$/, "$1")
         out[eventName].push({
+          type: "command",
           command: cmd,
           matcher,
           timeout: h.timeout,
@@ -168,7 +241,7 @@ function hookRegistryPath(owner: number, hookPid: number): string {
 
 async function spawnHook(
   projectRoot: string,
-  h: HookEntry,
+  h: CommandHookEntry,
   payload: string,
   ignoreOutput: boolean,
 ): Promise<{ proc: any; pid: number; cleanup: () => Promise<void> }> {
@@ -237,7 +310,7 @@ const readStreamText = (s: any): Promise<string> =>
  */
 async function runHookOnce(
   projectRoot: string,
-  h: HookEntry,
+  h: CommandHookEntry,
   payload: string,
   fireAndForget = false,
 ): Promise<{ exit: number; stdout: string; stderr: string }> {
@@ -261,6 +334,78 @@ async function runHookOnce(
   } finally {
     clearTimeout(killTimer)
     void cleanup()
+  }
+}
+
+async function resolveShieldToken(h: HttpHookEntry): Promise<string> {
+  if (!h.tokenEnv) return ""
+  const configured = process.env[h.tokenEnv]?.trim()
+  if (configured) return configured
+  if (h.tokenEnv !== "SHIELD_TOKEN") return ""
+  const home = process.env.HOME
+  if (!home) return ""
+  return (await readFile(`${home}/.savia/shield-token`, "utf8").catch(() => "")).trim()
+}
+
+async function runHttpHookOnce(
+  h: HttpHookEntry,
+  payload: string,
+): Promise<{ exit: number; stdout: string; stderr: string }> {
+  const token = await resolveShieldToken(h)
+  if (!token) return { exit: BLOCK_EXIT, stdout: "", stderr: "HTTP_GATE_MISSING_TOKEN" }
+
+  const controller = new AbortController()
+  let timedOut = false
+  const timer = setTimeout(() => {
+    timedOut = true
+    controller.abort()
+  }, timeoutFor(h))
+  try {
+    let response: Response
+    try {
+      response = await Bun.fetch(h.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Shield-Token": token,
+        },
+        body: payload,
+        redirect: "error",
+        signal: controller.signal,
+      })
+    } catch {
+      return {
+        exit: BLOCK_EXIT,
+        stdout: "",
+        stderr: timedOut ? "HTTP_GATE_TIMEOUT" : "HTTP_GATE_UNREACHABLE",
+      }
+    }
+    if (!response.ok) {
+      return { exit: BLOCK_EXIT, stdout: "", stderr: `HTTP_GATE_STATUS_${response.status}` }
+    }
+    let parsed: unknown
+    try {
+      parsed = await response.json()
+    } catch {
+      return {
+        exit: BLOCK_EXIT,
+        stdout: "",
+        stderr: timedOut ? "HTTP_GATE_TIMEOUT" : "HTTP_GATE_INVALID_RESPONSE",
+      }
+    }
+    const verdict = parsed && typeof parsed === "object"
+      ? (parsed as Record<string, unknown>).verdict
+      : undefined
+    if (typeof verdict !== "string") {
+      return { exit: BLOCK_EXIT, stdout: "", stderr: "HTTP_GATE_INVALID_RESPONSE" }
+    }
+    if (verdict === "ALLOW") return { exit: 0, stdout: "", stderr: "" }
+    if (verdict === "BLOCK") {
+      return { exit: BLOCK_EXIT, stdout: "", stderr: "HTTP_GATE_BLOCK" }
+    }
+    return { exit: BLOCK_EXIT, stdout: "", stderr: "HTTP_GATE_UNKNOWN_VERDICT" }
+  } finally {
+    clearTimeout(timer)
   }
 }
 
@@ -377,7 +522,7 @@ export async function runHooksForEvent(
   const hooks = hookMap[event] || []
   for (const h of hooks) {
     if (!matcherApplies(h.matcher, tool, payload)) continue
-    if (h.unsupported) {
+    if (h.type === "unsupported") {
       result.blocked = true
       result.stderr = "UNSUPPORTED_CRITICAL_HOOK"
       return result
@@ -386,13 +531,18 @@ export async function runHooksForEvent(
       // `async: true` hooks are fire-and-forget (Claude Code semantics):
       // their exit code and output are ignored, and the caller never waits.
       if (h.async) {
-        void runHookOnce(projectRoot, h, payload, true).catch(() => {})
+        if (h.type === "command") void runHookOnce(projectRoot, h, payload, true).catch(() => {})
+        else void runHttpHookOnce(h, payload).catch(() => {})
         continue
       }
-      const { exit, stdout, stderr } = await runHookOnce(projectRoot, h, payload, false)
+      const { exit, stdout, stderr } = h.type === "command"
+        ? await runHookOnce(projectRoot, h, payload, false)
+        : await runHttpHookOnce(h, payload)
       if (exit === BLOCK_EXIT) {
         result.blocked = true
-        result.stderr = stderr.trim() || `${h.command} exited ${BLOCK_EXIT}`
+        result.stderr = stderr.trim() || (h.type === "command"
+          ? `${h.command} exited ${BLOCK_EXIT}`
+          : "HTTP_GATE_BLOCK")
         return result
       }
       // Claude Code block contract #2: exit 0 + stdout JSON `{"decision":"block"}`
@@ -406,8 +556,8 @@ export async function runHooksForEvent(
       }
       if (parsed?.decision === "block") {
         result.blocked = true
-        result.stderr = String(parsed.reason ?? "") || `${h.command} blocked via {decision:block}`
-        await auditLog({ event: "hook-json-block", command: h.command, reason: result.stderr })
+        result.stderr = String(parsed.reason ?? "") || `${h.type === "command" ? h.command : h.url} blocked via {decision:block}`
+        await auditLog({ event: "hook-json-block", command: h.type === "command" ? h.command : h.url, reason: result.stderr })
         return result
       }
       // If a hook prints structured JSON on stdout, treat it as arg/context mutation.

--- a/scripts/pr-plan-gates.sh
+++ b/scripts/pr-plan-gates.sh
@@ -240,7 +240,19 @@ g6() {
   command -v bats >/dev/null 2>&1 || { echo "WARN: bats not installed"; return; }
   # Windows Git Bash: BATS has path issues, degrade to WARN
   [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]] && { echo "WARN: Windows — BATS deferred to CI"; return; }
+  # Some hook tests legitimately exercise branch switching, whose production
+  # hook clears this per-branch ephemeral file. G11 still needs the caller's
+  # original summary after G6, so isolate it from suite side effects.
+  local summary_snapshot=""
+  if [[ -f "$ROOT/.pr-summary.md" ]]; then
+    summary_snapshot=$(mktemp)
+    cp "$ROOT/.pr-summary.md" "$summary_snapshot"
+  fi
   local out; out=$(timeout 300 bash tests/run-all.sh 2>&1) || true
+  if [[ -n "$summary_snapshot" ]]; then
+    cp "$summary_snapshot" "$ROOT/.pr-summary.md"
+    rm -f "$summary_snapshot"
+  fi
   local fails; fails=$(echo "$out" | grep '❌' | sed 's/.*❌ //' | tr '\n' ', ' | sed 's/, $//') || true
   [[ -n "$fails" ]] && echo "FAIL: $fails" && return
   local p; p=$(echo "$out" | grep -oP '[0-9]+/[0-9]+ suites' | tail -1)

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -3,6 +3,7 @@
 Persistent log of corrections and patterns discovered during sessions.
 Reviewed at session start to prevent recurrence. Newest entries first.
 
+| 2026-09-08 | Skills | Frontmatter migrations must parse every `SKILL.md` as YAML after rewriting it. Grep-only checks missed invalid nesting below scalar metadata and unquoted colons in descriptions. Keep a repository-wide YAML regression test. | Codex skipped invalid skills at startup |
 | 2026-03-28 | Git | ALWAYS run /pr-plan before creating any PR. NEVER call push-pr.sh directly — it bypasses 10 pre-flight gates and the confidentiality signing protocol, causing CI failures (diff hash mismatch). Structural guard: push-pr.sh now requires .pr-plan-ok sentinel or exits with error. Rule #25. | CI failure PR #441 + user correction |
 | 2026-03-25 | Comms | When told to improve a response, ACTUALLY improve it. Don't resend the same quality. Re-read the original feedback, address every point, improve depth and tone. | User correction |
 | 2026-03-25 | Comms | Follow directives precisely. If user says "improve the email", the next version MUST be measurably better. Track directives as checklist, verify before executing. | User correction |

--- a/tests/dual-cli/test_core.py
+++ b/tests/dual-cli/test_core.py
@@ -2,6 +2,7 @@
 from concurrent.futures import ThreadPoolExecutor
 import json
 from pathlib import Path
+import sqlite3
 import sys
 import tempfile
 import unittest
@@ -137,6 +138,22 @@ class StateTests(unittest.TestCase):
         output = json.dumps(self.store.status())
         self.assertNotIn("PRIVATE_SENTINEL", output)
         self.assertNotIn(token, output)
+
+    def test_completion_rolls_back_journal_when_release_fails(self):
+        reserved_event = event(call_id="call")
+        token, replay = self.store.admit(reserved_event, "one", "r1", "call")
+        self.assertIsNone(replay)
+        with self.store.connection() as db:
+            db.execute(
+                "CREATE TRIGGER fail_release BEFORE DELETE ON lease "
+                "BEGIN SELECT RAISE(ABORT, 'injected release failure'); END"
+            )
+
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.store.complete(reserved_event, {"action": "deny"}, "one", token)
+
+        self.assertIsNone(self.store.prior_record(reserved_event))
+        self.assertEqual(self.store.status()["reservations"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/dual-cli/test_runtime.py
+++ b/tests/dual-cli/test_runtime.py
@@ -6,6 +6,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import unittest
 
@@ -131,6 +132,81 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(result["request_id"], "req")
         with self.assertRaisesRegex(ProtocolError, "UNKNOWN_ADAPTER"):
             runtime.handle({"op":"dispatch","session_id":"direct","session_token":hello["session_token"],"event":dict(event, event_id="e3", payload={"schema":2,"adapter_id":"missing","request":request})})
+
+    def test_registered_adapter_is_not_reexecuted_for_same_event(self):
+        class CountingAdapter(FixtureAdapter):
+            count = 0
+            def execute(self, request):
+                self.count += 1
+                return super().execute(request)
+        store=Store(self.root / "dedupe.db", "repo")
+        store.publish("r1", expected=None)
+        adapter=CountingAdapter()
+        runtime=Runtime(store, [adapter])
+        hello=runtime.handle({"op":"hello","session_id":"direct"})
+        runtime.handle({"op":"ack","session_id":"direct","session_token":hello["session_token"],"revision":"r1"})
+        request={"request_id":"req","capability_id":"local","context_ref":"ctx","scope_ref":"scope","input_ref":"input","required_capabilities":[],"deadline_ms":1000,"external_effect_intent":False}
+        event=dict(version=1, repo_id="repo", frontend="codex", session_id="direct", actor_id="test", event_id="same", call_id="call", kind="PreToolUse", revision="r1", payload={"schema":2,"adapter_id":"fixture","request":request})
+        dispatch={"op":"dispatch","session_id":"direct","session_token":hello["session_token"],"event":event}
+        first=runtime.handle(dispatch)
+        second=runtime.handle(dispatch)
+        self.assertEqual(first, second)
+        self.assertEqual(adapter.count, 1)
+        self.assertEqual(store.status()["reservations"], 0)
+
+    def test_result_request_id_mismatch_keeps_reservation(self):
+        class BadAdapter(FixtureAdapter):
+            def execute(self, request):
+                result=super().execute(request)
+                result["request_id"]="other"
+                return result
+        store=Store(self.root / "mismatch.db", "repo")
+        store.publish("r1", expected=None)
+        runtime=Runtime(store, [BadAdapter()])
+        hello=runtime.handle({"op":"hello","session_id":"direct"})
+        runtime.handle({"op":"ack","session_id":"direct","session_token":hello["session_token"],"revision":"r1"})
+        request={"request_id":"req","capability_id":"local","context_ref":"ctx","scope_ref":"scope","input_ref":"input","required_capabilities":[],"deadline_ms":1000,"external_effect_intent":False}
+        event=dict(version=1, repo_id="repo", frontend="codex", session_id="direct", actor_id="test", event_id="bad", call_id="call", kind="PreToolUse", revision="r1", payload={"schema":2,"adapter_id":"fixture","request":request})
+        with self.assertRaisesRegex(ProtocolError, "INCONSISTENT_RESULT"):
+            runtime.handle({"op":"dispatch","session_id":"direct","session_token":hello["session_token"],"event":event})
+        self.assertEqual(store.status()["reservations"], 1)
+        with self.assertRaisesRegex(ProtocolError, "AMBIGUOUS_EXECUTION"):
+            runtime.handle({"op":"dispatch","session_id":"direct","session_token":hello["session_token"],"event":event})
+
+    def test_concurrent_dispatch_reserves_before_execute(self):
+        entered = threading.Event()
+        unblock = threading.Event()
+
+        class BlockingAdapter(FixtureAdapter):
+            count = 0
+            def execute(self, request):
+                self.count += 1
+                entered.set()
+                self.assert_unblocked = unblock.wait(timeout=5)
+                return super().execute(request)
+
+        store=Store(self.root / "concurrent.db", "repo")
+        store.publish("r1", expected=None)
+        adapter=BlockingAdapter()
+        runtime=Runtime(store, [adapter])
+        hello=runtime.handle({"op":"hello","session_id":"direct"})
+        runtime.handle({"op":"ack","session_id":"direct","session_token":hello["session_token"],"revision":"r1"})
+        request={"request_id":"req","capability_id":"local","context_ref":"ctx","scope_ref":"scope","input_ref":"input","required_capabilities":[],"deadline_ms":1000,"external_effect_intent":False}
+        event=dict(version=1, repo_id="repo", frontend="codex", session_id="direct", actor_id="test", event_id="same", call_id="call", kind="PreToolUse", revision="r1", payload={"schema":2,"adapter_id":"fixture","request":request})
+        dispatch={"op":"dispatch","session_id":"direct","session_token":hello["session_token"],"event":event}
+        outcomes=[]
+        worker=threading.Thread(target=lambda: outcomes.append(runtime.handle(dispatch)))
+        worker.start()
+        self.assertTrue(entered.wait(timeout=5), "first execution did not start")
+        with self.assertRaisesRegex(ProtocolError, "AMBIGUOUS_EXECUTION"):
+            runtime.handle(dispatch)
+        unblock.set()
+        worker.join(timeout=5)
+        self.assertFalse(worker.is_alive())
+        self.assertTrue(adapter.assert_unblocked)
+        self.assertEqual(adapter.count, 1)
+        self.assertEqual(outcomes[0]["state"], "succeeded")
+        self.assertEqual(store.status()["reservations"], 0)
 
 
 class CrashTests(unittest.TestCase):

--- a/tests/test-agent-messaging.bats
+++ b/tests/test-agent-messaging.bats
@@ -4,4 +4,4 @@ S=".claude/skills/agent-messaging/SKILL.md"
 D=".claude/skills/agent-messaging/DOMAIN.md"
 @test "[agent-messaging] SKILL sustancial" { [ -f "$S" ]; [ "$(wc -l < "$S")" -ge 50 ]; }
 @test "[agent-messaging] DOMAIN presente" { [ -f "$D" ]; }
-@test "[agent-messaging] maturity stable" { grep -qE "^(savia\.)?maturity: stable" "$S"; }
+@test "[agent-messaging] maturity stable" { grep -qE "^  savia\.maturity: stable$" "$S"; }

--- a/tests/test-code-improvement-loop.bats
+++ b/tests/test-code-improvement-loop.bats
@@ -4,4 +4,4 @@ S=".claude/skills/code-improvement-loop/SKILL.md"
 D=".claude/skills/code-improvement-loop/DOMAIN.md"
 @test "[code-improvement-loop] SKILL sustancial" { [ -f "$S" ]; [ "$(wc -l < "$S")" -ge 50 ]; }
 @test "[code-improvement-loop] DOMAIN presente" { [ -f "$D" ]; }
-@test "[code-improvement-loop] maturity stable" { grep -qE "^(savia\.)?maturity: stable" "$S"; }
+@test "[code-improvement-loop] maturity stable" { grep -qE "^  savia\.maturity: stable$" "$S"; }

--- a/tests/test-overnight-sprint.bats
+++ b/tests/test-overnight-sprint.bats
@@ -4,4 +4,4 @@ S=".claude/skills/overnight-sprint/SKILL.md"
 D=".claude/skills/overnight-sprint/DOMAIN.md"
 @test "[overnight-sprint] SKILL sustancial" { [ -f "$S" ]; [ "$(wc -l < "$S")" -ge 50 ]; }
 @test "[overnight-sprint] DOMAIN presente" { [ -f "$D" ]; }
-@test "[overnight-sprint] maturity stable" { grep -qE "^(savia\.)?maturity: stable" "$S"; }
+@test "[overnight-sprint] maturity stable" { grep -qE "^  savia\.maturity: stable$" "$S"; }

--- a/tests/test-parallel-dispatch.bats
+++ b/tests/test-parallel-dispatch.bats
@@ -4,4 +4,4 @@ S=".claude/skills/parallel-dispatch/SKILL.md"
 D=".claude/skills/parallel-dispatch/DOMAIN.md"
 @test "[parallel-dispatch] SKILL sustancial" { [ -f "$S" ]; [ "$(wc -l < "$S")" -ge 50 ]; }
 @test "[parallel-dispatch] DOMAIN presente" { [ -f "$D" ]; }
-@test "[parallel-dispatch] maturity stable" { grep -qE "^(savia\.)?maturity: stable" "$S"; }
+@test "[parallel-dispatch] maturity stable" { grep -qE "^  savia\.maturity: stable$" "$S"; }

--- a/tests/test-pr-plan-summary-preservation.bats
+++ b/tests/test-pr-plan-summary-preservation.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  TEST_ROOT="$(mktemp -d)"
+  TEST_BIN="$TEST_ROOT/bin"
+  mkdir -p "$TEST_BIN/tests"
+  printf '#!/usr/bin/env bash\nrm -f "$ROOT/.pr-summary.md"\necho "1/1 suites"\n' > "$TEST_BIN/timeout"
+  chmod +x "$TEST_BIN/timeout"
+  touch "$TEST_BIN/tests/run-all.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+@test "G6 preserves the PR summary across test side effects" {
+  printf 'summary that must survive\n' > "$TEST_ROOT/.pr-summary.md"
+  export ROOT="$TEST_ROOT"
+  export PATH="$TEST_BIN:$PATH"
+  cd "$TEST_BIN"
+  source "$REPO_ROOT/scripts/pr-plan-gates.sh"
+
+  run g6
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "$TEST_ROOT/.pr-summary.md")" = "summary that must survive" ]
+}

--- a/tests/test-skill-frontmatter-yaml.bats
+++ b/tests/test-skill-frontmatter-yaml.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+@test "all SKILL.md frontmatter is valid YAML" {
+  run python3 - "$BATS_TEST_DIRNAME/.." <<'PY'
+from pathlib import Path
+import re
+import sys
+
+import yaml
+
+root = Path(sys.argv[1]).resolve()
+failures = []
+for path in sorted((root / ".claude" / "skills").glob("**/SKILL.md")):
+    text = path.read_text(encoding="utf-8")
+    match = re.match(r"^---\n(.*?)\n---(?:\n|$)", text, re.DOTALL)
+    if match is None:
+        failures.append(f"{path.relative_to(root)}: missing frontmatter")
+        continue
+    try:
+        value = yaml.safe_load(match.group(1))
+    except yaml.YAMLError as error:
+        failures.append(f"{path.relative_to(root)}: {error}")
+        continue
+    if not isinstance(value, dict) or not value.get("name") or not value.get("description"):
+        failures.append(f"{path.relative_to(root)}: missing name or description")
+
+if failures:
+    print("\n".join(failures))
+    raise SystemExit(1)
+PY
+
+  [ "$status" -eq 0 ]
+}

--- a/tests/test-tech-research-agent.bats
+++ b/tests/test-tech-research-agent.bats
@@ -4,4 +4,4 @@ S=".claude/skills/tech-research-agent/SKILL.md"
 D=".claude/skills/tech-research-agent/DOMAIN.md"
 @test "[tech-research-agent] SKILL sustancial" { [ -f "$S" ]; [ "$(wc -l < "$S")" -ge 50 ]; }
 @test "[tech-research-agent] DOMAIN presente" { [ -f "$D" ]; }
-@test "[tech-research-agent] maturity stable" { grep -qE "^(savia\.)?maturity: stable" "$S"; }
+@test "[tech-research-agent] maturity stable" { grep -qE "^  savia\.maturity: stable$" "$S"; }


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Corrige un problema que impedía cargar correctamente varias capacidades del
asistente al iniciar una sesión y añade una comprobación automática para que un
error equivalente no vuelva a pasar inadvertido.

También hace más segura la ejecución de acciones repetidas. Antes, una petición
reintentada en un momento incierto podía volver a ejecutarse. Ahora se reserva la
ejecución antes de iniciarla, se reutiliza el resultado cuando ya fue confirmado
y se detiene de forma segura cuando no puede saberse si el efecto anterior llegó
a ocurrir. El registro del resultado y la liberación de la reserva se guardan
juntos, evitando estados parciales.

Por último, conecta en OpenCode el control local de autorización. Si falta la
credencial, el servicio no responde, tarda demasiado o devuelve una respuesta
inválida, la acción se bloquea. La credencial no aparece en los mensajes de
salida y una configuración en segundo plano no puede rebajar esta protección.

Este cambio entrega una base concreta y probada, pero no declara terminada toda
la hoja de ruta propuesta. Las mejoras posteriores de conectividad, evidencia y
sustitución de proveedores continúan pendientes de aprobación y desarrollo.

## Detalle técnico

- Corrige seis frontmatters de skills y valida como YAML los 153 `SKILL.md`.
- Añade admisión, replay y finalización transaccional al store del harness.
- Implementa el Shield HTTP local fail-closed en el bridge de OpenCode.
- Conserva SE-395 y SE-396 como propuestas y documenta con precisión el avance.

Scope-trace: skip — las specs incluidas son propuestas de alcance futuro; este PR sólo entrega y prueba la base de integridad identificada durante la auditoría.

## Verificación

- 80 tests Python del dual CLI.
- 119 tests Bats focales, de paridad y preservación del preflight.
- 16 tests Bun del gate HTTP.
- Validación local: 6 gates correctos, 2 avisos consultivos.
- La suite global superó el límite de 300 segundos; antes del corte mostró fallos
  no relacionados en pruebas de F5, framing MCP, caché, pins, boundaries, capa de
  skills y architect-agent.
## Summary
fix(harness): enforce fail-closed operational integrity
### Changes
- 6dd0f5d6 fix(harness): enforce fail-closed operational integrity
### Stats
29 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed
