### PR TITLE
fix(chaos): fail suite when any scenario fails

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=0e6520ea5a6f3ea98f166148c6065bd1093224b081737550eac35fe285b9997c
-timestamp=2026-09-09T18:08:10Z
-branch=agent/overnight-20260909-planning-omissions
-head_commit=20d9de50
-signature=08e842cb355b2c52ffad64688a53c3f8f7e2b5602eeb662700e68db54dfc64a7
+diff_hash=0b4f61de4be4e93f2643b8fe51733ed8a4e6599c5b47080b9093643d0623b6b6
+timestamp=2026-09-09T18:25:01Z
+branch=agent/overnight-20260909-chaos-verdict
+head_commit=07ef6efc
+signature=6b0bd9d61bf9e9b29b673d4cfa3a862f9843485531451e39224e923e4b6346c5

--- a/CHANGELOG.d/se383-chaos-verdict.md
+++ b/CHANGELOG.d/se383-chaos-verdict.md
@@ -1,0 +1,7 @@
+---
+category: Fixed
+spec: SE-383
+---
+- Corrige el agregado de la suite chaos para que cualquier escenario FAIL y
+  también un corpus vacío produzcan exit no cero; añade un modo puro y
+  determinista para probar la decisión sin ejecutar perturbaciones.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,8 @@
 # Lessons Learned
 
+- Un runner agregado debe decidir por fallos, no por éxitos: `PASS > 0` sólo
+  demuestra que algún componente funcionó. El contrato sistémico correcto es
+  `FAIL == 0 && PASS > 0`, con corpus vacío tratado como fallo de evidencia.
 - Un registro canónico no es completo sólo porque sus entradas sean válidas:
   debe declarar el universo que pretende cubrir y fallar cuando una fuente de
   ese universo queda omitida. El suelo de cobertura evita confundir legacy no

--- a/tests/chaos/run-chaos-suite.sh
+++ b/tests/chaos/run-chaos-suite.sh
@@ -11,6 +11,21 @@ PASS=0; FAIL=0; RESULTS=""
 record() { RESULTS+="$1
 "; }
 
+aggregate_verdict() {
+  local pass_count="$1" fail_count="$2"
+  echo "-- chaos suite: $pass_count PASS / $fail_count FAIL-RED"
+  [[ "$fail_count" -eq 0 && "$pass_count" -gt 0 ]]
+}
+
+if [[ "${1:-}" == "--aggregate" ]]; then
+  if [[ $# -ne 3 ]] || ! [[ "$2" =~ ^[0-9]+$ && "$3" =~ ^[0-9]+$ ]]; then
+    echo "usage: $0 --aggregate PASS_COUNT FAIL_COUNT" >&2
+    exit 2
+  fi
+  aggregate_verdict "$2" "$3"
+  exit $?
+fi
+
 assert_clean_exit() { # nombre, exit_code, stdout, condiciones: no traceback, exit en {0,1,2}
   local name="$1" rc="$2" out="$3"
   if [[ $rc -gt 2 ]] || echo "$out" | grep -qiE "traceback|syntax error|bad substitution|unbound variable"; then
@@ -88,5 +103,5 @@ fi
 
 rm -rf "$S" "$S6"
 echo "$RESULTS"
-echo "-- chaos suite: $PASS PASS / $FAIL FAIL-RED"
-[[ $PASS -gt 0 ]] && exit 0 || exit 1
+aggregate_verdict "$PASS" "$FAIL"
+exit $?

--- a/tests/test-chaos-suite-verdict.bats
+++ b/tests/test-chaos-suite-verdict.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+# SE-383 chaos aggregation invariant: any FAIL makes the suite fail.
+# Ref: docs/specs/SE-383-harness-chaos-suite.spec.md
+
+SCRIPT="tests/chaos/run-chaos-suite.sh"
+
+setup() {
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+teardown() {
+  cd /
+}
+
+@test "chaos runner exists and is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+@test "chaos runner keeps strict pipefail safety" {
+  grep -q 'set -uo pipefail' "$SCRIPT"
+}
+
+@test "chaos runner exposes a deterministic aggregate verdict" {
+  grep -q 'aggregate_verdict' "$SCRIPT"
+}
+
+@test "aggregate accepts all-pass results" {
+  run bash "$SCRIPT" --aggregate 8 0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"8 PASS / 0 FAIL-RED"* ]]
+}
+
+@test "aggregate reports the complete passing count" {
+  run bash "$SCRIPT" --aggregate 3 0
+  [ "$status" -eq 0 ]
+  [[ "$output" == "-- chaos suite: 3 PASS / 0 FAIL-RED" ]]
+}
+
+@test "aggregate emits one deterministic summary line" {
+  run bash "$SCRIPT" --aggregate 2 0
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 1 ]
+}
+
+@test "aggregate rejects mixed pass and fail results" {
+  run bash "$SCRIPT" --aggregate 7 1
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"7 PASS / 1 FAIL-RED"* ]]
+}
+
+@test "aggregate rejects all-fail results" {
+  run bash "$SCRIPT" --aggregate 0 8
+  [ "$status" -ne 0 ]
+}
+
+@test "aggregate rejects an empty scenario set" {
+  run bash "$SCRIPT" --aggregate 0 0
+  [ "$status" -ne 0 ]
+}
+
+@test "aggregate rejects missing counters" {
+  run bash "$SCRIPT" --aggregate 1
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"usage"* ]]
+}
+
+@test "aggregate rejects negative counters" {
+  run bash "$SCRIPT" --aggregate -1 0
+  [ "$status" -eq 2 ]
+}
+
+@test "aggregate rejects non-numeric counters" {
+  run bash "$SCRIPT" --aggregate one zero
+  [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este cambio corrige cómo se decide el resultado global de las pruebas de fallos controlados. Antes bastaba con que un escenario pasara para devolver éxito, aunque otro hubiera fallado; una ejecución con siete resultados correctos y uno incorrecto podía presentarse como verde. Ahora el conjunto sólo pasa cuando no existe ningún fallo y se ha ejecutado al menos un escenario. También se añade una forma pura de probar esa decisión sin lanzar perturbaciones reales, cubriendo resultados mixtos, todos fallidos, conjunto vacío y entradas inválidas. La suite real sigue pasando sus ocho escenarios actuales. No se toca producción ni se amplía autoridad. El riesgo abierto es que los propios escenarios aún tienen alcance limitado; este cambio garantiza la honestidad del agregado, no la exhaustividad del corpus. Puede revertirse sin migración ni estado persistente.

Spec ref: SE-383

## Resumen

- Cualquier escenario FAIL hace fallar la suite completa.
- Un corpus vacío también falla por ausencia de evidencia.
- El modo puro `--aggregate` hace reproducible la decisión.
- PR apilada: requiere #1118 → #1117 → #1116 → #1115 → #1113.

## Summary

- Any failed scenario fails the complete suite.
- An empty corpus also fails due to missing evidence.
- Pure `--aggregate` mode makes the decision reproducible.
- Stacked PR: requires #1118 → #1117 → #1116 → #1115 → #1113.

## Evidencia / Test plan

- Suite chaos real: 8 PASS, 0 FAIL.
- Agregado determinista: 12/12 tests.
- Calidad determinista del test: 80/100.
- Validación CI local: 6 PASS, 0 FAIL, 2 WARN advisory.
- Preflight oficial: 20 PASS, 0 FAIL, 2 WARN advisory.

## Límite

No amplía el corpus de fallos de SE-383; corrige exclusivamente la semántica
del veredicto sistémico.
