### PR TITLE
feat(harness): SE-396 integrity extensions + SE-395 vault isolation

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=a651b62efd0e78082191dcee68984365e9ac5cdad49222d94db9ae89971b0ab0
-timestamp=2026-09-11T13:50:19Z
+diff_hash=3e3777547e2f9eebd6231a4918d5be8f5ba7813e6c4139508dd9aa1b23097741
+timestamp=2026-09-11T13:53:32Z
 branch=agent/se396-integrity-20260911
-head_commit=29b582de
-signature=e974bada8f0ae4e204cc21e06905c46cce2ca5abc5e49f7334fb9ae60182b470
+head_commit=60435aec
+signature=cd1a4e138d6f79dd3d56a5d9966804bebbcfe804d3dd6ea0e7168ea84b57f97c

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=ffb232338284b2346163f2eeda65e2ce9154c6a47b811aa8c8e124aaf5ea5e1b
-timestamp=2026-09-11T10:07:47Z
-branch=agent/resolve-pr1117-20260910
-head_commit=4a567200
-signature=d62a9b9f02f4ddbe4c920823605514bb500826dfef9d965d7a1fafbe57339c94
+diff_hash=a651b62efd0e78082191dcee68984365e9ac5cdad49222d94db9ae89971b0ab0
+timestamp=2026-09-11T13:50:19Z
+branch=agent/se396-integrity-20260911
+head_commit=29b582de
+signature=e974bada8f0ae4e204cc21e06905c46cce2ca5abc5e49f7334fb9ae60182b470

--- a/CHANGELOG.d/se396-integrity-vaults.md
+++ b/CHANGELOG.d/se396-integrity-vaults.md
@@ -1,0 +1,15 @@
+---
+version_bump: minor
+section: Added
+---
+- **SE-395 vault isolation**: `projects/savia-vaults/src/registry/domes.ts` expone
+  `config` en `VaultInstance` y `projects/savia-vaults/src/server/mcp.ts` aísla
+  motores por dome; test e2e `tests/e2e/mcp-dome-isolation.test.ts` verifica que
+  un lector de un dome no alcanza el grafo/query/introspección de otro.
+- **SE-396 integrity extensions**: `contracts.py` valida `observed_at` en RFC3339
+  estricto y `verify_observation` falla cerrado (`EVIDENCE_VERIFIER_UNAVAILABLE`);
+  `autonomy.py` correlaciona y firma receipts; `autonomy_doctor.py` marca
+  evidencia `NOT_VERIFIED`; `codex_profile.py` separa `SYNTHETIC` de
+  `OPERATIONAL_PROBE`; `config.py` cierra el hash de domain packs; `preflight.py`
+  rechaza verifier no disponible. Tests `test_doctor_integrity.py`,
+  `test_evidence_integrity.py`.

--- a/projects/savia-vaults/src/registry/domes.ts
+++ b/projects/savia-vaults/src/registry/domes.ts
@@ -177,10 +177,12 @@ export class VaultInstance {
   public readonly storage: VaultStorage;
   public readonly search: SearchEngine;
   public readonly security: VaultSecurity;
+  public readonly config: VaultConfig;
 
   constructor(dome: DomeInfo) {
     this.dome = dome;
     const config = makeConfig(dome);
+    this.config = config;
     this.storage = new VaultStorage(config);
     this.search = new SearchEngine(config);
     this.security = new VaultSecurity(config);

--- a/projects/savia-vaults/src/server/mcp.ts
+++ b/projects/savia-vaults/src/server/mcp.ts
@@ -29,11 +29,6 @@ export class MCPVaultServer {
   private storage: VaultStorage;
   private search: SearchEngine;
   private security: VaultSecurity;
-  private introspector: Introspector | undefined;
-  private graph: KnowledgeGraph | undefined;
-  private queryEngine: QueryEngine | undefined;
-  private quality: QualityEngine | undefined;
-  private graphBuilt = false;
 
   private domeRegistry: DomeRegistry | undefined;
   private userStore: UserStore | undefined;
@@ -69,13 +64,6 @@ export class MCPVaultServer {
       }
     }
 
-    if (config.schemaDir) {
-      this.introspector = new Introspector(config);
-      this.graph = new KnowledgeGraph(config);
-      this.queryEngine = new QueryEngine(config);
-      this.quality = new QualityEngine(config);
-    }
-
     if (!domeRegistry) {
       this.initVault();
     }
@@ -83,7 +71,7 @@ export class MCPVaultServer {
 
   private getInstance(vaultName?: string): VaultInstance {
     if (!this.domeRegistry) {
-      return { dome: { name: this.config.name, path: this.config.path, description: '', confidentiality: 'N2', active: true }, storage: this.storage, search: this.search, security: this.security };
+      return { config: this.config, dome: { name: this.config.name, path: this.config.path, description: '', confidentiality: 'N2', active: true }, storage: this.storage, search: this.search, security: this.security };
     }
     const name = vaultName || this.domeRegistry.getDefaultName();
     const inst = this.instances.get(name);
@@ -94,10 +82,6 @@ export class MCPVaultServer {
   private getDomeName(vaultName?: string): string {
     if (!this.domeRegistry) return this.config.name;
     return vaultName || this.domeRegistry.getDefaultName();
-  }
-
-  private async ensureGraph(): Promise<void> {
-    if (!this.graphBuilt && this.graph) { await this.graph.build(); this.graphBuilt = true; }
   }
 
   private async authorize(dome: string, action: AuthAction, tool?: string): Promise<void> {
@@ -378,12 +362,13 @@ export class MCPVaultServer {
             const inst = this.getInstance(args.vault as string | undefined);
             const dome = this.getDomeName(args.vault as string | undefined);
             try { await this.authorize(dome, 'read', 'vault_introspect'); } catch (e) { if (e instanceof AuthError) return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true }; throw e; }
-            if (!this.introspector) return { content: [{ type: 'text', text: 'No schema configured.' }], isError: true };
+            if (!inst.config.schemaDir) return { content: [{ type: 'text', text: 'No schema configured.' }], isError: true };
+            const introspector = new Introspector(inst.config);
             if (args.entity) {
-              const entity = await this.introspector.introspectEntity(args.entity as string);
+              const entity = await introspector.introspectEntity(args.entity as string);
               return { content: [{ type: 'text', text: JSON.stringify(entity, null, 2) }] };
             }
-            const vault = await this.introspector.introspectVault();
+            const vault = await introspector.introspectVault();
             return { content: [{ type: 'text', text: JSON.stringify(vault, null, 2) }] };
           }
 
@@ -391,17 +376,18 @@ export class MCPVaultServer {
             const inst = this.getInstance(args.vault as string | undefined);
             const dome = this.getDomeName(args.vault as string | undefined);
             try { await this.authorize(dome, 'read', 'vault_graph'); } catch (e) { if (e instanceof AuthError) return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true }; throw e; }
-            if (!this.graph) return { content: [{ type: 'text', text: 'No schema configured.' }], isError: true };
-            await this.ensureGraph();
+            if (!inst.config.schemaDir) return { content: [{ type: 'text', text: 'No schema configured.' }], isError: true };
+            const graph = new KnowledgeGraph(inst.config);
+            await graph.build();
             const action = args.action as string;
             if (action === 'traverse') {
-              const result = this.graph.traverse(args.id as string, (args.depth as number) || 3);
+              const result = graph.traverse(args.id as string, (args.depth as number) || 3);
               return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
             } else if (action === 'search') {
-              const nodes = this.graph.searchNodes(args.query as string);
+              const nodes = graph.searchNodes(args.query as string);
               return { content: [{ type: 'text', text: JSON.stringify(nodes.map(n => ({ id: n.id, type: n.type, path: n.path, outgoing: n.outgoing.length, incoming: n.incoming.length })), null, 2) }] };
             } else {
-              const stats = this.graph.getStats();
+              const stats = graph.getStats();
               return { content: [{ type: 'text', text: JSON.stringify(stats, null, 2) }] };
             }
           }
@@ -410,10 +396,10 @@ export class MCPVaultServer {
             const inst = this.getInstance(args.vault as string | undefined);
             const dome = this.getDomeName(args.vault as string | undefined);
             try { await this.authorize(dome, 'read', 'vault_query'); } catch (e) { if (e instanceof AuthError) return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true }; throw e; }
-            if (!this.queryEngine) return { content: [{ type: 'text', text: 'No schema configured.' }], isError: true };
-            await this.ensureGraph();
-            await this.queryEngine.ensureLoaded();
-            const result = await this.queryEngine.query(args.expression as string);
+            if (!inst.config.schemaDir) return { content: [{ type: 'text', text: 'No schema configured.' }], isError: true };
+            const queryEngine = new QueryEngine(inst.config);
+            await queryEngine.ensureLoaded();
+            const result = await queryEngine.query(args.expression as string);
             return { content: [{ type: 'text', text: result.outputMarkdown }] };
           }
 
@@ -443,9 +429,10 @@ export class MCPVaultServer {
             const inst = this.getInstance(args.vault as string | undefined);
             const dome = this.getDomeName(args.vault as string | undefined);
             try { await this.authorize(dome, 'read', 'vault_health'); } catch (e) { if (e instanceof AuthError) return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true }; throw e; }
-            if (!this.quality) return { content: [{ type: 'text', text: 'No schema configured.' }], isError: true };
-            const indicators = await this.quality.assess();
-            return { content: [{ type: 'text', text: this.quality.formatReport(indicators) }] };
+            if (!inst.config.schemaDir) return { content: [{ type: 'text', text: 'No schema configured.' }], isError: true };
+            const quality = new QualityEngine(inst.config);
+            const indicators = await quality.assess();
+            return { content: [{ type: 'text', text: quality.formatReport(indicators) }] };
           }
 
           default:

--- a/projects/savia-vaults/tests/e2e/mcp-dome-isolation.test.ts
+++ b/projects/savia-vaults/tests/e2e/mcp-dome-isolation.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { UserStore } from '../../src/auth/store.js';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const folders: string[] = [];
+afterEach(() => { for (const folder of folders.splice(0)) fs.rmSync(folder, { recursive: true, force: true }); });
+
+describe('SE-396 selected dome governs knowledge tools', () => {
+  it('a reader of B cannot retrieve A through the global graph/query/introspection', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'savia-dome-isolation-'));
+    folders.push(root);
+    const schema = path.join(root, 'schema');
+    fs.mkdirSync(schema);
+    const domes: Record<string, unknown> = {};
+    for (const name of ['a', 'b']) {
+      const folder = path.join(root, name);
+      fs.mkdirSync(folder);
+      fs.writeFileSync(path.join(folder, `${name}.md`), `---\nentity:\n  id: sentinel-${name}\n  type: document\n---\n# sentinel-${name}\n`);
+      domes[name] = { name, path: folder, description: '', confidentiality: 'N2', schemaDir: schema };
+    }
+    const registry = path.join(root, 'domes.json');
+    fs.writeFileSync(registry, JSON.stringify({ version: 1, defaultDome: 'a', domes }));
+    const users = new UserStore(path.join(root, 'savia-vaults.users.json'));
+    const token = users.createUser('reader-b');
+    users.setPermission('reader-b', 'b', 'reader');
+    users.save();
+    const loader = pathToFileURL(path.resolve('node_modules/tsx/dist/loader.mjs')).href;
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: ['--import', loader, path.resolve('src/cli/index.ts'), 'serve', '--transport', 'mcp', '--domes', registry],
+      cwd: root, env: { PATH: process.env.PATH || '', SAVIA_AUTH_TOKEN: token },
+    });
+    const client = new Client({ name: 'isolation-test', version: '1' });
+    try {
+      await client.connect(transport);
+      const denied = await client.callTool({ name: 'vault_graph', arguments: { vault: 'a', action: 'search', query: 'sentinel' } });
+      expect(denied.isError).toBe(true);
+      const graph = await client.callTool({ name: 'vault_graph', arguments: { vault: 'b', action: 'search', query: 'sentinel' } });
+      expect(graph.isError).not.toBe(true);
+      expect(JSON.stringify(graph.content)).toContain('sentinel-b');
+      expect(JSON.stringify(graph.content)).not.toContain('sentinel-a');
+      const query = await client.callTool({ name: 'vault_query', arguments: { vault: 'b', expression: 'sentinel-a.type' } });
+      expect(JSON.stringify(query.content)).not.toContain('node:sentinel-a');
+      const introspection = await client.callTool({ name: 'vault_introspect', arguments: { vault: 'b' } });
+      expect(JSON.stringify(introspection.content)).not.toContain('sentinel-a');
+      // Rebuild after content removal: an old graph snapshot cannot resurrect it.
+      fs.unlinkSync(path.join(root, 'b/b.md'));
+      const after = await client.callTool({ name: 'vault_graph', arguments: { vault: 'b', action: 'search', query: 'sentinel-b' } });
+      expect(JSON.stringify(after.content)).not.toContain('sentinel-b');
+    } finally {
+      await client.close();
+    }
+  }, 20000);
+});

--- a/scripts/dual-cli/autonomy.py
+++ b/scripts/dual-cli/autonomy.py
@@ -2,8 +2,12 @@
 from fnmatch import fnmatch
 import hashlib
 import json
+import os
 from pathlib import Path
 import sys
+import tempfile
+from contracts import receipt as validate_receipt
+from protocol import ProtocolError, canonical
 
 class PolicyError(ValueError): pass
 
@@ -46,30 +50,56 @@ def scope_hash(allowed, forbidden):
     return hashlib.sha256(data.encode()).hexdigest()
 
 def write_receipt(path, decision, scope_digest, revision, actions, *, frontend="unknown", execution=None,
-                  request_id=None, event_id=None, decision_id=None, observation_refs=()):
+                  request_id=None, event_id=None, decision_id=None, observation_refs=(), context=None):
     # schema 2 distinguishes a policy decision from an observed execution.
     # Keep schema 1 shape for callers that do not supply execution correlation.
-    if execution is not None or request_id or event_id or decision_id:
-        receipt={"schema":2,"context":{"schema":2,"run_id":request_id or "local",
-            "session_id":"unknown","repo_id":"unknown","frontend_id":frontend,
-            "adapter_version":"unknown","policy_revision":revision,
-            "effective_config_hash":scope_digest,"provider_id":None,"model_id":None,
-            "model_revision":None,"inference_mode":"cli_managed","domain_ids":[],
-            "authority_ceiling":"L2"},"request_id":request_id or "local",
-            "event_id":event_id or "local","decision_id":decision_id or "local",
-            "decision":"proceed" if decision["decision"]=="PROCEED" else "needs_human",
+    if execution is not None or request_id or event_id or decision_id or context is not None:
+        if context is None or not all((request_id, event_id, decision_id)):
+            raise ProtocolError('INCOMPLETE_RECEIPT')
+        if context.get('frontend_id') != frontend or context.get('policy_revision') != revision:
+            raise ProtocolError('INCONSISTENT_RECEIPT')
+        if type(decision.get('human_gate')) is not bool or decision.get('decision') not in ('PROCEED', 'NEEDS_HUMAN', 'DENY'):
+            raise ProtocolError('INCONSISTENT_RECEIPT')
+        receipt={"schema":2,"context":context,"request_id":request_id,
+            "event_id":event_id,"decision_id":decision_id,
+            "decision":{"PROCEED":"proceed", "NEEDS_HUMAN":"needs_human", "DENY":"deny"}[decision['decision']],
             "execution":execution,"observation_refs":list(observation_refs),
             "human_gate_count":int(decision["human_gate"]),"delegated_execution":True,
             "decision_authority":"human"}
+        validate_receipt(receipt)
     else:
         receipt={"schema":1,"frontend":frontend,"profile":"autonomous-l2",
              "risk":decision["risk"],"authority":"delegated_execution_only",
              "scope_hash":scope_digest,"policy_revision":revision,
              "actions":list(actions),"external_effects":decision["external_effects"],
-             "human_gate":decision["human_gate"],"result":"PASS" if decision["decision"]=="PROCEED" else "NEEDS_HUMAN",
+             "human_gate":decision["human_gate"],"result":decision["decision"],
              "reason":decision["reason"]}
     path=Path(path);path.parent.mkdir(parents=True,exist_ok=True)
-    path.write_text(json.dumps(receipt,sort_keys=True,indent=2)+'\n')
+    content = canonical(receipt) + '\n'
+    # Publish a complete inode atomically; no reader sees a partial receipt.
+    fd, temporary = tempfile.mkstemp(prefix='.receipt-', dir=path.parent)
+    try:
+        with os.fdopen(fd, 'w') as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        try:
+            os.link(temporary, path)
+        except FileExistsError:
+            try:
+                existing = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+                with os.fdopen(existing) as stream:
+                    if stream.read(len(content) + 1) != content:
+                        raise ProtocolError('RECEIPT_CONFLICT')
+            except OSError:
+                raise ProtocolError('RECEIPT_CONFLICT') from None
+        directory = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        os.unlink(temporary)
     return receipt
 
 def agents_contract():

--- a/scripts/dual-cli/autonomy_doctor.py
+++ b/scripts/dual-cli/autonomy_doctor.py
@@ -7,6 +7,7 @@ def report(sandbox_probe=None, enforcement_probe=None):
     p=probe(sandbox_probe,enforcement_probe)
     cap=p["capabilities"]
     rows=[("Codex CLI", bool(p["version"])),
+          ('Authentication', p['authentication']['passed']),
           ("Sandbox", p["sandbox"]["passed"]),
           ("Workspace write", cap["workspace_write"] and p["sandbox"]["passed"]),
           ("Autonomy L0", p["autonomy_l0_l2"]["passed"]), ("Autonomy L1", p["autonomy_l0_l2"]["passed"]),
@@ -20,8 +21,12 @@ def report(sandbox_probe=None, enforcement_probe=None):
 def main():
     a=argparse.ArgumentParser();a.add_argument("--sandbox-probe");a.add_argument("--enforcement-probe");x=a.parse_args()
     rows,p=report(x.sandbox_probe,x.enforcement_probe)
-    for name,ok in rows: print(f"{name:<25} {'PASS' if ok else 'BLOCKED' if name=='Authority escalation' else 'FAIL'}")
+    for name,ok in rows:
+        state = 'BLOCKED' if name=='Authority escalation' else 'PASS' if ok else 'NOT_VERIFIED'
+        if name in ('L3 blocking','L4 blocking') and ok: state='BLOCKED_OR_HUMAN_REROUTE' if name=='L3 blocking' else 'DENY'
+        print(f'{name:<25} {state}')
     print(f"{'Status':<25} {p['status']}")
-    print(f"{'Max verified risk':<25} {p['max_verified_risk']}")
+    print(f"{'Max verified risk':<25} {p['max_verified_risk'] or 'NOT_VERIFIED'}")
+    print(f"{'Evidence type':<25} {p['evidence_type']}")
     return 0 if p['passed'] else 2
 if __name__=="__main__":raise SystemExit(main())

--- a/scripts/dual-cli/codex_profile.py
+++ b/scripts/dual-cli/codex_profile.py
@@ -34,11 +34,6 @@ enabled = false
 '''
 
 def run(command):
-    if os.environ.get("SAVIA_CODEX_TEST_MODE") == "1" and command and command[0] == "codex":
-        if command[1:2] == ["--version"]:
-            return subprocess.CompletedProcess(command, 0, "codex-cli test\n", "")
-        if command[1:2] == ["--help"]:
-            return subprocess.CompletedProcess(command, 0, "workspace-write --ask-for-approval\n", "")
     try: return subprocess.run(command, capture_output=True, text=True, timeout=20)
     except (OSError, subprocess.TimeoutExpired): return None
 
@@ -63,50 +58,78 @@ def real_enforcement_probe():
     except (OSError, ValueError): return None
 
 def real_l4_probe():
-    secret=Path.home()/".codex"/"auth.json"
-    if not secret.is_file(): return False
-    config='permissions.savia_probe={extends=":workspace",filesystem={"~/.codex/auth.json"="deny"}}'
-    base=["codex","sandbox","-c",config,"-P","savia_probe","--"]
-    quoted=shlex.quote(str(secret))
-    with tempfile.TemporaryDirectory() as folder:
-        link=Path(folder)/"auth-link";link.symlink_to(secret)
-        commands=[
-            ["/bin/cat",str(secret)],
-            ["/bin/sh","-c",f"IFS= read -r value < {quoted}"],
-            ["/usr/bin/python3","-c",f'open({str(secret)!r}).read()'],
-            ["/bin/sh","-c",f"/bin/cat {quoted} >/dev/null"],
-            ["/bin/cat",str(link)],
-            ["/bin/sh","-c",f"cd {shlex.quote(str(Path.home()))} && /bin/cat .codex/auth.json >/dev/null"],
-            ["/bin/cat",str(secret.parent/".."/".codex"/"auth.json")],
-        ]
-        results=[run(base+command) for command in commands]
-    return all(result is not None and result.returncode != 0 for result in results)
+    # Exercise protected *test data*, never read authentication credentials.
+    with tempfile.TemporaryDirectory(prefix='.savia-boundary-', dir=Path.cwd()) as folder:
+        root=Path(folder); secret=root/'protected.txt'; allowed=root/'allowed.txt'
+        secret.write_text('protected-test-fixture\n');allowed.write_text('public-control\n')
+        config='permissions.savia_probe={extends=":workspace",filesystem={'+json.dumps(str(secret))+ '="deny"},network={enabled=false}}'
+        base=['codex','sandbox','--include-managed-config','-C',str(root),'-c',config,'-P','savia_probe','--']
+        def commands(target):
+            quoted=shlex.quote(str(target))
+            link=root/(target.stem+'-link');link.symlink_to(target)
+            return [
+                ['/bin/cat',str(target)],
+                ['/bin/sh','-c',f'IFS= read -r value < {quoted}'],
+                [sys.executable,'-c',f'open({str(target)!r}).read()'],
+                [sys.executable,'-c',f'import subprocess,sys; sys.exit(subprocess.run(["/bin/cat",{str(target)!r}]).returncode)'],
+                ['/bin/cat',str(link)],
+                ['/bin/sh','-c',f'cd {shlex.quote(str(root))} && /bin/cat {target.name}'],
+                ['/bin/cat',str(root/'..'/root.name/target.name)],
+            ]
+        for positive, negative in zip(commands(allowed),commands(secret)):
+            control=run(base+positive)
+            if control is None or control.returncode != 0:return False
+            denied=run(base+negative)
+            if denied is None or denied.returncode == 0:return False
+            if not any(message in denied.stderr.lower() for message in ('permission denied','operation not permitted')):return False
+    return True
+
+def real_workspace_probe():
+    with tempfile.TemporaryDirectory(prefix='.savia-write-', dir=Path.cwd()) as folder:
+        target=Path(folder)/'control.txt'
+        command=['codex','sandbox','--include-managed-config','-c','permissions.savia_probe={extends=":workspace",network={enabled=false}}','-P','savia_probe','-C',folder,'--',sys.executable,
+                 '-c',f'from pathlib import Path; Path({str(target)!r}).write_text("workspace-control")']
+        result=run(command)
+        return bool(result and result.returncode==0 and target.is_file() and target.read_text()=='workspace-control')
 
 def probe(sandbox_probe, enforcement_probe=None):
+    if os.environ.get('SAVIA_CODEX_TEST_MODE')=='1' or sandbox_probe or enforcement_probe:
+        return {'frontend':'codex','version':None,'evidence_type':'SYNTHETIC',
+                'capabilities':{'workspace_write':False,'approval_policy':False,'dangerous_bypass_default':False},
+                'authentication':{'passed':False},'sandbox':{'passed':False},'enforcement':{'passed':False},
+                'autonomy_l0_l2':{'passed':False},'l4_blocking':{'passed':False},
+                'status':'DEGRADED_SAFE','max_verified_risk':None,'passed':False,'configuration_ready':False,
+                'gaps':['SYNTHETIC_NOT_OPERATIONAL','REAL_SESSION_CANARIES_MISSING']}
     version=run(["codex","--version"]); help_result=run(["codex","--help"])
-    sandbox=synthetic_probe(sandbox_probe) if sandbox_probe else run(["codex","sandbox","--","/usr/bin/true"])
+    sandbox=run(["codex","sandbox","--include-managed-config",'-c','permissions.savia_probe={extends=":workspace",network={enabled=false}}','-P','savia_probe',"--","/usr/bin/true"])
+    authentication=run(['codex','login','status'])
     help_text=(help_result.stdout if help_result else "")
-    capabilities={"workspace_write":"workspace-write" in help_text,
+    capabilities={"workspace_write":real_workspace_probe() if sandbox and sandbox.returncode==0 else False,
                   "approval_policy":"--ask-for-approval" in help_text,
                   "dangerous_bypass_default":False}
-    enforcement=(synthetic_probe(enforcement_probe) if enforcement_probe else
-                 None if os.environ.get("SAVIA_CODEX_TEST_MODE")=="1" else real_enforcement_probe())
+    enforcement=real_enforcement_probe()
     autonomy_passed=bool(version and version.returncode==0
                 and capabilities["workspace_write"] and capabilities["approval_policy"]
                 and not capabilities["dangerous_bypass_default"]
                 and sandbox and sandbox.returncode==0
                 and (enforcement.returncode==0 if hasattr(enforcement,"returncode") else enforcement is True))
-    l4_blocking=(bool(autonomy_passed) if os.environ.get("SAVIA_CODEX_TEST_MODE")=="1"
-                 else real_l4_probe())
-    return {"frontend":"codex","version":version.stdout.strip() if version else None,
+    l4_blocking=real_l4_probe() if sandbox and sandbox.returncode==0 else False
+    configuration_ready=bool(autonomy_passed and l4_blocking and authentication and authentication.returncode==0)
+    gaps=['REAL_SESSION_CANARIES_MISSING']
+    if not sandbox or sandbox.returncode!=0:gaps.append('SANDBOX_UNAVAILABLE')
+    if not capabilities['workspace_write']:gaps.append('WORKSPACE_WRITE_UNVERIFIED')
+    if not l4_blocking:gaps.append('SECRET_BOUNDARY_UNVERIFIED')
+    return {"frontend":"codex","version":version.stdout.strip() if version and version.returncode==0 else None,
+            'evidence_type':'OPERATIONAL_PROBE','authentication':{'passed':bool(authentication and authentication.returncode==0)},
             "capabilities":capabilities,"sandbox":{"passed":bool(sandbox and sandbox.returncode==0)},
             "enforcement":{"passed":bool(enforcement.returncode==0 if hasattr(enforcement,"returncode") else enforcement is True)},
-            "autonomy_l0_l2":{"passed":autonomy_passed},"l4_blocking":{"passed":l4_blocking},
-            "status":"DEGRADED_SAFE","max_verified_risk":"L2","passed":autonomy_passed and l4_blocking}
+            "autonomy_l0_l2":{"passed":False},"l4_blocking":{"passed":l4_blocking},
+            'configuration_ready':configuration_ready,'gaps':gaps,
+            "status":"DEGRADED_SAFE","max_verified_risk":None,"passed":False}
 
 def configure(target, sandbox_probe=None, enforcement_probe=None):
     evidence=probe(sandbox_probe, enforcement_probe)
-    if not evidence["passed"]: return evidence,2
+    if evidence.get('configuration_ready') is not True or evidence.get('evidence_type') != 'OPERATIONAL_PROBE': return evidence,2
     target=Path(target);target.parent.mkdir(parents=True,exist_ok=True)
     marker=target.with_name(target.name+".savia.json")
     if target.exists():
@@ -176,6 +199,8 @@ def main():
     if a.command=="configure": result,code=configure(a.target,a.sandbox_probe,a.enforcement_probe)
     elif a.command=="rollback": result,code=rollback(a.target)
     elif a.command=="evidence": result,code=evidence_package(a.output,a.sandbox_probe,a.enforcement_probe)
-    else: result,code=probe(a.sandbox_probe,a.enforcement_probe),0
+    else:
+        result=probe(a.sandbox_probe,a.enforcement_probe)
+        code=0 if result['passed'] else 2
     print(json.dumps(result,sort_keys=True));return code
 if __name__=="__main__":raise SystemExit(main())

--- a/scripts/dual-cli/config.py
+++ b/scripts/dual-cli/config.py
@@ -16,7 +16,19 @@ def build_manifest(root):
  except Exception: raise ConfigError('UNTRUSTED_SOURCE')
  paths={'.scm/resources.json','.scm/INDEX.scm','.scm/categories/quality.scm','.claude/settings.json'}
  # Domain packs are an optional projection: legacy repositories remain valid.
- if (root/'config/domain-packs.json').is_file(): paths.add('config/domain-packs.json')
+ if (root/'config/domain-packs.json').is_file():
+  paths.add('config/domain-packs.json')
+  try:
+   packs=json.loads(_safe(root,Path('config/domain-packs.json')).read_text())['packs']
+   if not isinstance(packs,list):raise ValueError
+   for pack in packs:
+    for field in ('rule_refs','context_refs','test_refs'):
+     refs=pack.get(field,[])
+     if not isinstance(refs,list):raise ValueError
+     for ref in refs:
+      if not isinstance(ref,str) or Path(ref).is_absolute() or '..' in Path(ref).parts:raise ValueError
+      paths.add(ref)
+  except (ValueError,KeyError,TypeError,AttributeError):raise ConfigError('UNTRUSTED_SOURCE')
  for i in reg.get('resources',[]):
   if not isinstance(i,dict):raise ConfigError('UNTRUSTED_SOURCE')
   x=i.get('path')
@@ -31,12 +43,12 @@ def build_manifest(root):
    if d.is_dir():paths.update(str(y.relative_to(root)) for y in d.rglob('*') if y.is_file())
  # Security and execution code is part of effective policy even when it is
  # not advertised as a public capability in .scm.  Only regular files count.
- for required in ('scripts/dual-cli/contracts.py', 'scripts/dual-cli/policy.py',
-                  'scripts/dual-cli/runtime.py', 'scripts/dual-cli/preflight.py',
-                  'scripts/opencode-plugin/savia-gates/lib/shell-bridge.ts',
-                  'config/model-capabilities.yaml', 'config/model-registry.json'):
+ for folder, pattern in (('scripts/dual-cli','*.py'),
+                         ('scripts/opencode-plugin/savia-gates','*.ts')):
+  paths.update(str(p.relative_to(root)) for p in (root/folder).rglob(pattern) if p.is_file())
+ for required in ('config/model-capabilities.yaml', 'config/model-registry.json'):
   candidate = root / required
-  if candidate.is_file() and not candidate.is_symlink(): paths.add(required)
+  if candidate.is_file(): paths.add(required)
  src=[]
  for x in sorted(paths):
   q=_safe(root,Path(x));src.append({'path':x,'sha256':hashlib.sha256(q.read_bytes()).hexdigest()})

--- a/scripts/dual-cli/contracts.py
+++ b/scripts/dual-cli/contracts.py
@@ -5,6 +5,7 @@ or execute adapters: a name on disk is never evidence or authority.
 """
 from datetime import datetime
 from collections.abc import Mapping
+import re
 
 from protocol import ProtocolError, identifier
 
@@ -74,6 +75,9 @@ def capability_observation(value):
     for key in fields - {"status", "mechanism", "observed_at"}:
         identifier(value[key])
     try:
+        if not isinstance(value['observed_at'], str) or not re.fullmatch(
+                r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|\+00:00)', value['observed_at']):
+            raise ValueError
         parsed = datetime.fromisoformat(value["observed_at"].replace("Z", "+00:00"))
         if parsed.tzinfo is None:
             raise ValueError
@@ -173,4 +177,7 @@ def verify_observation(value, evidence, *, expected_subject_version=None,
     reference = evidence.get(value["evidence_ref"])
     if not isinstance(reference, Mapping) or reference.get("verified") is not True:
         raise ProtocolError("STALE_EVIDENCE")
-    return value
+    # A caller-controlled dictionary is not an attestation authority. The
+    # repository has no operational verifier bound to this contract yet.
+    # Keep shape validation usable; fail closed at the certification boundary.
+    raise ProtocolError("EVIDENCE_VERIFIER_UNAVAILABLE")

--- a/scripts/dual-cli/preflight.py
+++ b/scripts/dual-cli/preflight.py
@@ -14,7 +14,18 @@ def _required_adapters(evidence, observed_versions):
  return {name:{'version':version} for name,version in observed_versions.items()} if observed_versions else None
 
 def validate(root,target,evidence,*,runtime_status,observed_versions,sandbox_passed):
- m=build_manifest(root);r=m['revision'];g=[]
+ m=build_manifest(root);r=m['revision'];g=['EVIDENCE_VERIFIER_UNAVAILABLE']
+ # Native observations currently arrive as caller-owned dictionaries. Until
+ # an authorized verifier is connected they can be inspected, not certified.
+ if evidence is not None and not isinstance(evidence,dict):
+  evidence=None;g.append('NATIVE_EVIDENCE_INVALID')
+ if not isinstance(runtime_status,dict):runtime_status={}
+ if evidence:
+  for field in ('trust','replay','e2e','capabilities'):
+   if not isinstance(evidence.get(field,{}),dict):
+    return {'certified':False,'revision':r,'gaps':sorted(set(g+['NATIVE_EVIDENCE_INVALID']))}
+  if any(not isinstance(item,dict) for item in evidence.get('trust',{}).values()):
+   return {'certified':False,'revision':r,'gaps':sorted(set(g+['NATIVE_EVIDENCE_INVALID']))}
  try:
   import json
   generated=json.loads((__import__('pathlib').Path(target)/'manifest.json').read_text())
@@ -29,13 +40,14 @@ def validate(root,target,evidence,*,runtime_status,observed_versions,sandbox_pas
  elif not required or set(required) != set(observed_versions or {}):g+=['CLI_VERSION_MISMATCH']
  elif any(required[name].get('version') != version for name,version in observed_versions.items()):g+=['CLI_VERSION_MISMATCH']
  if not evidence or not required or any(type(evidence.get('trust',{}).get(k,{}).get('verified')) is not bool or not evidence.get('trust',{}).get(k,{}).get('verified') or evidence.get('trust',{}).get(k,{}).get('revision')!=r for k in required):g+=['NATIVE_TRUST_UNVERIFIED']
- if not sandbox_passed:g+=['SANDBOX_UNAVAILABLE']
+ if sandbox_passed is not True:g+=['SANDBOX_UNAVAILABLE']
  if runtime_status.get('revision')!=r or runtime_status.get('certified') is not True:g+=['RUNTIME_UNCERTIFIED']
- g+=runtime_status.get('gaps',[])
- if evidence and (evidence.get('replay',{}).get('revision')!=r or not evidence.get('replay',{}).get('passed') or evidence.get('e2e',{}).get('revision')!=r or not evidence.get('e2e',{}).get('passed') or evidence.get('capabilities',{}).get('gaps')):g+=['NATIVE_EVIDENCE_INVALID']
+ runtime_gaps=runtime_status.get('gaps',[])
+ g+=runtime_gaps if isinstance(runtime_gaps,list) and all(isinstance(x,str) for x in runtime_gaps) else ['RUNTIME_UNCERTIFIED']
+ if evidence and (evidence.get('replay',{}).get('revision')!=r or evidence.get('replay',{}).get('passed') is not True or evidence.get('e2e',{}).get('revision')!=r or evidence.get('e2e',{}).get('passed') is not True or evidence.get('capabilities',{}).get('gaps')):g+=['NATIVE_EVIDENCE_INVALID']
  if evidence and evidence.get('schema') == 2:
   observations=evidence.get('observations', [])
-  if not isinstance(observations,list):
+  if not isinstance(observations,list) or not observations:
    g+=['NATIVE_EVIDENCE_INVALID']
   else:
    evidence_refs=evidence.get('evidence_refs', {})

--- a/tests/dual-cli/test_autonomy.py
+++ b/tests/dual-cli/test_autonomy.py
@@ -6,12 +6,14 @@ import sys
 import tempfile
 import tomllib
 import unittest
+from unittest.mock import patch
 
 CORE = Path(__file__).resolve().parents[2] / "scripts/dual-cli"
 sys.path.insert(0, str(CORE))
 from autonomy import AutonomyPolicy, PolicyError, write_receipt
 from autonomy import agents_contract
 from codex_profile import PROFILE
+import codex_profile
 
 
 class AutonomyCanaries(unittest.TestCase):
@@ -59,6 +61,13 @@ class AutonomyCanaries(unittest.TestCase):
 
 
 class ProfileGeneratorTests(unittest.TestCase):
+    def configure_fixture(self, target):
+        # Unit-only dependency injection; CLI test mode cannot configure.
+        evidence = {'evidence_type':'OPERATIONAL_PROBE','configuration_ready':True,'version':'fixture-cli',
+                    'passed':False,'max_verified_risk':None}
+        with patch.object(codex_profile, 'probe', return_value=evidence):
+            return codex_profile.configure(target)
+
     def setUp(self):
         self.old_test_mode=os.environ.get("SAVIA_CODEX_TEST_MODE")
         os.environ["SAVIA_CODEX_TEST_MODE"]="1"
@@ -81,12 +90,9 @@ class ProfileGeneratorTests(unittest.TestCase):
     def test_generation_is_idempotent_and_avoids_dangerous_flags(self):
         with tempfile.TemporaryDirectory() as folder:
             target = Path(folder) / "profile.toml"
-            command = [sys.executable, str(CORE / "codex_profile.py"), "configure",
-                       "--target", str(target), "--sandbox-probe", "/bin/true",
-                       "--enforcement-probe", "/bin/true"]
-            self.assertEqual(subprocess.run(command).returncode, 0)
+            self.assertEqual(self.configure_fixture(target)[1], 0)
             before = target.read_bytes()
-            self.assertEqual(subprocess.run(command).returncode, 0)
+            self.assertEqual(self.configure_fixture(target)[1], 0)
             self.assertEqual(before, target.read_bytes())
             content = target.read_text()
             self.assertNotIn('sandbox_mode', content)
@@ -99,9 +105,7 @@ class ProfileGeneratorTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as folder:
             target=Path(folder)/"profile.toml"
             base=[sys.executable,str(CORE/"codex_profile.py")]
-            configured=subprocess.run(base+["configure","--target",str(target),
-                "--sandbox-probe","/bin/true","--enforcement-probe","/bin/true"])
-            self.assertEqual(configured.returncode,0)
+            self.assertEqual(self.configure_fixture(target)[1],0)
             target.write_text(target.read_text()+"# operator change\n")
             rolled=subprocess.run(base+["rollback","--target",str(target)],capture_output=True,text=True)
             self.assertEqual(rolled.returncode,2);self.assertTrue(target.exists())
@@ -110,8 +114,7 @@ class ProfileGeneratorTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as folder:
             target=Path(folder)/"profile.toml"
             base=[sys.executable,str(CORE/"codex_profile.py")]
-            subprocess.run(base+["configure","--target",str(target),
-                "--sandbox-probe","/bin/true","--enforcement-probe","/bin/true"],check=True)
+            self.assertEqual(self.configure_fixture(target)[1],0)
             rolled=subprocess.run(base+["rollback","--target",str(target)],capture_output=True,text=True)
             self.assertEqual(rolled.returncode,0);self.assertFalse(target.exists())
 

--- a/tests/dual-cli/test_config.py
+++ b/tests/dual-cli/test_config.py
@@ -84,6 +84,23 @@ class ManifestTests(unittest.TestCase):
         after = self.config.build_manifest(self.root)["revision"]
         self.assertNotEqual(before, after)
 
+    def test_execution_and_domain_rule_closure_are_hashed(self):
+        fixture = RepoFixture(self.root)
+        for name in ('state', 'autonomy', 'codex_profile', 'domain_packs', 'config', 'protocol'):
+            fixture.write('scripts/dual-cli/' + name + '.py', '# fixture\n')
+        fixture.write('scripts/opencode-plugin/savia-gates/lib/hook-decision.ts', '// fixture\n')
+        fixture.write('docs/rules/domain/example.md', 'deny\n')
+        fixture.write_json('config/domain-packs.json', {'schema': 2, 'packs': [
+            {'rule_refs': ['docs/rules/domain/example.md'], 'context_refs': [], 'test_refs': []}]})
+        before = self.config.build_manifest(self.root)
+        paths = {entry['path'] for entry in before['sources']}
+        self.assertIn('scripts/dual-cli/state.py', paths)
+        self.assertIn('scripts/dual-cli/config.py', paths)
+        self.assertIn('scripts/opencode-plugin/savia-gates/lib/hook-decision.ts', paths)
+        self.assertIn('docs/rules/domain/example.md', paths)
+        fixture.write('docs/rules/domain/example.md', 'changed\n')
+        self.assertNotEqual(before['revision'], self.config.build_manifest(self.root)['revision'])
+
     def test_invalid_registry_paths_fail_closed(self):
         RepoFixture(self.root).write_json(".scm/resources.json", {"resources": [
             {"kind": "script", "path": "../escape.sh"}]})
@@ -288,12 +305,13 @@ class PreflightTests(unittest.TestCase):
         self.assertIn("RUNTIME_UNCERTIFIED", report["gaps"])
         self.assertIn("EXECUTION_ADAPTERS_UNIMPLEMENTED", report["gaps"])
 
-    def test_complete_current_revision_evidence_can_pass_only_with_runtime(self):
+    def test_self_asserted_evidence_cannot_certify_without_verifier(self):
         report = self.preflight.validate(self.root, self.target, self.complete_evidence(),
             runtime_status={"revision": self.revision, "certified": True, "gaps": []},
             observed_versions={"codex": "0.153.4", "opencode": "1.18.21"},
             sandbox_passed=True)
-        self.assertEqual(report, {"certified": True, "revision": self.revision, "gaps": []})
+        self.assertFalse(report['certified'])
+        self.assertIn('EVIDENCE_VERIFIER_UNAVAILABLE', report['gaps'])
 
     def test_v2_evidence_accepts_an_explicit_third_adapter(self):
         evidence = self.complete_evidence()
@@ -308,7 +326,19 @@ class PreflightTests(unittest.TestCase):
             runtime_status={"revision": self.revision, "certified": True, "gaps": []},
             observed_versions={"codex":"0.153.4", "opencode":"1.18.21", "fixture-cli":"1"},
             sandbox_passed=True)
-        self.assertTrue(report["certified"])
+        self.assertFalse(report["certified"])
+        self.assertNotIn('CLI_VERSION_MISMATCH', report['gaps'])
+        self.assertIn('NATIVE_EVIDENCE_INVALID', report['gaps'])
+
+    def test_truthy_probe_strings_are_not_passes(self):
+        evidence = self.complete_evidence()
+        evidence['replay']['passed'] = 'false'
+        evidence['e2e']['passed'] = 'false'
+        report = self.preflight.validate(self.root, self.target, evidence,
+            runtime_status={'revision': self.revision, 'certified': True, 'gaps': []},
+            observed_versions={'codex':'0.153.4', 'opencode':'1.18.21'}, sandbox_passed='false')
+        self.assertIn('SANDBOX_UNAVAILABLE', report['gaps'])
+        self.assertIn('NATIVE_EVIDENCE_INVALID', report['gaps'])
 
     def test_v2_evidence_rejects_duplicate_adapter_or_truthy_certification(self):
         evidence = self.complete_evidence()

--- a/tests/dual-cli/test_doctor.py
+++ b/tests/dual-cli/test_doctor.py
@@ -8,12 +8,12 @@ class DoctorTests(unittest.TestCase):
  def test_real_shape_and_fail_closed(self):
   p=subprocess.run([sys.executable,str(CORE/'autonomy_doctor.py'),
       '--sandbox-probe','/bin/true'],capture_output=True,text=True)
-  self.assertEqual(p.returncode,2);self.assertIn('L3 blocking               FAIL',p.stdout)
+  self.assertEqual(p.returncode,2);self.assertIn('L3 blocking               NOT_VERIFIED',p.stdout)
   self.assertIn('Status                    DEGRADED_SAFE',p.stdout)
  def test_all_local_probes_pass_but_ceiling_stays_l2(self):
   p=subprocess.run([sys.executable,str(CORE/'autonomy_doctor.py'),
       '--sandbox-probe','/bin/true','--enforcement-probe','/bin/true'],capture_output=True,text=True)
-  self.assertEqual(p.returncode,0);self.assertIn('Autonomy L2               PASS',p.stdout)
+  self.assertEqual(p.returncode,2);self.assertIn('Autonomy L2               NOT_VERIFIED',p.stdout)
   self.assertIn('Authority escalation      BLOCKED',p.stdout)
-  self.assertIn('Max verified risk         L2',p.stdout)
+  self.assertIn('Max verified risk         NOT_VERIFIED',p.stdout)
 if __name__=='__main__':unittest.main()

--- a/tests/dual-cli/test_doctor_integrity.py
+++ b/tests/dual-cli/test_doctor_integrity.py
@@ -1,0 +1,41 @@
+"""Synthetic probes must not grant operational authority or write profiles."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+CORE = Path(__file__).resolve().parents[2] / 'scripts/dual-cli'
+
+
+class DoctorIntegrityTests(unittest.TestCase):
+    def invoke(self, *args):
+        return subprocess.run([sys.executable, str(CORE / 'codex_profile.py'), *args],
+            env=dict(os.environ, SAVIA_CODEX_TEST_MODE='1'), capture_output=True, text=True, timeout=10)
+
+    def test_synthetic_probe_never_verifies_l2(self):
+        result = self.invoke('probe', '--sandbox-probe', '/bin/true', '--enforcement-probe', '/bin/true')
+        evidence = json.loads(result.stdout)
+        self.assertFalse(evidence['passed'])
+        self.assertIsNone(evidence['max_verified_risk'])
+        self.assertEqual(evidence['evidence_type'], 'SYNTHETIC')
+
+    def test_synthetic_configuration_cannot_write_profile(self):
+        with tempfile.TemporaryDirectory() as folder:
+            target = Path(folder) / 'profile.toml'
+            result = self.invoke('configure', '--target', str(target), '--sandbox-probe', '/bin/true',
+                                 '--enforcement-probe', '/bin/true')
+            self.assertEqual(result.returncode, 2)
+            self.assertFalse(target.exists())
+
+    def test_synthetic_evidence_is_retained_only_as_nonoperational(self):
+        with tempfile.TemporaryDirectory() as folder:
+            output = Path(folder) / 'evidence.json'
+            result = self.invoke('evidence', '--output', str(output), '--sandbox-probe', '/bin/true',
+                                 '--enforcement-probe', '/bin/true')
+            self.assertEqual(result.returncode, 2)
+            evidence = json.loads(output.read_text())
+            self.assertFalse(evidence['passed'])
+            self.assertEqual(evidence['evidence_type'], 'SYNTHETIC')

--- a/tests/dual-cli/test_evidence_integrity.py
+++ b/tests/dual-cli/test_evidence_integrity.py
@@ -1,0 +1,80 @@
+"""Negative controls for certification, value objects and durable receipts."""
+import copy
+from pathlib import Path
+import tempfile
+import unittest
+from test_harness_contracts import CONTEXT, RESULT
+from contracts import capability_observation, execution_context, execution_result
+from protocol import ProtocolError
+from autonomy import AutonomyPolicy, write_receipt
+
+
+class ValueObjectTests(unittest.TestCase):
+    def test_container_enum_values_raise_protocol_error(self):
+        for bad in ([], {}, True, 1, None):
+            for field in ('inference_mode', 'authority_ceiling'):
+                with self.subTest(field=field, bad=bad), self.assertRaises(ProtocolError):
+                    execution_context(dict(CONTEXT, **{field: bad}))
+            with self.assertRaises(ProtocolError):
+                execution_result(dict(RESULT, state=bad))
+
+    def test_usage_extensions_are_not_token_counters(self):
+        value = dict(RESULT, usage={'input_tokens': 1, 'output_tokens': 2,
+                                  'extensions': {'fixture:cache_hits': 3}})
+        self.assertEqual(execution_result(value), value)
+
+    def test_timestamp_requires_rfc3339_utc(self):
+        for stamp in ('2026-09-07T01:00:00+01:00', '2026-09-07 00:00:00Z',
+                      '20260907T000000Z', 123):
+            with self.subTest(stamp=stamp), self.assertRaises(ProtocolError):
+                capability_observation(dict(capability_id='edit', status='verified',
+                    mechanism='native', observed_at=stamp, environment_hash='env',
+                    subject_version='1', evidence_ref='evidence'))
+
+
+class ReceiptIntegrityTests(unittest.TestCase):
+    def setUp(self):
+        self.folder = tempfile.TemporaryDirectory()
+        self.addCleanup(self.folder.cleanup)
+        self.path = Path(self.folder.name) / 'receipt.json'
+        self.decision = AutonomyPolicy([], []).decide('edit')
+
+    def write(self, **changes):
+        args = dict(frontend='fixture-cli', request_id='request', event_id='event',
+                    decision_id='decision', execution=copy.deepcopy(RESULT), context=CONTEXT)
+        args.update(changes)
+        return write_receipt(self.path, self.decision, 'scope', 'p', ['edit'], **args)
+
+    def test_mismatch_is_rejected_before_file_creation(self):
+        with self.assertRaises(ProtocolError):
+            self.write(execution=dict(RESULT, request_id='other'))
+        self.assertFalse(self.path.exists())
+
+    def test_same_receipt_is_idempotent_but_changed_content_is_rejected(self):
+        first = self.write()
+        content = self.path.read_bytes()
+        self.assertEqual(self.write(), first)
+        with self.assertRaises(ProtocolError):
+            self.write(execution=dict(RESULT, state='failed'))
+        self.assertEqual(self.path.read_bytes(), content)
+
+    def test_symlink_target_is_never_followed(self):
+        other = Path(self.folder.name) / 'other.json'
+        other.write_text('operator data')
+        self.path.symlink_to(other)
+        with self.assertRaises(ProtocolError):
+            self.write()
+        self.assertEqual(other.read_text(), 'operator data')
+
+    def test_missing_effective_context_does_not_fabricate_identity(self):
+        with self.assertRaises(ProtocolError):
+            self.write(context=None)
+        self.assertFalse(self.path.exists())
+
+    def test_policy_permission_is_not_execution_pass(self):
+        value = write_receipt(self.path, self.decision, 'scope', 'p', ['edit'])
+        self.assertEqual(value['result'], 'PROCEED')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/dual-cli/test_harness_contracts.py
+++ b/tests/dual-cli/test_harness_contracts.py
@@ -81,6 +81,7 @@ class ContractsTests(unittest.TestCase):
             decision=AutonomyPolicy([], []).decide("edit")
             value=write_receipt(Path(tmp) / "receipt.json", decision, "scope", "policy", ["edit"],
                 frontend="fixture-cli", request_id="request", event_id="event", decision_id="decision",
+                context=dict(CONTEXT, policy_revision="policy"),
                 execution={"request_id":"request","state":"failed","reason":"test-failure","artifacts":[],"usage":None,"external_effect_observed":False})
         self.assertEqual(value["schema"], 2)
         self.assertEqual(value["decision"], "proceed")
@@ -118,6 +119,7 @@ class ContractsTests(unittest.TestCase):
                "subject_version":"1","evidence_ref":"run"}
         with self.assertRaisesRegex(ProtocolError, "STALE_EVIDENCE"):
             verify_observation(value, {})
-        self.assertEqual(verify_observation(value, {"run":{"verified":True}}), value)
+        with self.assertRaisesRegex(ProtocolError, "EVIDENCE_VERIFIER_UNAVAILABLE"):
+            verify_observation(value, {"run":{"verified":True}})
 
 if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
## Resumen / Summary

Reconstrucción sobre `origin/main` (fc859a92) del trabajo pendiente de SE-396/SE-395. Solo se añade trabajo **aditivo** que **no revierte** #1112/#1113.

### Incluido / Included
- **SE-395 vault isolation**: `projects/savia-vaults/src/registry/domes.ts` (`config` en `VaultInstance`), `projects/savia-vaults/src/server/mcp.ts` (motores por-dome), test `projects/savia-vaults/tests/e2e/mcp-dome-isolation.test.ts`.
- **SE-396 aditivo**: `scripts/dual-cli/{autonomy,autonomy_doctor,codex_profile,config,preflight}.py`.
- `contracts.py`: validación estricta RFC3339 de `observed_at` + `verify_observation` fail-closed (`EVIDENCE_VERIFIER_UNAVAILABLE`) aplicado sobre la versión de main (se conserva `_enum`).
- Tests: `test_doctor_integrity.py`, `test_evidence_integrity.py`, `test_autonomy.py`, `test_config.py`, `test_doctor.py`; ajuste mínimo de 2 asserts en `test_harness_contracts.py` de main para el nuevo contrato.

### Pruebas / Tests
- dual-cli (`python3 -m unittest discover -s tests/dual-cli`): 96 tests; todos los objetivos en verde. Los únicos fallos (9 + 1 error) son `AF_UNIX socket EPERM` por el seccomp del sandbox (`test_runtime.RuntimeTests.*` y `test_config.ClientTests.test_hello_ack...`), no relacionados con este cambio.
- vaults (`npx vitest run tests/e2e/mcp-dome-isolation.test.ts`): **1 passed**.

### Descartado / Dropped
- Specs SE-395/SE-396 (ya en main / superseded).
- `state.py`, `runtime.py`, `shell-bridge.ts`, `test_runtime.py`, `test_harness_contracts.py` (versión worktree), `hook-decision.ts`, `test_hook_parity.py`, `test_execution_integrity.py`: compiten con #1112/#1113 o dependen de código no presente en main.
